### PR TITLE
Do Not Error If Text Form Field Has No Text Property

### DIFF
--- a/packages/form-js-editor/src/render/components/properties-panel/Util.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/Util.js
@@ -26,7 +26,7 @@ export function stopPropagation(listener) {
   };
 }
 
-export function textToLabel(text) {
+export function textToLabel(text = '...') {
   if (text.length > 10) {
     return `${ text.substring(0, 10) }...`;
   }

--- a/packages/form-js-editor/test/spec/properties-panel/Util.spec.js
+++ b/packages/form-js-editor/test/spec/properties-panel/Util.spec.js
@@ -1,0 +1,29 @@
+import { textToLabel } from 'src/render/components/properties-panel/Util';
+
+
+describe('properties panel util', function() {
+
+  describe('#textToLabel', function() {
+
+    it('should shorten text', function() {
+
+      // when
+      const label = textToLabel('Lorem ipsum dolor sit amet');
+
+      // then
+      expect(label).to.equal('Lorem ipsu...');
+    });
+
+
+    it('should default to ...', function() {
+
+      // when
+      const label = textToLabel();
+
+      // then
+      expect(label).to.equal('...');
+    });
+
+  });
+
+});

--- a/packages/form-js-viewer/src/render/components/form-fields/Text.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Text.js
@@ -12,7 +12,7 @@ const type = 'text';
 export default function Text(props) {
   const { field } = props;
 
-  const { text } = field;
+  const { text = '' } = field;
 
   return <div class={ formFieldClasses(type) }>
     <Markup markup={ safeMarkdown(text) } trim={ false } />

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -35,6 +35,30 @@ describe('Text', function() {
   });
 
 
+  it('should render (no text)', function() {
+
+    // when
+    const { container } = createText({
+      field: {
+        type: 'text'
+      }
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    console.log(formField);
+
+    expect(formField).to.exist;
+    expect(formField.classList.contains('fjs-form-field-text')).to.be.true;
+
+    const paragraph = container.querySelector('p');
+
+    expect(paragraph).to.exist;
+    expect(paragraph.textContent).to.equal('');
+  });
+
+
   it('#create', function() {
 
     // when


### PR DESCRIPTION
Savely remove text without an error being thrown.

![NBlF9bRVfB](https://user-images.githubusercontent.com/7633572/122547533-839c5380-d030-11eb-8e5d-a79f5bb2cd30.gif)

Closes #94

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
