### PR TITLE
chore(eslint): add rule to catch invalid inter-package imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,16 @@
   "rules": {
     "import/first": "error",
     "import/no-amd": "error",
-    "import/no-webpack-loader-syntax": "error"
+    "import/no-webpack-loader-syntax": "error",
+    "import/no-restricted-paths": [ "error", {
+      "basePath": "./packages",
+      "zones": [
+        { "target": "form-js/src", "from": ".", "except": [ "form-js" ] },
+        { "target": "form-js-editor/src", "from": ".", "except": [ "form-js-editor" ] },
+        { "target": "form-js-playground/src", "from": ".", "except": [ "form-js-playground" ] },
+        { "target": "form-js-viewer/src", "from": ".", "except": [ "form-js-viewer" ] }
+      ]
+    }]
   },
   "plugins": [
     "import"


### PR DESCRIPTION
closes #119

Also cf. https://github.com/bpmn-io/hour-of-code/blob/master/snippets/dmn-js_importFromSrc.md

This avoids to have something like 
```javascript
export {
  createFormEditor,
  FormEditor,
  schemaVersion
// wrong, but works during dev:
} from '../../form-js-editor'; 
// correct:
// } from '@bpmn-io/form-js-editor'; 
```

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
