### PR TITLE
Add Dedicated Importer to Viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Renders a form based on [a form schema](./docs/FORM_SCHEMA.md) and existing data
 ```javascript
 import { createForm } from '@bpmn-io/form-js';
 
-const form = createForm({
+const form = await createForm({
   schema,
   data,
   container: document.querySelector('#form')

--- a/packages/form-js-editor/test/TestHelper.js
+++ b/packages/form-js-editor/test/TestHelper.js
@@ -25,4 +25,6 @@ export function insertStyles() {
   insertCSS('test.css', testCSS);
 }
 
+insertStyles();
+
 export * from './helper';

--- a/packages/form-js-viewer/README.md
+++ b/packages/form-js-viewer/README.md
@@ -32,7 +32,7 @@ const data = {
   creditor: 'John Doe Company'
 };
 
-const form = createForm({
+const form = await createForm({
   container: document.getElementById('form'),
   schema,
   data

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -173,12 +173,12 @@ export default class Form {
 
       const fieldErrors = validator.validateField(field, value);
 
-      return set(errors, path, fieldErrors.length ? fieldErrors : undefined);
+      return set(errors, [ pathStringify(path) ], fieldErrors.length ? fieldErrors : undefined);
     }, {});
 
     this._setState({ errors });
 
-    return this._getState().errors;
+    return errors;
   }
 
   /**

--- a/packages/form-js-viewer/src/core/index.js
+++ b/packages/form-js-viewer/src/core/index.js
@@ -2,10 +2,11 @@ import EventBus from './EventBus';
 import Validator from './Validator';
 import FormFieldRegistry from './FormFieldRegistry';
 
+import importModule from '../import';
 import renderModule from '../render';
 
 export default {
-  __depends__: [ renderModule ],
+  __depends__: [ importModule, renderModule ],
   eventBus: [ 'type', EventBus ],
   formFieldRegistry: [ 'type', FormFieldRegistry ],
   validator: [ 'type', Validator ]

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -1,0 +1,120 @@
+import { generateIdForType } from '../util';
+
+export default class Importer {
+
+  /**
+   * @constructor
+   * @param { import('../core/FormFieldRegistry').default } formFieldRegistry
+   * @param { import('../render/FormFields').default } formFields
+   */
+  constructor(formFieldRegistry, formFields) {
+    this._formFieldRegistry = formFieldRegistry;
+    this._formFields = formFields;
+  }
+
+  /**
+   * Import schema adding `id`, `parent` and `path` information to each field and adding it to the form field registry.
+   *
+   * @param {any} schema
+   * @param {any} data
+   *
+   * @returns {Promise}
+   */
+  importSchema(schema, data = {}) {
+    this._formFieldRegistry.clear();
+
+    // TODO: Add warnings
+    const warnings = [];
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.importFormField(schema, data);
+      } catch (err) {
+        err.warnings = warnings;
+
+        reject(err);
+      }
+
+      resolve({ warnings });
+    });
+  }
+
+  importFormField(formField, data = {}, parentId) {
+    const {
+      components,
+      key,
+      type
+    } = formField;
+
+    let parent;
+
+    if (parentId) {
+
+      // Set form field parent
+      formField.parent = parentId;
+
+      parent = this._formFieldRegistry.get(parentId);
+    }
+
+    if (!this._formFields.get(type)) {
+      throw new Error(`form field of type <${ type }> not supported`);
+    }
+
+    if (key) {
+
+      if (!parent || !parent.isMany) {
+        this._formFieldRegistry.forEach((formField) => {
+          if (formField.key === key) {
+            throw new Error(`form field with key <${ key }> already exists`);
+          }
+        });
+      }
+
+      const path = [];
+
+      if (parent) {
+        path.push(...getParentPath(parent));
+      }
+
+      // Set form field path
+      formField.path = [...path, key];
+    }
+
+    const id = generateIdForType(type);
+
+    // Set form field ID
+    formField.id = id;
+
+    this._formFieldRegistry.set(id, formField);
+
+    if (components) {
+      this.importFormFields(components, data, id);
+    }
+
+    return formField;
+  }
+
+  importFormFields(components, data = {}, parent) {
+    components.forEach((component) => {
+      this.importFormField(component, data, parent);
+    });
+  }
+}
+
+Importer.$inject = [ 'formFieldRegistry', 'formFields' ];
+
+// helpers //////////
+
+function getParentPath(parent) {
+  const { path } = parent;
+
+  if (path) {
+    return path;
+  }
+
+  if (parent.parent) {
+    return getParentPath(parent.parent);
+  }
+
+  return [];
+}

--- a/packages/form-js-viewer/src/import/index.js
+++ b/packages/form-js-viewer/src/import/index.js
@@ -1,0 +1,5 @@
+import Importer from './Importer';
+
+export default {
+  importer: [ 'type', Importer ]
+};

--- a/packages/form-js-viewer/src/index.js
+++ b/packages/form-js-viewer/src/index.js
@@ -34,9 +34,9 @@ export {
  *
  * @param {FormViewerOptions} options
  *
- * @return {Form}
+ * @return {Promise<Form>}
  */
-export function createForm(options) {
+export async function createForm(options) {
   const {
     data,
     schema,
@@ -45,7 +45,7 @@ export function createForm(options) {
 
   const form = new Form(rest);
 
-  form.importSchema(schema, data);
+  await form.importSchema(schema, data);
 
   return form;
 }

--- a/packages/form-js-viewer/src/render/components/FormComponent.js
+++ b/packages/form-js-viewer/src/render/components/FormComponent.js
@@ -38,7 +38,6 @@ export default function FormComponent(props) {
       <FormField
         field={ schema }
         onChange={ onChange }
-        path={ [] }
       />
 
       <PoweredBy />

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -1,30 +1,25 @@
-import {
-  useContext,
-  useEffect
-} from 'preact/hooks';
+import { useContext } from 'preact/hooks';
+
+import { get } from 'min-dash';
 
 import { FormRenderContext } from '../context';
 
 import useService from '../hooks/useService';
 
-import {
-  findData,
-  findErrors,
-  pathStringify
-} from '../../util';
+import { findErrors } from '../../util';
 
 const noop = () => false;
 
 
 export default function FormField(props) {
   const {
-    path,
     field,
     onChange
   } = props;
 
-  const formFieldRegistry = useService('formFieldRegistry'),
-        formFields = useService('formFields'),
+  const { path } = field;
+
+  const formFields = useService('formFields'),
         form = useService('form');
 
   const {
@@ -39,22 +34,13 @@ export default function FormField(props) {
 
   const FormFieldComponent = formFields.get(field.type);
 
-  const { id } = field;
-
   if (!FormFieldComponent) {
     throw new Error(`cannot render field <${field.type}>`);
   }
 
-  const value = findData(data, path);
+  const value = get(data, path);
 
   const fieldErrors = findErrors(errors, path);
-
-  useEffect(() => {
-    formFieldRegistry.set(id, {
-      ...field,
-      path
-    });
-  }, [ pathStringify(path) ]);
 
   return (
     <Element field={ field }>

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -16,7 +16,6 @@ export default function Checkbox(props) {
     disabled,
     errors = [],
     field,
-    path,
     value = false
   } = props;
 
@@ -28,7 +27,7 @@ export default function Checkbox(props) {
 
   const onChange = ({ target }) => {
     props.onChange({
-      path,
+      field,
       value: target.checked
     });
   };

--- a/packages/form-js-viewer/src/render/components/form-fields/Default.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Default.js
@@ -13,10 +13,7 @@ export default function Default(props) {
     Empty
   } = useContext(FormRenderContext);
 
-  let {
-    field,
-    path
-  } = props;
+  const { field } = props;
 
   const { id } = field;
 
@@ -25,16 +22,9 @@ export default function Default(props) {
   return <Children class="fjs-vertical-layout" field={ field }>
     {
       components.map((field) => {
-        if (field.key) {
-          path = [ ...path.slice(0, -1), field.key ];
-        } else {
-          path = path.slice(0, -1);
-        }
-
         return <FormField
           { ...props }
           key={ id }
-          path={ path }
           field={ field } />;
       })
     }

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -16,7 +16,6 @@ export default function Number(props) {
     disabled,
     errors = [],
     field,
-    path,
     value
   } = props;
 
@@ -31,7 +30,7 @@ export default function Number(props) {
 
   const onChange = ({ target }) => {
     props.onChange({
-      path,
+      field,
       value: target.value ? parseInt(target.value, 10) : undefined
     });
   };

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -16,7 +16,6 @@ export default function Radio(props) {
     disabled,
     errors = [],
     field,
-    path,
     value
   } = props;
 
@@ -32,7 +31,7 @@ export default function Radio(props) {
 
   const onChange = (v) => {
     props.onChange({
-      path,
+      field,
       value: v === value ? undefined : v
     });
   };

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -16,7 +16,6 @@ export default function Select(props) {
     disabled,
     errors = [],
     field,
-    path,
     value
   } = props;
 
@@ -32,7 +31,7 @@ export default function Select(props) {
 
   const onChange = ({ target }) => {
     props.onChange({
-      path,
+      field,
       value: target.value === '' ? undefined : target.value
     });
   };

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -16,7 +16,6 @@ export default function Textfield(props) {
     disabled,
     errors = [],
     field,
-    path,
     value = ''
   } = props;
 
@@ -31,7 +30,7 @@ export default function Textfield(props) {
 
   const onChange = ({ target }) => {
     props.onChange({
-      path,
+      field,
       value: target.value.length ? target.value : undefined
     });
   };

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -1,26 +1,8 @@
 export * from './injector';
 export * from './form';
 
-export function findData(data, path) {
-  for (const key of path) {
-    data = data[key];
-
-    if (data === undefined) {
-      return undefined;
-    }
-  }
-
-  return data;
-}
-
 export function findErrors(errors, path) {
   return errors[ pathStringify(path) ];
-}
-
-export function findFieldRenderer(renderers, type) {
-  return renderers.find(renderer => {
-    return renderer.type === type;
-  });
 }
 
 export function isRequired(field) {

--- a/packages/form-js-viewer/test/TestHelper.js
+++ b/packages/form-js-viewer/test/TestHelper.js
@@ -1,3 +1,5 @@
+import { insertCSS } from './helper';
+
 // @ts-ignore-next-line
 import formCSS from '../dist/assets/form-js.css';
 
@@ -14,22 +16,6 @@ function insertStyles() {
   insertCSS('form-js.css', formCSS);
   insertCSS('test.css', testCSS);
 }
-
-export function insertCSS(name, css) {
-  if (document.querySelector('[data-css-file="' + name + '"]')) {
-    return;
-  }
-
-  const head = document.head || document.getElementsByTagName('head')[0];
-  const style = document.createElement('style');
-  style.setAttribute('data-css-file', name);
-
-  style.type = 'text/css';
-  style.appendChild(document.createTextNode(css));
-
-  head.appendChild(style);
-}
-
 
 insertStyles();
 
@@ -57,3 +43,5 @@ export function createFormContainer() {
 
   return container;
 }
+
+export * from './helper';

--- a/packages/form-js-viewer/test/helper/index.js
+++ b/packages/form-js-viewer/test/helper/index.js
@@ -1,0 +1,165 @@
+import {
+  forEach,
+  isFunction,
+  merge
+} from 'min-dash';
+
+import TestContainer from 'mocha-test-container-support';
+
+import Form from '../../src/Form';
+
+let OPTIONS, FORM;
+
+function cleanup() {
+  if (!FORM) {
+    return;
+  }
+
+  FORM.destroy();
+}
+
+/**
+ * Bootstrap the form given the specified options and a number of locals (i.e. services)
+ *
+ * @example
+ *
+ * describe(function() {
+ *
+ *   const mockEvents;
+ *
+ *   beforeEach(bootstrapForm(function() {
+ *     mockEvents = new Events();
+ *
+ *     return {
+ *       events: mockEvents
+ *     };
+ *   }));
+ *
+ * });
+ *
+ * @param  {Object} schema
+ * @param  {Object} [options]
+ * @param  {Object|Function} locals
+ *
+ * @returns {Promise}
+ */
+export function bootstrapForm(schema, options, locals) {
+
+  return function() {
+
+    let testContainer;
+
+    // Make sure the test container is an optional dependency and we fall back
+    // to an empty <div> if it does not exist.
+    //
+    // This is needed if other libraries rely on this helper for testing
+    // while not adding the mocha-test-container-support as a dependency.
+    try {
+      testContainer = TestContainer.get(this);
+    } catch (e) {
+      testContainer = document.createElement('div');
+      testContainer.classList.add('test-content-container');
+
+      document.body.appendChild(testContainer);
+    }
+
+    let _options = options,
+        _locals = locals;
+
+    if (!_locals && isFunction(_options)) {
+      _locals = _options;
+      _options = null;
+    }
+
+    if (isFunction(_options)) {
+      _options = _options();
+    }
+
+    if (isFunction(_locals)) {
+      _locals = _locals();
+    }
+
+    _options = merge({
+      renderer: {
+        container: testContainer
+      }
+    }, OPTIONS, _options);
+
+
+    const mockModule = {};
+
+    forEach(_locals, function(value, key) {
+      mockModule[ key ] = [ 'value', value ];
+    });
+
+    _options.modules = [].concat(_options.modules || [], [ mockModule ]);
+
+    // remove previous instance
+    cleanup();
+
+    FORM = new Form(_options);
+
+    if (schema) {
+      return FORM.importXML(schema).then(function(result) {
+        return { error: null, warnings: result.warnings };
+      }).catch(function(err) {
+        return { error: err, warnings: err.warnings };
+      });
+    }
+  };
+}
+
+/**
+ * Injects services of an instantiated form into the argument.
+ *
+ * Use it in conjunction with {@link #bootstrapForm}.
+ *
+ * @example
+ *
+ * describe(function() {
+ *
+ *   const mockEvents;
+ *
+ *   beforeEach(bootstrapForm(...));
+ *
+ *   it('should provide mocked events', inject(function(events) {
+ *     expect(events).toBe(mockEvents);
+ *   }));
+ *
+ * });
+ *
+ * @param  {Function} fn the function to inject to
+ * @return {Function} a function that can be passed to it to carry out the injection
+ */
+export function inject(fn) {
+  return function() {
+
+    if (!FORM) {
+      throw new Error('no bootstraped diagram, ensure you created it via #bootstrapForm');
+    }
+
+    return FORM.invoke(fn);
+  };
+}
+
+export function getForm() {
+  return FORM;
+}
+
+export function insertCSS(name, css) {
+  if (document.querySelector('[data-css-file="' + name + '"]')) {
+    return;
+  }
+
+  const head = document.head || document.getElementsByTagName('head')[ 0 ];
+
+  const style = document.createElement('style');
+
+  style.setAttribute('data-css-file', name);
+
+  style.type = 'text/css';
+
+  style.appendChild(document.createTextNode(css));
+
+  head.appendChild(style);
+}

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -97,6 +97,26 @@ describe('createForm', function() {
   });
 
 
+  it('#validate', async function() {
+
+    // given
+    const form = await createForm({
+      container,
+      schema
+    });
+
+    // when
+    const errors = form.validate();
+
+    // then
+    expect(errors).to.eql({
+      creditor: [
+        'Field is required.'
+      ]
+    });
+  });
+
+
   it('should attach', async function() {
 
     // given

--- a/packages/form-js-viewer/test/spec/import/Importer.spec.js
+++ b/packages/form-js-viewer/test/spec/import/Importer.spec.js
@@ -1,0 +1,136 @@
+import {
+  bootstrapForm,
+  getForm,
+  inject
+} from 'test/TestHelper';
+
+import { clone } from 'src/util';
+
+import schema from '../form.json';
+
+
+describe('Importer', function() {
+
+  beforeEach(bootstrapForm());
+
+  afterEach(function() {
+    getForm().destroy();
+  });
+
+
+  it('should import without errors', inject(async function(form, formFieldRegistry) {
+
+    // given
+    const data = {
+      creditor: 'John Doe Company',
+      amount: 456,
+      invoiceNumber: 'C-123',
+      approved: true,
+      approvedBy: 'John Doe',
+      product: 'camunda-cloud',
+      language: 'english'
+    };
+
+    // when
+    const { err, warnings } = await form.importSchema(schema, data);
+
+    // then
+    expect(err).not.to.exist;
+    expect(warnings).to.be.empty;
+
+    expect(formFieldRegistry.size).to.equal(11);
+  }));
+
+
+  it('should error if form field of type not supported', inject(async function(form) {
+
+    // given
+    const error = clone(schema);
+
+    error.components.push({
+      type: 'foo'
+    });
+
+    // when
+    try {
+      await form.importSchema(error);
+    } catch (err) {
+
+      // then
+      expect(err).to.exist;
+      expect(err.message).to.eql('form field of type <foo> not supported');
+
+      expect(err.warnings).to.exist;
+      expect(err.warnings).to.be.empty;
+    }
+  }));
+
+
+  it('should error if form field with key already exists', inject(async function(form) {
+
+    // given
+    const error = clone(schema);
+
+    error.components.push({
+      type: 'textfield',
+      key: 'creditor'
+    });
+
+    // when
+    try {
+      await form.importSchema(error);
+    } catch (err) {
+
+      // then
+      expect(err).to.exist;
+      expect(err.message).to.eql('form field with key <creditor> already exists');
+
+      expect(err.warnings).to.exist;
+      expect(err.warnings).to.be.empty;
+    }
+  }));
+
+
+  it('should error if broken JSON is imported', inject(async function(form) {
+
+    // when
+    try {
+      await form.importSchema('foo');
+    } catch (err) {
+
+      // then
+      expect(err).to.exist;
+      expect(err.message).to.equal('form field of type <undefined> not supported');
+
+      expect(err.warnings).to.exist;
+      expect(err.warnings).to.be.empty;
+    }
+  }));
+
+
+  // TODO: Catch broken schema errors during import
+  it.skip('should error if broken schema is imported', inject(async function(form) {
+
+    // given
+    const error = clone(schema);
+
+    error.components.push({
+      type: 'select',
+      key: 'foo',
+      values: 123
+    });
+
+    // when
+    try {
+      await form.importSchema(error);
+    } catch (err) {
+
+      // then
+      expect(err).to.exist;
+
+      expect(err.warnings).to.exist;
+      expect(err.warnings).to.be.empty;
+    }
+  }));
+
+});

--- a/packages/form-js-viewer/test/spec/rendering/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/rendering/components/form-fields/Checkbox.spec.js
@@ -111,7 +111,7 @@ describe('Checkbox', function() {
 
     // then
     expect(onChangeSpy).to.have.been.calledWith({
-      path: [ 'approved' ],
+      field: defaultField,
       value: false
     });
   });

--- a/packages/form-js-viewer/test/spec/rendering/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/rendering/components/form-fields/Number.spec.js
@@ -111,7 +111,7 @@ describe('Number', function() {
 
     // then
     expect(onChangeSpy).to.have.been.calledWith({
-      path: [ 'amount' ],
+      field: defaultField,
       value: 124
     });
   });

--- a/packages/form-js-viewer/test/spec/rendering/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/rendering/components/form-fields/Radio.spec.js
@@ -114,7 +114,7 @@ describe('Radio', function() {
 
       // then
       expect(onChangeSpy).to.have.been.calledWith({
-        path: [ 'product' ],
+        field: defaultField,
         value: 'camunda-cloud'
       });
     });
@@ -137,7 +137,7 @@ describe('Radio', function() {
 
       // then
       expect(onChangeSpy).to.have.been.calledWith({
-        path: [ 'product' ],
+        field: defaultField,
         value: undefined
       });
     });

--- a/packages/form-js-viewer/test/spec/rendering/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/rendering/components/form-fields/Select.spec.js
@@ -110,7 +110,7 @@ describe('Select', function() {
 
       // then
       expect(onChangeSpy).to.have.been.calledWith({
-        path: [ 'language' ],
+        field: defaultField,
         value: 'english'
       });
     });
@@ -133,7 +133,7 @@ describe('Select', function() {
 
       // then
       expect(onChangeSpy).to.have.been.calledWith({
-        path: [ 'language' ],
+        field: defaultField,
         value: undefined
       });
     });

--- a/packages/form-js-viewer/test/spec/rendering/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/rendering/components/form-fields/Textfield.spec.js
@@ -111,7 +111,7 @@ describe('Textfield', function() {
 
     // then
     expect(onChangeSpy).to.have.been.calledWith({
-      path: [ 'creditor' ],
+      field: defaultField,
       value: 'Jane Doe Company'
     });
   });

--- a/packages/form-js/test/distro/form-viewer.js
+++ b/packages/form-js/test/distro/form-viewer.js
@@ -20,7 +20,7 @@ describe('form-viewer', function() {
   });
 
 
-  it('should display form', function() {
+  it('should display form', async function() {
 
     const { createForm } = window.FormViewer;
 
@@ -47,7 +47,7 @@ describe('form-viewer', function() {
     };
 
     // when
-    const form = createForm({
+    const form = await createForm({
       container,
       schema,
       data

--- a/packages/form-js/test/spec/Form.spec.js
+++ b/packages/form-js/test/spec/Form.spec.js
@@ -27,7 +27,7 @@ describe('createForm', function() {
   });
 
 
-  (singleStart ? it.only : it)('should render', function() {
+  (singleStart ? it.only : it)('should render', async function() {
 
     // given
     const data = {
@@ -41,7 +41,7 @@ describe('createForm', function() {
     };
 
     // when
-    const form = createForm({
+    const form = await createForm({
       container,
       schema,
       data


### PR DESCRIPTION
* add dedicated importer to viewer
* import each form field adding `id`, `parent` and `path` and adding it to form field registry
* throw error if form field of type not supported or if form field with key already exists
* call `_update` with `field` instead of `path` since `path` is now set at all times
* verify #validate is working

BREAKING CHANGES

* #createForm returns promise resolving with form instead of returning form

Closes #79
Closes #30

Follow-up issues:

* Refactor Editor Import (https://github.com/bpmn-io/form-js/issues/82)