### PR TITLE
fix: interpret empty textfield/number as undefined

### DIFF
--- a/packages/form-js-editor/src/rendering/PropertiesPanel.js
+++ b/packages/form-js-editor/src/rendering/PropertiesPanel.js
@@ -35,12 +35,12 @@ const FIELDS = [
   'textfield'
 ];
 
-function Checkbox(props) {
+export function Checkbox(props) {
   const {
     id,
     label,
-    value,
     onChange,
+    value = false,
     ...rest
   } = props;
 
@@ -56,19 +56,19 @@ function Checkbox(props) {
   );
 }
 
-function Textfield(props) {
+export function Textfield(props) {
   const { emit } = useContext(FormEditorContext);
 
   const {
     id,
     label,
-    value
+    value = ''
   } = props;
 
-  const debouncedOnInput = useCallback(debounce(props.onInput, 300), [ props.onInput ]);
+  const debouncedOnInput = useCallback(props.debounce ? debounce(props.onInput, 300) : props.onInput, [ props.onInput ]);
 
   const onInput = ({ target }) => {
-    debouncedOnInput(target.value);
+    debouncedOnInput(target.value.length ? target.value : undefined);
   };
 
   const onFocus = () => emit('propertiesPanel.focusin');
@@ -91,17 +91,17 @@ function Textfield(props) {
   );
 }
 
-function Number(props) {
+export function Number(props) {
   const {
     id,
     label,
-    value,
     onInput,
+    value,
     ...rest
   } = props;
 
   const handleInput = ({ target }) => {
-    onInput(target.value);
+    onInput(target.value ? parseInt(target.value, 10) : undefined);
   };
 
   return (
@@ -112,13 +112,13 @@ function Number(props) {
   );
 }
 
-function Select(props) {
+export function Select(props) {
   const {
     id,
     label,
-    value,
     onChange,
     options,
+    value,
     ...rest
   } = props;
 

--- a/packages/form-js-editor/test/spec/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/PropertiesPanel.spec.js
@@ -1,0 +1,247 @@
+import {
+  fireEvent,
+  render
+} from '@testing-library/preact/pure';
+
+import PropertiesPanel, {
+  Checkbox,
+  Number,
+  Textfield
+} from '../../src/rendering/PropertiesPanel';
+
+import schema from './form.json';
+
+import { insertStyles } from '../TestHelper';
+
+insertStyles();
+
+const spy = sinon.spy;
+
+
+describe('properties panel', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = document.createElement('div');
+
+    container.style.height = '100%';
+
+    document.body.appendChild(container);
+  });
+
+  afterEach(function() {
+    document.body.removeChild(container);
+  });
+
+
+  it('should render (no field)', async function() {
+
+    // given
+    const { container } = createPropertiesPanel();
+
+    // then
+    expect(container.querySelector('.fjs-properties-panel-placeholder')).to.exist;
+  });
+
+
+  it('should render (field)', async function() {
+
+    // given
+    const field = schema.components.find(({ key }) => key === 'creditor');
+
+    const { container } = createPropertiesPanel({
+      field
+    });
+
+    // then
+    expect(container.querySelector('.fjs-properties-panel-placeholder')).not.to.exist;
+
+    expect(container.querySelector('.fjs-properties-panel-header-type')).to.exist;
+    expect(container.querySelectorAll('.fjs-properties-panel-group')).to.have.length(2);
+  });
+
+
+  describe('inputs', function() {
+
+    describe('checkbox', function() {
+
+      it('should render', function() {
+
+        // when
+        const { container } = render(<Checkbox value={ false } />);
+
+        // then
+        const input = container.querySelector('input[type="checkbox"]');
+
+        expect(input).to.exist;
+        expect(input.checked).to.be.false;
+      });
+
+
+      it('should handle change', function() {
+
+        // given
+        const onChangeSpy = spy();
+
+        const { container } = render(
+          <Checkbox
+            value={ false }
+            onChange={ onChangeSpy } />
+        );
+
+        // when
+        const input = container.querySelector('input[type="checkbox"]');
+
+        fireEvent.change(input, { target: { checked: true } });
+
+        // then
+        expect(input.checked).to.be.true;
+
+        expect(onChangeSpy).to.have.been.calledWith(true);
+      });
+
+    });
+
+
+    describe('number', function() {
+
+      it('should render', function() {
+
+        // when
+        const { container } = render(<Number value={ 123 } />);
+
+        // then
+        const input = container.querySelector('input[type="number"]');
+
+        expect(input).to.exist;
+        expect(input.value).to.equal('123');
+      });
+
+
+      it('should handle input (number)', function() {
+
+        // given
+        const onInputSpy = spy();
+
+        const { container } = render(
+          <Number
+            value={ 123 }
+            onInput={ onInputSpy } />
+        );
+
+        // when
+        const input = container.querySelector('input[type="number"]');
+
+        fireEvent.input(input, { target: { value: '124' } });
+
+        // then
+        expect(input.value).to.equal('124');
+
+        expect(onInputSpy).to.have.been.calledWith(124);
+      });
+
+
+      it('should handle input (undefined)', function() {
+
+        // given
+        const onInputSpy = spy();
+
+        const { container } = render(
+          <Number
+            value={ 123 }
+            onInput={ onInputSpy } />
+        );
+
+        // when
+        const input = container.querySelector('input[type="number"]');
+
+        fireEvent.input(input, { target: { value: '' } });
+
+        // then
+        expect(input.value).to.equal('');
+
+        expect(onInputSpy).to.have.been.calledWith(undefined);
+      });
+
+    });
+
+
+    describe('textfield', function() {
+
+      it('should render', function() {
+
+        // when
+        const { container } = render(<Textfield value="foo" />);
+
+        // then
+        const input = container.querySelector('input[type="text"]');
+
+        expect(input).to.exist;
+        expect(input.value).to.equal('foo');
+      });
+
+
+      it('should handle input (string)', function() {
+
+        // given
+        const onInputSpy = spy();
+
+        const { container } = render(
+          <Textfield
+            value="foo"
+            onInput={ onInputSpy } />
+        );
+
+        // when
+        const input = container.querySelector('input[type="text"]');
+
+        fireEvent.input(input, { target: { value: 'bar' } });
+
+        // then
+        expect(input.value).to.equal('bar');
+
+        expect(onInputSpy).to.have.been.calledWith('bar');
+      });
+
+
+      it('should handle input (undefined)', function() {
+
+        // given
+        const onInputSpy = spy();
+
+        const { container } = render(
+          <Textfield
+            value="foo"
+            onInput={ onInputSpy } />
+        );
+
+        // when
+        const input = container.querySelector('input[type="text"]');
+
+        fireEvent.input(input, { target: { value: '' } });
+
+        // then
+        expect(input.value).to.equal('');
+
+        expect(onInputSpy).to.have.been.calledWith(undefined);
+      });
+
+    });
+
+  });
+
+});
+
+function createPropertiesPanel(options = {}) {
+  const {
+    editField = () => {},
+    field = null
+  } = options;
+
+  return render(
+    <PropertiesPanel
+      editField={ editField }
+      field={ field } />
+  );
+}


### PR DESCRIPTION
* textfield and number inputs now behave the same as in form-viewer

Closes #42

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
