### PR TITLE
Simplify editor properties

### DIFF
--- a/packages/form-js-editor/src/rendering/PropertiesPanel.js
+++ b/packages/form-js-editor/src/rendering/PropertiesPanel.js
@@ -205,7 +205,7 @@ function LabelProperty(props) {
   return TextfieldEntry({
     editField,
     field,
-    label: 'Label',
+    label: 'Field Label',
     path: [ 'label' ]
   });
 }
@@ -219,7 +219,7 @@ function DescriptionProperty(props) {
   return TextfieldEntry({
     editField,
     field,
-    label: 'Description',
+    label: 'Field Description',
     path: [ 'description' ]
   });
 }
@@ -329,7 +329,7 @@ function Group(props) {
   </div>;
 }
 
-function DesignGroup(field, editField) {
+function GeneralGroup(field, editField) {
   const { type } = field;
 
   const entries = [];
@@ -355,7 +355,7 @@ function DesignGroup(field, editField) {
   }
 
   return (
-    <Group label="Design">
+    <Group label="General">
       {
         entries
       }
@@ -372,12 +372,6 @@ function ValidationGroup(field, editField) {
 
   if (type === 'textfield') {
     entries.push(
-      TextfieldEntry({
-        editField,
-        field,
-        label: 'Pattern',
-        path: [ 'validate', 'pattern' ]
-      }),
       NumberEntry({
         editField,
         field,
@@ -389,7 +383,13 @@ function ValidationGroup(field, editField) {
         field,
         label: 'Maximum Length',
         path: [ 'validate', 'maxLength' ]
-      })
+      }),
+      TextfieldEntry({
+        editField,
+        field,
+        label: 'Regular Expression Pattern',
+        path: [ 'validate', 'pattern' ]
+      }),
     );
   }
 
@@ -406,7 +406,7 @@ function getGroups(field, editField) {
   const { type } = field;
 
   const groups = [
-    DesignGroup(field, editField)
+    GeneralGroup(field, editField)
   ];
 
   if (FIELDS.includes(type)) {

--- a/packages/form-js-viewer/src/rendering/fields/ButtonRenderer.js
+++ b/packages/form-js-viewer/src/rendering/fields/ButtonRenderer.js
@@ -1,6 +1,5 @@
 import {
-  generateIdForType,
-  idToLabel
+  generateIdForType
 } from '../../util';
 
 import { formFieldClasses } from './Util';
@@ -27,7 +26,7 @@ ButtonRenderer.create = function(options = {}) {
   return {
     id,
     key: id,
-    label: idToLabel(id),
+    label: this.label,
     type,
     ...options
   };

--- a/packages/form-js-viewer/src/rendering/fields/CheckboxRenderer.js
+++ b/packages/form-js-viewer/src/rendering/fields/CheckboxRenderer.js
@@ -5,8 +5,7 @@ import Label from './Label';
 import { formFieldClasses } from './Util';
 
 import {
-  generateIdForType,
-  idToLabel
+  generateIdForType
 } from '../../util';
 
 
@@ -60,7 +59,7 @@ CheckboxRenderer.create = function(options = {}) {
   return {
     id,
     key: id,
-    label: idToLabel(id),
+    label: this.label,
     type,
     ...options
   };

--- a/packages/form-js-viewer/src/rendering/fields/DefaultRenderer.js
+++ b/packages/form-js-viewer/src/rendering/fields/DefaultRenderer.js
@@ -5,8 +5,7 @@ import FormElement from '../FormElement';
 import { FormRenderContext } from '../context';
 
 import {
-  generateIdForType,
-  idToLabel
+  generateIdForType
 } from '../../util';
 
 
@@ -55,7 +54,7 @@ DefaultRenderer.create = function(options = {}) {
   return {
     components: [],
     id,
-    label: idToLabel(id),
+    label: this.label,
     type,
     ...options
   };

--- a/packages/form-js-viewer/src/rendering/fields/NumberRenderer.js
+++ b/packages/form-js-viewer/src/rendering/fields/NumberRenderer.js
@@ -5,8 +5,7 @@ import Label from './Label';
 import { formFieldClasses } from './Util';
 
 import {
-  generateIdForType,
-  idToLabel
+  generateIdForType
 } from '../../util';
 
 
@@ -60,7 +59,7 @@ NumberRenderer.create = function(options = {}) {
   return {
     id,
     key: id,
-    label: idToLabel(id),
+    label: this.label,
     type,
     ...options
   };

--- a/packages/form-js-viewer/src/rendering/fields/TextfieldRenderer.js
+++ b/packages/form-js-viewer/src/rendering/fields/TextfieldRenderer.js
@@ -5,8 +5,7 @@ import Label from './Label';
 import { formFieldClasses } from './Util';
 
 import {
-  generateIdForType,
-  idToLabel
+  generateIdForType
 } from '../../util';
 
 
@@ -60,7 +59,7 @@ TextfieldRenderer.create = function(options = {}) {
   return {
     id,
     key: id,
-    label: idToLabel(id),
+    label: this.label,
     type,
     ...options
   };

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -119,9 +119,3 @@ export function exportSchema(schema) {
     return value;
   });
 }
-
-export function idToLabel(string) {
-  return string
-    .replace(/^\w/, (match) => match.toUpperCase())
-    .replace(/\d/, '');
-}


### PR DESCRIPTION
Applies a number of simplifications to the properties panel.

---

**Screenshot**

![image](https://user-images.githubusercontent.com/58601/112480016-e2299c80-8d75-11eb-8686-f3bb952c40f7.png)

---

Out of scope: `Key`, still being finalized.