### PR TITLE
feat(editor): add compact mode

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -345,3 +345,23 @@
   pointer-events: none !important;
   height: 54px !important;
 }
+
+/**
+ * Compact editor overrides
+ */
+
+.fjs-editor-compact .fjs-hide-compact {
+  display: none;
+}
+
+.fjs-editor-compact .fjs-palette-container {
+  width: auto;
+}
+
+.fjs-editor-compact .fjs-palette-field {
+  justify-content: center;
+}
+
+.fjs-editor-compact .fjs-palette-field-icon {
+  margin: 0;
+}

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -209,14 +209,16 @@ export default class FormEditor {
   _createInjector(options, container) {
     const {
       additionalModules = [],
-      modules = this._getModules()
+      modules = this._getModules(),
+      renderer = {}
     } = options;
 
     const config = {
+      ...options,
       renderer: {
+        ...renderer,
         container
-      },
-      ...options
+      }
     };
 
     return createInjector([

--- a/packages/form-js-editor/src/render/Renderer.js
+++ b/packages/form-js-editor/src/render/Renderer.js
@@ -6,20 +6,25 @@ import FormEditor from './components/FormEditor';
 import { FormEditorContext } from './context';
 
 /**
- * @typedef { { container } } Config
+ * @typedef { { container: Element, compact?: boolean } } RenderConfig
  * @typedef { import('didi').Injector } Injector
  * @typedef { import('../core/EventBus').default } EventBus
  * @typedef { import('../FormEditor').default } FormEditor
  */
 
 /**
- * @param {Config} config
+ * @param {RenderConfig} renderConfig
  * @param {EventBus} eventBus
  * @param {FormEditor} formEditor
  * @param {Injector} injector
  */
 export default class Renderer {
-  constructor(config, eventBus, formEditor, injector) {
+  constructor(renderConfig, eventBus, formEditor, injector) {
+
+    const {
+      container,
+      compact = false
+    } = renderConfig;
 
     const App = () => {
       const [ state, setState ] = useState(formEditor._getState());
@@ -41,15 +46,13 @@ export default class Renderer {
       }
 
       return (
-        <div class="fjs-container fjs-editor-container">
+        <div class={ `fjs-container fjs-editor-container ${ compact ? 'fjs-editor-compact' : '' }` }>
           <FormEditorContext.Provider value={ formEditorContext }>
             <FormEditor />
           </FormEditorContext.Provider>
         </div>
       );
     };
-
-    const { container } = config;
 
     eventBus.on('form.init', () => {
       render(<App />, container);

--- a/packages/form-js-editor/src/render/components/palette/Palette.js
+++ b/packages/form-js-editor/src/render/components/palette/Palette.js
@@ -36,18 +36,24 @@ const types = [
 
 export default function Palette(props) {
   return <Fragment>
-    <div class="fjs-palette-header">FORM ELEMENTS LIBRARY</div>
+    <div class="fjs-palette-header" title="Form elements library">
+      <span class="fjs-hide-compact">FORM ELEMENTS </span>LIBRARY
+    </div>
     <div class="fjs-palette fjs-drag-container fjs-no-drop">
       {
         types.map(({ label, type }) => {
           const Icon = iconsByType[ type ];
 
           return (
-            <div class="fjs-palette-field fjs-drag-copy fjs-no-drop" data-field-type={ type }>
+            <div
+              class="fjs-palette-field fjs-drag-copy fjs-no-drop"
+              data-field-type={ type }
+              title={ `Create a ${ label } element` }
+            >
               {
                 Icon ? <Icon class="fjs-palette-field-icon" width="36" height="36" viewBox="0 0 54 54" /> : null
               }
-              <span>{ label }</span>
+              <span class="fjs-palette-field-text fjs-hide-compact">{ label }</span>
             </div>
           );
         })

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -63,6 +63,29 @@ describe('FormEditor', function() {
   });
 
 
+  it('should render compact', async function() {
+
+    // when
+    await createFormEditor({
+      container,
+      schema,
+      debounce: true,
+      renderer: {
+        compact: true
+      },
+      keyboard: {
+        bindTo: document
+      }
+    });
+
+    // then
+    const editorContainer = container.querySelector('.fjs-editor-container');
+
+    expect(editorContainer).to.exist;
+    expect(editorContainer.matches('.fjs-editor-compact')).to.be.true;
+  });
+
+
   it('should create instance and import', async function() {
 
     // given


### PR DESCRIPTION
This allows users to configure a compact editor rendering mode:

![screely-1626866387466](https://user-images.githubusercontent.com/58601/126480665-5d4008a8-8bd2-49f6-b30b-9d04839ca61c.png)


In compact mode the editor is geared towards smaller screen widths, compresses the palette and potentially provides further improvements in the future.

This approach does not add true responsiveness. Instead, integrators must decide on instantiation whether the editor should be rendered compact or not. An alternative would be to provide additional APIs to trigger that behavior / make it reactive via a generic _set property_ interface (cf. https://github.com/bpmn-io/form-js/blob/22a9ac92bc45bcb309df04770fa0fc004e49a628/packages/form-js-viewer/src/Form.js#L61).