### PR TITLE
feat(editor): debounce input per default

### DIFF
--- a/packages/form-js-editor/src/core/Debounce.js
+++ b/packages/form-js-editor/src/core/Debounce.js
@@ -3,9 +3,9 @@ import { debounce } from 'min-dash';
 /**
  * A factory to create a configurable debouncer.
  *
- * @param {number|boolean} config
+ * @param {number|boolean} [config=true]
  */
-export default function DebounceFactory(config) {
+export default function DebounceFactory(config=true) {
 
   const timeout = typeof config === 'number' ? config : config ? 300 : 0;
 

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -48,7 +48,6 @@ describe('FormEditor', function() {
     const formEditor = await createFormEditor({
       container,
       schema,
-      debounce: true,
       keyboard: {
         bindTo: document
       }


### PR DESCRIPTION
This ensures that we debounce editor input per default, unless disabled.

This is standard behavior in editing environments and allows users to get good UX without further configuration.