### PR TITLE
fix(viewer): turn number form field into controlled component

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -16,7 +16,7 @@ export default function Number(props) {
     disabled,
     errors = [],
     field,
-    value
+    value = ''
   } = props;
 
   const {

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -388,10 +388,45 @@ describe('Form', function() {
     // when reset
     form.reset();
 
+    // then
     const state = form._getState();
 
-    // then
     expect(state.data).to.eql(data);
+    expect(state.errors).to.be.empty;
+  });
+
+
+  it('should reset (no data)', async function() {
+
+    // when
+    const form = await createForm({
+      container,
+      schema
+    });
+
+    // update programmatically
+    form._update({
+      field: getFormField(form, 'creditor'),
+      value: 'Jane Doe Company'
+    });
+
+    form._update({
+      field: getFormField(form, 'amount'),
+      value: '123'
+    });
+
+    form._update({
+      field: getFormField(form, 'approved'),
+      value: true
+    });
+
+    // when
+    form.reset();
+
+    // then
+    const state = form._getState();
+
+    expect(state.data).to.be.empty;
     expect(state.errors).to.be.empty;
   });
 
@@ -585,3 +620,9 @@ describe('Form', function() {
   });
 
 });
+
+// helpers //////////
+
+function getFormField(form, key) {
+  return Array.from(form.get('formFieldRegistry').values()).find((formField) => formField.key === key);
+}

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -363,7 +363,7 @@ describe('Form', function() {
       schema
     });
 
-    const field = Array.from(form.get('formFieldRegistry').values()).find(({ key }) => key === 'creditor');
+    const field = getFormField(form, 'creditor');
 
     // update programmatically
     form._update({
@@ -461,7 +461,7 @@ describe('Form', function() {
     form.on('changed', changedListener);
 
     // when
-    const field = Array.from(form.get('formFieldRegistry').values()).find(({ key }) => key === 'creditor');
+    const field = getFormField(form, 'creditor');
 
     form._update({
       field,

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -61,6 +61,32 @@ describe('Number', function() {
   });
 
 
+  it('should render default value on value removed', function() {
+
+    // given
+    const props = {
+      disabled: false,
+      errors: [],
+      field: defaultField,
+      onChange: () => {},
+      path: [ defaultField.key ]
+    };
+
+    const options = { container: container.querySelector('.fjs-form') };
+
+    const { rerender } = render(<Number { ...props } value={ 123 } />, options);
+
+    // when
+    rerender(<Number { ...props } value={ undefined } />, options);
+
+    // then
+    const input = container.querySelector('input[type="number"]');
+
+    expect(input).to.exist;
+    expect(input.value).to.equal('');
+  });
+
+
   it('should render disabled', function() {
 
     // when

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -61,6 +61,32 @@ describe('Textfield', function() {
   });
 
 
+  it('should render default value on value removed', function() {
+
+    // given
+    const props = {
+      disabled: false,
+      errors: [],
+      field: defaultField,
+      onChange: () => {},
+      path: [ defaultField.key ]
+    };
+
+    const options = { container: container.querySelector('.fjs-form') };
+
+    const { rerender } = render(<Textfield { ...props } value={ 'John Doe Company' } />, options);
+
+    // when
+    rerender(<Textfield { ...props } value={ undefined } />, options);
+
+    // then
+    const input = container.querySelector('input[type="text"]');
+
+    expect(input).to.exist;
+    expect(input.value).to.equal('');
+  });
+
+
   it('should render disabled', function() {
 
     // when


### PR DESCRIPTION
Setting the value of a number form field from a number (e.g. `123`) to `undefined` wouldn't result in the displayed value being set to `""`. Turning the form field into a controlled component (avoiding switch between `undefined` and a value e.g. `123`) fixes the issue (cf. https://reactjs.org/docs/forms.html#controlled-components). In fact, we already did that for the `textfield` form field (cf. https://github.com/bpmn-io/form-js/blob/v0.2.4/packages/form-js-viewer/src/render/components/form-fields/Textfield.js#L19).

Closes #122

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
