### PR TITLE
fix(form-editor): clean up before import

### DIFF
--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -92,7 +92,12 @@ export default class FormEditor {
   }
 
   destroy() {
+
+    // Destroy form services
     this.get('eventBus').fire('form.destroy');
+
+    // Destroy diagram services (e.g. EventBus)
+    this.get('eventBus').fire('diagram.destroy');
 
     this._detach(false);
   }

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -89,6 +89,8 @@ export default class FormEditor {
 
     // Clear diagram services (e.g. EventBus)
     this._emit('form.clear');
+
+    this.get('formFieldRegistry').clear();
   }
 
   destroy() {

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -82,6 +82,15 @@ export default class FormEditor {
     }
   }
 
+  clear() {
+
+    // Clear form services
+    this._emit('diagram.clear');
+
+    // Clear diagram services (e.g. EventBus)
+    this._emit('form.clear');
+  }
+
   destroy() {
     this.get('eventBus').fire('form.destroy');
 
@@ -93,6 +102,8 @@ export default class FormEditor {
    */
   importSchema(schema) {
     return new Promise((resolve, reject) => {
+      this.clear();
+
       const importer = this.get('importer');
 
       schema = clone(schema);
@@ -103,9 +114,13 @@ export default class FormEditor {
             schema
           });
 
+          this._emit('import.done', { warnings });
+
           resolve({ warnings });
         })
         .catch(err => {
+          this._emit('import.done', { error: err, warnings: err.warnings });
+
           reject(err);
         });
     });

--- a/packages/form-js-editor/src/import/Importer.js
+++ b/packages/form-js-editor/src/import/Importer.js
@@ -20,7 +20,6 @@ export default class Importer {
    * @returns {Promise}
    */
   importSchema(schema) {
-    this._formFieldRegistry.clear();
 
     // TODO: Add warnings
     const warnings = [];

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -269,6 +269,8 @@ describe('FormEditor', function() {
 
     expect(diagramClearSpy).to.have.been.calledOnce;
     expect(formClearSpy).to.have.been.calledOnce;
+
+    expect(formEditor.get('formFieldRegistry')).to.be.empty;
   });
 
 

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -280,11 +280,20 @@ describe('FormEditor', function() {
       schema
     });
 
+    const diagramDestroySpy = spy(),
+          formDestroySpy = spy();
+
+    formEditor.on('diagram.destroy', diagramDestroySpy);
+    formEditor.on('form.destroy', formDestroySpy);
+
     // when
     formEditor.destroy();
 
     // then
     expect(container.childNodes).to.be.empty;
+
+    expect(diagramDestroySpy).to.have.been.calledOnce;
+    expect(formDestroySpy).to.have.been.calledOnce;
   });
 
 

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -99,7 +99,12 @@ export default class Form {
   }
 
   destroy() {
+
+    // Destroy form services
     this.get('eventBus').fire('form.destroy');
+
+    // Destroy diagram services (e.g. EventBus)
+    this.get('eventBus').fire('diagram.destroy');
 
     this._detach(false);
   }

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -89,6 +89,15 @@ export default class Form {
     }
   }
 
+  clear() {
+
+    // Clear form services
+    this._emit('diagram.clear');
+
+    // Clear diagram services (e.g. EventBus)
+    this._emit('form.clear');
+  }
+
   destroy() {
     this.get('eventBus').fire('form.destroy');
 
@@ -100,9 +109,11 @@ export default class Form {
    * @param {Data} [data]
    */
   importSchema(schema, data = {}) {
-    this._importedData = null;
-
     return new Promise((resolve, reject) => {
+      this.clear();
+
+      this._importedData = null;
+
       const importer = this.get('importer');
 
       schema = clone(schema);
@@ -118,9 +129,13 @@ export default class Form {
             schema
           });
 
+          this._emit('import.done', { warnings });
+
           resolve({ warnings });
         })
         .catch(err => {
+          this._emit('import.done', { error: err, warnings: err.warnings });
+
           reject(err);
         });
     });

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -96,6 +96,8 @@ export default class Form {
 
     // Clear diagram services (e.g. EventBus)
     this._emit('form.clear');
+
+    this.get('formFieldRegistry').clear();
   }
 
   destroy() {

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -21,7 +21,6 @@ export default class Importer {
    * @returns {Promise}
    */
   importSchema(schema, data = {}) {
-    this._formFieldRegistry.clear();
 
     // TODO: Add warnings
     const warnings = [];

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -255,6 +255,8 @@ describe('Form', function() {
 
     expect(diagramClearSpy).to.have.been.calledOnce;
     expect(formClearSpy).to.have.been.calledOnce;
+
+    expect(form.get('formFieldRegistry')).to.be.empty;
   });
 
 

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -266,11 +266,20 @@ describe('Form', function() {
       schema
     });
 
+    const diagramDestroySpy = spy(),
+          formDestroySpy = spy();
+
+    form.on('diagram.destroy', diagramDestroySpy);
+    form.on('form.destroy', formDestroySpy);
+
     // when
     form.destroy();
 
     // then
     expect(container.childNodes).to.be.empty;
+
+    expect(diagramDestroySpy).to.have.been.calledOnce;
+    expect(formDestroySpy).to.have.been.calledOnce;
   });
 
 


### PR DESCRIPTION
* fire <diagram.clear> and <form.clear> before import making sure the command stack is cleared
* fire <import.done> after import (necessary in the context of integrating v0.2.x into the Camunda Modeler)
* fire <diagram.destroy> to ensure diagram services like command stack are destroyed

Closes #135

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
