### PR TITLE
Make Options Optional

### DIFF
--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -6,7 +6,8 @@ import {
 import {
   createInjector,
   clone,
-  createFormContainer
+  createFormContainer,
+  schemaVersion
 } from '@bpmn-io/form-js-viewer';
 
 import core from './core';
@@ -27,7 +28,6 @@ import KeyboardModule from './features/keyboard';
  *   injector?: Injector,
  *   modules?: Modules,
  *   properties?: FormEditorProperties,
- *   schemaVersion?: number,
  *   [x: string]: any
  * } } FormEditorOptions
  *
@@ -53,8 +53,7 @@ export default class FormEditor {
       container,
       exporter,
       injector = this._createInjector(options, this._container),
-      properties = {},
-      schemaVersion
+      properties = {}
     } = options;
 
     /**
@@ -62,12 +61,6 @@ export default class FormEditor {
      * @type {any}
      */
     this.exporter = exporter;
-
-    /**
-     * @private
-     * @type {number}
-     */
-    this.schemaVersion = schemaVersion;
 
     /**
      * @private
@@ -134,7 +127,7 @@ export default class FormEditor {
     return exportSchema(
       schema,
       this.exporter,
-      this.schemaVersion
+      schemaVersion
     );
   }
 

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -27,7 +27,7 @@ import KeyboardModule from './features/keyboard';
  *   injector?: Injector,
  *   modules?: Modules,
  *   properties?: FormEditorProperties,
- *   schemaVersion: number,
+ *   schemaVersion?: number,
  *   [x: string]: any
  * } } FormEditorOptions
  *
@@ -41,7 +41,7 @@ export default class FormEditor {
    * @constructor
    * @param {FormEditorOptions} options
    */
-  constructor(options) {
+  constructor(options = {}) {
 
     /**
      * @private

--- a/packages/form-js-editor/src/index.js
+++ b/packages/form-js-editor/src/index.js
@@ -37,10 +37,7 @@ export function createFormEditor(options) {
     ...rest
   } = options;
 
-  const formEditor = new FormEditor({
-    ...rest,
-    schemaVersion
-  });
+  const formEditor = new FormEditor(rest);
 
   return formEditor.importSchema(schema).then(() => {
     return formEditor;

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -1,5 +1,6 @@
 import {
   createFormEditor,
+  FormEditor,
   schemaVersion
 } from '../../src';
 
@@ -25,7 +26,7 @@ const spy = sinon.spy;
 const singleStart = isSingleStart('basic');
 
 
-describe('createFormEditor', function() {
+describe('FormEditor', function() {
 
   let container;
 
@@ -43,7 +44,7 @@ describe('createFormEditor', function() {
 
   (singleStart ? it.only : it)('should render', async function() {
 
-    // given
+    // when
     const formEditor = await createFormEditor({
       container,
       schema,
@@ -56,6 +57,21 @@ describe('createFormEditor', function() {
     formEditor.on('changed', event => {
       console.log('Form Editor <changed>', event, formEditor.getSchema());
     });
+
+    // then
+    expect(formEditor.get('formFieldRegistry').size).to.equal(11);
+  });
+
+
+  it('should create instance and import', async function() {
+
+    // given
+    const formEditor = new FormEditor();
+
+    await formEditor.importSchema(schema);
+
+    // then
+    expect(formEditor.get('formFieldRegistry').size).to.equal(11);
   });
 
 

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -47,7 +47,7 @@ export default class Form {
    * @constructor
    * @param {FormOptions} options
    */
-  constructor(options) {
+  constructor(options = {}) {
 
     /**
      * @private

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -1,5 +1,6 @@
 import {
   createForm,
+  Form,
   schemaVersion
 } from '../../src';
 
@@ -24,7 +25,7 @@ insertCSS('custom.css', customCSS);
 const singleStart = isSingleStart('basic');
 
 
-describe('createForm', function() {
+describe('Form', function() {
 
   let container;
 
@@ -73,13 +74,44 @@ describe('createForm', function() {
       schema
     });
 
-    form.on('changed', ({ data, errors }) => console.log(data, errors));
+    form.on('changed', event => {
+      console.log('Form <changed>', event);
+    });
 
     // then
-    expect(form).to.exist;
-    expect(form.reset).to.exist;
-    expect(form.submit).to.exist;
-    expect(form._update).to.exist;
+    expect(form.get('formFieldRegistry').size).to.equal(11);
+  });
+
+
+  it('should create instance and import', async function() {
+
+    // given
+    const data = {
+      creditor: 'John Doe Company',
+      amount: 456,
+      invoiceNumber: 'C-123',
+      approved: true,
+      approvedBy: 'John Doe',
+      product: 'camunda-cloud',
+      language: 'english',
+      documents: [
+        {
+          title: 'invoice.pdf',
+          author: 'John Doe'
+        },
+        {
+          title: 'products.pdf'
+        }
+      ]
+    };
+
+    // when
+    const form = new Form();
+
+    await form.importSchema(schema, data);
+
+    // then
+    expect(form.get('formFieldRegistry').size).to.equal(11);
   });
 
 


### PR DESCRIPTION
Instantiating a form or form editor without the `options` argument would blow up even though we consider them optional.

```javascript
const form = new Form();
```

doesn't 💥 up anymore.
