### PR TITLE
test: verify import error during instantiation

### DIFF
--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -330,4 +330,39 @@ describe('createForm', function() {
     form.submit();
   });
 
+
+  it('should fail instantiation with import error', async function() {
+
+    // given
+    const data = {
+      amount: 456
+    };
+
+    const schema = {
+      type: 'default',
+      components: [
+        {
+          type: 'unknown-component'
+        }
+      ]
+    };
+
+    let error;
+
+    // when
+    try {
+      await createForm({
+        container,
+        data,
+        schema
+      });
+    } catch (_error) {
+      error = _error;
+    }
+
+    // then
+    expect(error).to.exist;
+    expect(error.message).to.eql('form field of type <unknown-component> not supported');
+  });
+
 });


### PR DESCRIPTION
This ensures our story for handling import errors works, specifically the following:

```javascript
try {
  await createForm({ schema: someBrokenSchema });
} catch (error) {
  // blows up on error
}
```