### PR TITLE
fix: properly generate paragraphs

### DIFF
--- a/packages/form-js-editor/test/spec/form.json
+++ b/packages/form-js-editor/test/spec/form.json
@@ -2,7 +2,7 @@
   "components": [
     {
       "type": "text",
-      "text": "# Invoice\nLorem _ipsum_ __dolor__ `sit`.\n  \n  \nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
     },
     {
       "key": "creditor",

--- a/packages/form-js-viewer/src/render/components/Util.js
+++ b/packages/form-js-viewer/src/render/components/Util.js
@@ -43,9 +43,21 @@ const ALLOWED_ATTRIBUTES = [
   'valign'
 ];
 
+export function markdownToHTML(markdown) {
+  const htmls = markdown
+    .split(/(?:\r?\n){2,}/)
+    .map(line =>
+      /^[<\s#-*]/.test(line)
+        ? snarkdown(line)
+        : `<p>${ snarkdown(line) }</p>`,
+    );
+
+  return htmls.join('\n\n');
+}
+
 // See https://github.com/developit/snarkdown/issues/70
 export function safeMarkdown(markdown) {
-  const html = snarkdown(markdown);
+  const html = markdownToHTML(markdown);
 
   const doc = new DOMParser().parseFromString(
     `<!DOCTYPE html>\n<html><body><div>${ html }`,

--- a/packages/form-js-viewer/src/render/components/form-fields/Text.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Text.js
@@ -15,7 +15,7 @@ export default function Text(props) {
   const { text } = field;
 
   return <div class={ formFieldClasses(type) }>
-    <Markup markup={ safeMarkdown(text) } />
+    <Markup markup={ safeMarkdown(text) } trim={ false } />
   </div>;
 }
 

--- a/packages/form-js-viewer/test/spec/form.json
+++ b/packages/form-js-viewer/test/spec/form.json
@@ -2,7 +2,7 @@
   "components": [
     {
       "type": "text",
-      "text": "# Invoice\nLorem _ipsum_ __dolor__ `sit`.\n  \n  \nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
     },
     {
       "key": "creditor",

--- a/packages/form-js-viewer/test/spec/render/components/Util.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Util.spec.js
@@ -1,5 +1,6 @@
 import {
   formFieldClasses,
+  markdownToHTML,
   safeMarkdown
 } from '../../../../src/render/components/Util';
 
@@ -25,6 +26,127 @@ describe('Util', function() {
 
       // then
       expect(classes).to.equal('fjs-form-field fjs-form-field-button fjs-has-errors');
+    });
+
+  });
+
+
+  describe('markdownToHTML', function() {
+
+    it('should generate paragraphs', function() {
+
+      // given
+      const markdown = `
+# H1
+
+__Lorem ipsum dolor__ first.
+
+Second.
+Second continued.
+
+## H2
+
+Third.
+
+1.  List
+    List continued.
+2.  Second List
+
+*   Unordered List
+    Unordered list continued
+*   Second Unordered List Item
+
+![some small image](https://via.placeholder.com/400x150)
+![ſome big image](https://via.placeholder.com/1000x150)
+      `.trim();
+
+      const expectedHTML = `
+<h1>H1</h1>
+
+<p><strong>Lorem ipsum dolor</strong> first.</p>
+
+<p>Second.
+Second continued.</p>
+
+<h2>H2</h2>
+
+<p>Third.</p>
+
+<p><ol><li>List</li></ol><pre class="code poetry"><code>List continued.</code></pre><ol><li>Second List</li></ol></p>
+
+<ul><li>Unordered List</li></ul><pre class="code poetry"><code>Unordered list continued</code></pre><ul><li>Second Unordered List Item</li></ul>
+
+<p><img src="https://via.placeholder.com/400x150" alt="some small image">
+<img src="https://via.placeholder.com/1000x150" alt="ſome big image"></p>
+      `.trim();
+
+      // when
+      const html = markdownToHTML(markdown);
+
+      // then
+      expect(html).to.eql(expectedHTML);
+    });
+
+
+    it('should not paragraph-wrap heading', function() {
+
+      // given
+      const markdown = '#Foo<span>HELLO</span>';
+
+      // when
+      const html = markdownToHTML(markdown);
+
+      // then
+      expect(html).to.equal('<h1>Foo<span>HELLO</span></h1>');
+    });
+
+
+    it('should not paragraph-wrap HTML markup', function() {
+
+      // given
+      const markdown = '<h1>HELLO</h1>';
+
+      // when
+      const html = markdownToHTML(markdown);
+
+      // then
+      expect(html).to.equal('<h1>HELLO</h1>');
+    });
+
+
+    it('should create link', function() {
+
+      // given
+      const markdown = 'at [varius](http://foo) turpis nunc eget.';
+
+      // when
+      const html = markdownToHTML(markdown);
+
+      // then
+      expect(html).to.equal('<p>at <a href="http://foo">varius</a> turpis nunc eget.</p>');
+    });
+
+
+    it('should create heading + paragraph', function() {
+
+      // given
+      const markdown = `
+# H1
+
+Do [this](http://localhost), not __that__.
+      `.trim();
+
+      const expectedHTML = `
+<h1>H1</h1>
+
+<p>Do <a href="http://localhost">this</a>, not <strong>that</strong>.</p>
+      `.trim();
+
+      // when
+      const html = markdownToHTML(markdown);
+
+      // then
+      expect(html).to.eql(expectedHTML);
     });
 
   });


### PR DESCRIPTION
Should generate proper paragraphs from markdown now as the user would expect:

![image](https://user-images.githubusercontent.com/58601/122541012-7d56a900-d029-11eb-9ab6-fbc25a731d93.png)

![image](https://user-images.githubusercontent.com/58601/122541263-bb53cd00-d029-11eb-834c-13008554bd34.png)

Had to workaround https://github.com/developit/preact-markup/issues/10 as well as https://github.com/developit/snarkdown/issues/75. Added a special rule to not wrap existing HTML tags (i.e. user-created `<p>` tags).

---

Related to https://github.com/bpmn-io/form-js/issues/87