### PR TITLE
Add `id` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1000,9 +1000,242 @@
 			}
 		},
 		"@bpmn-io/snarkdown": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@bpmn-io/snarkdown/-/snarkdown-2.0.1.tgz",
-			"integrity": "sha512-Ze1gfrmlUz5N6cvD15M7DH1TSfHDgriCYEQoX58Pbm0GZovQnmFh/wh3N4kBqJn85j45TLTBPSlQgo4TwCjYfQ=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@bpmn-io/snarkdown/-/snarkdown-2.1.0.tgz",
+			"integrity": "sha512-OWe9YQx3Vtnopz0trJCJVI3y7k2EfeR4QkKHfRhukcB7yxG4PD1FGaB5LAxc1wxp66V1S3LU4bqUpJdVhQhIww=="
+		},
+		"@codemirror/autocomplete": {
+			"version": "0.18.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.18.8.tgz",
+			"integrity": "sha512-Va1Q763Vu/rVmIazru/ZnO2kkWVq6SlmMEjeD0qmxLAypyP6j/QNdpmaPDI1qb/+Mb9VFZBbac6a0aLTTi8qxQ==",
+			"requires": {
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/tooltip": "^0.18.4",
+				"@codemirror/view": "^0.18.0",
+				"lezer-tree": "^0.13.0"
+			}
+		},
+		"@codemirror/basic-setup": {
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.18.2.tgz",
+			"integrity": "sha512-4UNFQ4jhU7wKxJH23AJcZW6Ho54VXUpmbtFnN5amIdtGci4ZLvci4M7JKgKFraHmKfDIYQnSzN8d8ohXR7CRhw==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.18.0",
+				"@codemirror/closebrackets": "^0.18.0",
+				"@codemirror/commands": "^0.18.0",
+				"@codemirror/comment": "^0.18.0",
+				"@codemirror/fold": "^0.18.0",
+				"@codemirror/gutter": "^0.18.3",
+				"@codemirror/highlight": "^0.18.0",
+				"@codemirror/history": "^0.18.0",
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/lint": "^0.18.0",
+				"@codemirror/matchbrackets": "^0.18.0",
+				"@codemirror/rectangular-selection": "^0.18.0",
+				"@codemirror/search": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/closebrackets": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.18.0.tgz",
+			"integrity": "sha512-O1RAgUkzF4nq/B8IyXenZKZ1rJi2Mc7I6y4IhWhELiTnjyQy7YdAthTsJ40mNr8kZ6gRbasYe3K7TraITElZJA==",
+			"requires": {
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/rangeset": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/commands": {
+			"version": "0.18.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.18.3.tgz",
+			"integrity": "sha512-nHYDG13qOirioXTAKmjl10W2L0eZ1ftvmTwvUTNY27UWVBPFSpk5zDXP3WqJ0mgMhQ4AOFLJaTjJEO3hmPComg==",
+			"requires": {
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/matchbrackets": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/view": "^0.18.0",
+				"lezer-tree": "^0.13.0"
+			}
+		},
+		"@codemirror/comment": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.18.1.tgz",
+			"integrity": "sha512-Inhqs0F24WE28Fcp1dBZghwixBGv1HDwY9MjE0d5tpMY/IPGI6uT30fGyHAXrir6hUqk7eJRkO4UYnODGOnoIA==",
+			"requires": {
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/fold": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.18.1.tgz",
+			"integrity": "sha512-vvMUgDeSmeVow7/75YoNTERxPsdnIBeEw1JL2YVpLyscsUlalqwuxdhiHDLT5zjAu6JvMoTC103mwqgAYwM9tA==",
+			"requires": {
+				"@codemirror/gutter": "^0.18.0",
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/rangeset": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/gutter": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.18.4.tgz",
+			"integrity": "sha512-Sf2IWshMi9zwVVqpGmd2NRplY0qfrE2IiBEII9n2gB9M8hgIMg5GCyhdnsUDsOm0gcSut65W62vV7/DfYJHQCA==",
+			"requires": {
+				"@codemirror/rangeset": "^0.18.3",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/highlight": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.18.4.tgz",
+			"integrity": "sha512-3azJntqWrShOIq/0kVcdMc9k7ACL0LQErgK+A6aWXmCj5Mx0gShq+Iajy8AMQ2zB0v3nhCBgFaniL1LLD5m5hQ==",
+			"requires": {
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/rangeset": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0",
+				"lezer-tree": "^0.13.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"@codemirror/history": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.18.1.tgz",
+			"integrity": "sha512-Aad3p4zs6UYKCUMXYjh7cvPK0ajuL+rMib9yBZ61w81LLl6OkM31Xrn9J6CLJmPxCwP3OJFiqBmNSBQ05oIsTw==",
+			"requires": {
+				"@codemirror/state": "^0.18.3",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/lang-json": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-0.18.0.tgz",
+			"integrity": "sha512-1xquwhwrocZEcURmccMYk1C3g2oj6mu0np1LT1dDGmvd/VVXC0Z9j6NV78zCSyJCIdL2y+RRBh4LVWW6J6NU6Q==",
+			"requires": {
+				"@codemirror/highlight": "^0.18.0",
+				"@codemirror/language": "^0.18.0",
+				"lezer-json": "^0.13.0"
+			}
+		},
+		"@codemirror/language": {
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.18.2.tgz",
+			"integrity": "sha512-2Kz0Xyfvt1Ex2KfTUcYZ3IBxpnFCqHaJijwZknGBT7JXv9dwbOPs9SfPfL4oxVuDIHZx8JTPfoV3LTTJrm8M3Q==",
+			"requires": {
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/view": "^0.18.0",
+				"lezer": "^0.13.4",
+				"lezer-tree": "^0.13.0"
+			}
+		},
+		"@codemirror/lint": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.18.4.tgz",
+			"integrity": "sha512-H77qYfZOmo1kKf0ZQagzk/JRGVhIpwP0hq1TSO6DFC1WLjW6gcsFJO5NDMS86enm0KX0w4/IkA7PItz2mjmHhQ==",
+			"requires": {
+				"@codemirror/panel": "^0.18.1",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/tooltip": "^0.18.4",
+				"@codemirror/view": "^0.18.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"@codemirror/matchbrackets": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.18.0.tgz",
+			"integrity": "sha512-dPDopnZVkD54sSYdmQbyQbPdiuIA83p7XxX6Hp1ScEkOjukwCiFXiA/84x10FUTsQpUYp8bDzm7gwII119bGIw==",
+			"requires": {
+				"@codemirror/language": "^0.18.0",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0",
+				"lezer-tree": "^0.13.0"
+			}
+		},
+		"@codemirror/panel": {
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.18.2.tgz",
+			"integrity": "sha512-ea/g2aAKtfmie1kD7C8GDutD/5u+uzRJr/varUiAbHKr1sAdjtz5xYvC3GBAMYMan1GOh0vD5zP1yEupJl3b3Q==",
+			"requires": {
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/rangeset": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.18.4.tgz",
+			"integrity": "sha512-HHAebb85KoNrnzKG7Z3bOK3HirstPFFB5tu70QfSaUgSZeWnsSgcmGk033rMLGYV9GNTiibWKpqRPaCuyOUk7w==",
+			"requires": {
+				"@codemirror/state": "^0.18.0"
+			}
+		},
+		"@codemirror/rectangular-selection": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.18.0.tgz",
+			"integrity": "sha512-BQ4pp2zhXCVZNqct5LtLR3AOWVseENBF/3oOgBmwsCKH7c11NfTqIqgWG5EW8NLOXp8HP8cDm3np8eWez0VkGQ==",
+			"requires": {
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/search": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.18.4.tgz",
+			"integrity": "sha512-3chVkMPzl+pTUSqtimTicebhti4SLpvkj03pQx2aPZScXxIiYuDk4cLdIJK9omjmO1+oycRKbOrqvG7iZJJwMg==",
+			"requires": {
+				"@codemirror/panel": "^0.18.1",
+				"@codemirror/rangeset": "^0.18.0",
+				"@codemirror/state": "^0.18.6",
+				"@codemirror/text": "^0.18.0",
+				"@codemirror/view": "^0.18.0",
+				"crelt": "^1.0.5"
+			}
+		},
+		"@codemirror/state": {
+			"version": "0.18.7",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.18.7.tgz",
+			"integrity": "sha512-cVyTiAC9vv90NKmGOfNtBjyIem3BqKui1L5Hfcxurp8K9votQj2oH9COcgWPnQ2Xs64yC70tEuTt9DF1pj5PFQ==",
+			"requires": {
+				"@codemirror/text": "^0.18.0"
+			}
+		},
+		"@codemirror/text": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.18.1.tgz",
+			"integrity": "sha512-vjXs6mi1F418kucTPlFvnCt9glKnjtYssdXb8mm1oaY/F5O+tgGVepm9Z8F7AKWCQvW8Bns1D3uLz/DOIEywIw=="
+		},
+		"@codemirror/tooltip": {
+			"version": "0.18.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.18.4.tgz",
+			"integrity": "sha512-LDlDOSEfjoG24uapLN7exK3Z3JchYFKUwWqo1x/9YdlAkmD1ik7cMSQZboCquP1uJVcXhtbpKmaO6vENGVaarg==",
+			"requires": {
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/view": "^0.18.0"
+			}
+		},
+		"@codemirror/view": {
+			"version": "0.18.19",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.18.19.tgz",
+			"integrity": "sha512-TmazVl8H3L+aYwlNb8xk6qADRb8KiYOO047pz51R4mGCg4Ja2siSjXktZgUvklsyWbUY7h9q+oAf4piH+mQZTw==",
+			"requires": {
+				"@codemirror/rangeset": "^0.18.2",
+				"@codemirror/state": "^0.18.0",
+				"@codemirror/text": "^0.18.1",
+				"style-mod": "^4.0.0",
+				"w3c-keyname": "^2.2.4"
+			}
 		},
 		"@eslint/eslintrc": {
 			"version": "0.4.2",
@@ -5406,6 +5639,11 @@
 				}
 			}
 		},
+		"crelt": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+			"integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+		},
 		"cross-env": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -8249,6 +8487,11 @@
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			}
 		},
+		"ids": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ids/-/ids-1.0.0.tgz",
+			"integrity": "sha512-Zvtq1xUto4LttpstyOlFum8lKx+i1OmRfg+6A9drFS9iSZsDPMHG4Sof/qwNR4kCU7jBeWFPrY2ocHxiz7cCRw=="
+		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -9464,6 +9707,27 @@
 				"type-check": "~0.4.0"
 			}
 		},
+		"lezer": {
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/lezer/-/lezer-0.13.5.tgz",
+			"integrity": "sha512-cAiMQZGUo2BD8mpcz7Nv1TlKzWP7YIdIRrX41CiP5bk5t4GHxskOxWUx2iAOuHlz8dO+ivbuXr0J1bfHsWD+lQ==",
+			"requires": {
+				"lezer-tree": "^0.13.2"
+			}
+		},
+		"lezer-json": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/lezer-json/-/lezer-json-0.13.2.tgz",
+			"integrity": "sha512-J5wc5KpYywJroIQ7A2+bW0e3JiSo2wX4uDgbCni2Ww5bvTD/iV2tvZ0cHBLmMU/p5qS4dD5bAPysSqHMS9eNAg==",
+			"requires": {
+				"lezer": "^0.13.0"
+			}
+		},
+		"lezer-tree": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/lezer-tree/-/lezer-tree-0.13.2.tgz",
+			"integrity": "sha512-15ZxW8TxVNAOkHIo43Iouv4zbSkQQ5chQHBpwXcD2bBFz46RB4jYLEEww5l1V0xyIx9U2clSyyrLes+hAUFrGQ=="
+		},
 		"libnpmaccess": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-4.0.3.tgz",
@@ -10299,6 +10563,11 @@
 			"requires": {
 				"minipass": "^2.9.0"
 			}
+		},
+		"mitt": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+			"integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
 		},
 		"mkdirp": {
 			"version": "0.5.5",
@@ -13232,6 +13501,11 @@
 				"through": "^2.3.4"
 			}
 		},
+		"style-mod": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13959,6 +14233,11 @@
 			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
 			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
 			"dev": true
+		},
+		"w3c-keyname": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
+			"integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
 		},
 		"watchpack": {
 			"version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -901,6 +901,23 @@
 				"@babel/plugin-transform-react-jsx": "^7.12.17"
 			}
 		},
+		"@babel/plugin-transform-react-jsx-source": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.14.5.tgz",
+			"integrity": "sha512-1TpSDnD9XR/rQ2tzunBVPThF5poaYT9GqP+of8fAtguYuI/dm2RkrMBDemsxtY0XBzvW7nXjYM0hRyKX9QYj7Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+					"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/plugin-transform-react-pure-annotations": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@babel/core": "^7.14.6",
     "@babel/plugin-transform-react-jsx": "^7.14.5",
+    "@babel/plugin-transform-react-jsx-source": "^7.14.5",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",

--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -1,4 +1,8 @@
 .fjs-editor-container {
+  --color-blue-lighten-99: #fafcff;
+}
+
+.fjs-editor-container {
   height: 100%;
   width: 100%;
   display: flex;
@@ -61,13 +65,21 @@
 
 .fjs-editor-container .fjs-children > .fjs-element {
   position: relative;
-  border: dashed 2px transparent;
+  border: solid 2px transparent;
 }
 
 .fjs-editor-container .fjs-children > .fjs-element:hover,
 .fjs-editor-container .fjs-children > .fjs-element.fjs-editor-selected {
-  border-color: var(--color-blue-darken-62);
   border-radius: 3px;
+}
+
+.fjs-editor-container .fjs-children > .fjs-element.fjs-editor-selected {
+  border-color: var(--color-blue-lighten-75);
+  background-color: var(--color-blue-lighten-99);
+}
+
+.fjs-editor-container .fjs-children > .fjs-element:hover {
+  border-color: var(--color-blue-lighten-82) !important;
 }
 
 /**

--- a/packages/form-js-editor/karma.conf.js
+++ b/packages/form-js-editor/karma.conf.js
@@ -64,7 +64,8 @@ module.exports = function(karma) {
                   [ '@babel/plugin-transform-react-jsx', {
                     'importSource': 'preact',
                     'runtime': 'automatic'
-                  } ]
+                  } ],
+                  '@babel/plugin-transform-react-jsx-source'
                 ]
               }
             }

--- a/packages/form-js-editor/package-lock.json
+++ b/packages/form-js-editor/package-lock.json
@@ -72,6 +72,11 @@
         "crossvent": "1.5.5"
       }
     },
+    "ids": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.0.tgz",
+      "integrity": "sha512-Zvtq1xUto4LttpstyOlFum8lKx+i1OmRfg+6A9drFS9iSZsDPMHG4Sof/qwNR4kCU7jBeWFPrY2ocHxiz7cCRw=="
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",

--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -44,6 +44,7 @@
     "@bpmn-io/form-js-viewer": "^0.2.4",
     "array-move": "^3.0.1",
     "dragula": "^3.7.3",
+    "ids": "^1.0.0",
     "min-dash": "^3.7.0",
     "min-dom": "^3.1.3",
     "preact": "^10.5.13"

--- a/packages/form-js-editor/rollup.config.js
+++ b/packages/form-js-editor/rollup.config.js
@@ -48,6 +48,7 @@ export default [
       }
     ],
     external: [
+      'ids',
       'min-dash',
       'array-move',
       'preact',

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -106,30 +106,34 @@ export default class FormEditor {
 
   /**
    * @param {Schema} schema
+   *
+   * @return {Promise<{ warnings: Array<any> }>}
    */
   importSchema(schema) {
     return new Promise((resolve, reject) => {
-      this.clear();
+      try {
+        this.clear();
 
-      const importer = this.get('importer');
+        const {
+          schema: importedSchema,
+          warnings
+        } = this.get('importer').importSchema(schema);
 
-      schema = clone(schema);
-
-      importer.importSchema(schema)
-        .then(({ warnings }) => {
-          this._setState({
-            schema
-          });
-
-          this._emit('import.done', { warnings });
-
-          resolve({ warnings });
-        })
-        .catch(err => {
-          this._emit('import.done', { error: err, warnings: err.warnings });
-
-          reject(err);
+        this._setState({
+          schema: importedSchema
         });
+
+        this._emit('import.done', { warnings });
+
+        return resolve({ warnings });
+      } catch (error) {
+        this._emit('import.done', {
+          error: error,
+          warnings: error.warnings || []
+        });
+
+        return reject(error);
+      }
     });
   }
 

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -292,7 +292,7 @@ export function exportSchema(schema, exporter, schemaVersion) {
   } : {};
 
   const cleanedSchema = clone(schema, (name, value) => {
-    if ([ '_id', '_parent', '_path' ].includes(name)) {
+    if ([ '_parent', '_path' ].includes(name)) {
       return undefined;
     }
 

--- a/packages/form-js-editor/src/core/FieldFactory.js
+++ b/packages/form-js-editor/src/core/FieldFactory.js
@@ -1,0 +1,61 @@
+import Ids from 'ids';
+
+
+export default class FieldFactory {
+
+  /**
+   * @constructor
+   *
+   * @param { import('@bpmn-io/form-js-viewer').FormFields } formFields
+   * @param { import('./EventBus').default } eventBus
+   */
+  constructor(formFields, eventBus) {
+    this._ids = new Ids([ 32, 36, 1 ]);
+
+    this._formFields = formFields;
+
+    eventBus.on('diagram.clear', () => {
+      this._ids.clear();
+    });
+  }
+
+  create(attrs) {
+
+    const {
+      type
+    } = attrs;
+
+    if (!this._formFields.get(type)) {
+      throw new Error(`form field of type <${ type }> not supported`);
+    }
+
+    const field = {
+      ...attrs
+    };
+
+    this._ensureId(field);
+
+    return field;
+  }
+
+  _ensureId(field) {
+
+    if (field.id) {
+      return;
+    }
+
+    let prefix = 'Field';
+
+    if (field.type === 'default') {
+      prefix = 'Form';
+    }
+
+    field.id = this._ids.nextPrefixed(`${prefix}_`);
+  }
+}
+
+
+FieldFactory.$inject = [
+  'formFields',
+  'eventBus'
+];

--- a/packages/form-js-editor/src/core/FieldFactory.js
+++ b/packages/form-js-editor/src/core/FieldFactory.js
@@ -25,8 +25,7 @@ export default class FieldFactory {
   create(attrs) {
 
     const {
-      type,
-      key
+      type
     } = attrs;
 
     const fieldDefinition = this._formFields.get(type);

--- a/packages/form-js-editor/src/core/FieldFactory.js
+++ b/packages/form-js-editor/src/core/FieldFactory.js
@@ -22,7 +22,7 @@ export default class FieldFactory {
     });
   }
 
-  create(attrs) {
+  create(attrs, applyDefaults=true) {
 
     const {
       type
@@ -34,11 +34,11 @@ export default class FieldFactory {
       throw new Error(`form field of type <${ type }> not supported`);
     }
 
-    const labelAttrs = fieldDefinition.label ? {
+    const labelAttrs = applyDefaults && fieldDefinition.label ? {
       label: fieldDefinition.label
     } : {};
 
-    const keyAttrs = fieldDefinition.keyed ? {
+    const keyAttrs = applyDefaults && fieldDefinition.keyed ? {
       key: `field_${ (this._num++) }`
     } : {};
 

--- a/packages/form-js-editor/src/core/FieldFactory.js
+++ b/packages/form-js-editor/src/core/FieldFactory.js
@@ -12,9 +12,12 @@ export default class FieldFactory {
   constructor(formFields, eventBus) {
     this._ids = new Ids([ 32, 36, 1 ]);
 
+    this._num = 0;
+
     this._formFields = formFields;
 
     eventBus.on('diagram.clear', () => {
+      this._num = 0;
       this._ids.clear();
     });
   }
@@ -22,16 +25,29 @@ export default class FieldFactory {
   create(attrs) {
 
     const {
-      type
+      type,
+      key
     } = attrs;
 
-    if (!this._formFields.get(type)) {
+    const fieldDefinition = this._formFields.get(type);
+
+    if (!fieldDefinition) {
       throw new Error(`form field of type <${ type }> not supported`);
     }
 
-    const field = {
+    const labelAttrs = fieldDefinition.label ? {
+      label: fieldDefinition.label
+    } : {};
+
+    const keyAttrs = fieldDefinition.keyed ? {
+      key: `field_${ (this._num++) }`
+    } : {};
+
+    const field = fieldDefinition.create({
+      ...keyAttrs,
+      ...labelAttrs,
       ...attrs
-    };
+    });
 
     this._ensureId(field);
 

--- a/packages/form-js-editor/src/core/Modeling.js
+++ b/packages/form-js-editor/src/core/Modeling.js
@@ -7,10 +7,11 @@ import { isObject } from 'min-dash';
 
 
 export default class Modeling {
-  constructor(commandStack, eventBus, formEditor, formFieldRegistry) {
+  constructor(commandStack, eventBus, formEditor, formFieldRegistry, fieldFactory) {
     this._commandStack = commandStack;
     this._formEditor = formEditor;
     this._formFieldRegistry = formFieldRegistry;
+    this._fieldFactory = fieldFactory;
 
     eventBus.on('form.init', () => {
       this.registerHandlers();
@@ -32,7 +33,10 @@ export default class Modeling {
     };
   }
 
-  addFormField(targetFormField, targetIndex, newFormField) {
+  addFormField(targetFormField, targetIndex, fieldAttrs) {
+
+    const newFormField = this._fieldFactory.create(fieldAttrs);
+
     const context = {
       newFormField,
       targetFormField,
@@ -40,6 +44,8 @@ export default class Modeling {
     };
 
     this._commandStack.execute('formField.add', context);
+
+    return newFormField;
   }
 
   editFormField(formField, properties, value) {
@@ -78,4 +84,10 @@ export default class Modeling {
   }
 }
 
-Modeling.$inject = [ 'commandStack', 'eventBus', 'formEditor', 'formFieldRegistry' ];
+Modeling.$inject = [
+  'commandStack',
+  'eventBus',
+  'formEditor',
+  'formFieldRegistry',
+  'fieldFactory'
+];

--- a/packages/form-js-editor/src/core/Selection.js
+++ b/packages/form-js-editor/src/core/Selection.js
@@ -9,9 +9,21 @@ export default class Selection {
   }
 
   set(selection) {
+    if (this._selection === selection) {
+      return;
+    }
+
     this._selection = selection;
 
-    this._eventBus.fire('selection.changed', this._selection);
+    this._eventBus.fire('selection.changed', {
+      selection: this._selection
+    });
+  }
+
+  toggle(selection) {
+    const newSelection = this._selection === selection ? null : selection;
+
+    this.set(newSelection);
   }
 
   clear() {

--- a/packages/form-js-editor/src/core/cmd/AddFormFieldHandler.js
+++ b/packages/form-js-editor/src/core/cmd/AddFormFieldHandler.js
@@ -25,7 +25,7 @@ export default class AddFormFieldHandler {
       targetIndex
     } = context;
 
-    let { schema } = this._formEditor._getState();
+    const { schema } = this._formEditor._getState();
 
     const targetPath = [ ...targetFormField._path, 'components' ];
 
@@ -51,7 +51,7 @@ export default class AddFormFieldHandler {
       targetIndex
     } = context;
 
-    let { schema } = this._formEditor._getState();
+    const { schema } = this._formEditor._getState();
 
     const targetPath = [ ...targetFormField._path, 'components' ];
 

--- a/packages/form-js-editor/src/core/cmd/AddFormFieldHandler.js
+++ b/packages/form-js-editor/src/core/cmd/AddFormFieldHandler.js
@@ -29,7 +29,7 @@ export default class AddFormFieldHandler {
 
     const targetPath = [ ...targetFormField._path, 'components' ];
 
-    newFormField._parent = targetFormField._id;
+    newFormField._parent = targetFormField.id;
 
     // (1) Add new form field
     arrayAdd(get(schema, targetPath), targetIndex, newFormField);
@@ -38,7 +38,7 @@ export default class AddFormFieldHandler {
     get(schema, targetPath).forEach((formField, index) => updatePath(this._formFieldRegistry, formField, index));
 
     // (3) Add new form field to form field registry
-    this._formFieldRegistry.set(newFormField._id, newFormField);
+    this._formFieldRegistry.set(newFormField.id, newFormField);
 
     // TODO: Create updater/change support that automatically updates paths and schema on command execution
     this._formEditor._setState({ schema });
@@ -62,7 +62,7 @@ export default class AddFormFieldHandler {
     get(schema, targetPath).forEach((formField, index) => updatePath(this._formFieldRegistry, formField, index));
 
     // (3) Remove new form field from form field registry
-    this._formFieldRegistry.delete(newFormField._id);
+    this._formFieldRegistry.delete(newFormField.id);
 
     // TODO: Create updater/change support that automatically updates paths and schema on command execution
     this._formEditor._setState({ schema });

--- a/packages/form-js-editor/src/core/cmd/MoveFormFieldHandler.js
+++ b/packages/form-js-editor/src/core/cmd/MoveFormFieldHandler.js
@@ -51,7 +51,7 @@ export default class MoveFormFieldHandler {
 
     const sourcePath = [ ...sourceFormField._path, 'components' ];
 
-    if (sourceFormField._id === targetFormField._id) {
+    if (sourceFormField.id === targetFormField.id) {
 
       if (revert) {
         if (sourceIndex > targetIndex) {
@@ -72,7 +72,7 @@ export default class MoveFormFieldHandler {
     } else {
       const formField = get(schema, [ ...sourcePath, sourceIndex ]);
 
-      formField._parent = targetFormField._id;
+      formField._parent = targetFormField.id;
 
       // (1) Remove form field
       arrayRemove(get(schema, sourcePath), sourceIndex);

--- a/packages/form-js-editor/src/core/cmd/RemoveFormFieldHandler.js
+++ b/packages/form-js-editor/src/core/cmd/RemoveFormFieldHandler.js
@@ -37,7 +37,7 @@ export default class RemoveFormFieldHandler {
     get(schema, sourcePath).forEach((formField, index) => updatePath(this._formFieldRegistry, formField, index));
 
     // (3) Remove form field from form field registry
-    this._formFieldRegistry.delete(formField._id);
+    this._formFieldRegistry.delete(formField.id);
 
     // TODO: Create updater/change support that automatically updates paths and schema on command execution
     this._formEditor._setState({ schema });
@@ -61,7 +61,7 @@ export default class RemoveFormFieldHandler {
     get(schema, sourcePath).forEach((formField, index) => updatePath(this._formFieldRegistry, formField, index));
 
     // (3) Add form field to form field registry
-    this._formFieldRegistry.set(formField._id, formField);
+    this._formFieldRegistry.set(formField.id, formField);
 
     // TODO: Create updater/change support that automatically updates paths and schema on command execution
     this._formEditor._setState({ schema });

--- a/packages/form-js-editor/src/core/index.js
+++ b/packages/form-js-editor/src/core/index.js
@@ -3,6 +3,7 @@ import Modeling from './Modeling';
 import Selection from './Selection';
 import DebounceFactory from './Debounce';
 import FormFieldRegistry from './FormFieldRegistry';
+import FieldFactory from './FieldFactory';
 
 import commandModule from 'diagram-js/lib/command';
 import importModule from '../import';
@@ -13,6 +14,7 @@ export default {
   __init__: [ 'modeling' ],
   eventBus: [ 'type', EventBus ],
   formFieldRegistry: [ 'type', FormFieldRegistry ],
+  fieldFactory: [ 'type', FieldFactory ],
   modeling: [ 'type', Modeling ],
   selection: [ 'type', Selection ],
   debounce: [ 'factory', DebounceFactory ]

--- a/packages/form-js-editor/src/import/Importer.js
+++ b/packages/form-js-editor/src/import/Importer.js
@@ -1,5 +1,7 @@
 import { generateIdForType } from '@bpmn-io/form-js-viewer';
 
+import { isUndefined } from 'min-dash';
+
 export default class Importer {
 
   /**
@@ -40,6 +42,7 @@ export default class Importer {
   importFormField(formField, parentId, index) {
     const {
       components,
+      id,
       key,
       type
     } = formField;
@@ -77,6 +80,10 @@ export default class Importer {
 
     // Set form field ID
     formField._id = _id;
+
+    if (isUndefined(id)) {
+      formField.id = _id;
+    }
 
     this._formFieldRegistry.set(_id, formField);
 

--- a/packages/form-js-editor/src/import/Importer.js
+++ b/packages/form-js-editor/src/import/Importer.js
@@ -1,6 +1,7 @@
-import { generateIdForType } from '@bpmn-io/form-js-viewer';
+import { generateIdForType, clone } from '@bpmn-io/form-js-viewer';
 
 import { isUndefined } from 'min-dash';
+
 
 export default class Importer {
 
@@ -15,28 +16,31 @@ export default class Importer {
   }
 
   /**
-   * Import schema adding `_id`, `_parent` and `_path` information to each field and adding it to the form field registry.
+   * Import schema adding `_id`, `_parent` and `_path`
+   * information to each field and adding it to the
+   * form field registry.
    *
    * @param {any} schema
    *
-   * @returns {Promise}
+   * @returns { { warnings: Array<any>, schema: any } }
    */
   importSchema(schema) {
 
     // TODO: Add warnings
     const warnings = [];
 
-    return new Promise((resolve, reject) => {
-      try {
-        this.importFormField(schema);
-      } catch (err) {
-        err.warnings = warnings;
+    try {
+      const importedSchema = this.importFormField(clone(schema));
 
-        reject(err);
-      }
+      return {
+        schema: importedSchema,
+        warnings
+      };
+    } catch (err) {
+      err.warnings = warnings;
 
-      resolve({ warnings });
-    });
+      throw err;
+    }
   }
 
   importFormField(formField, parentId, index) {

--- a/packages/form-js-editor/src/import/Importer.js
+++ b/packages/form-js-editor/src/import/Importer.js
@@ -93,7 +93,7 @@ export default class Importer {
       ...fieldAttrs,
       _path: path,
       _parent: parent && parent.id
-    });
+    }, false);
 
     this._formFieldRegistry.set(field.id, field);
 

--- a/packages/form-js-editor/src/import/Importer.js
+++ b/packages/form-js-editor/src/import/Importer.js
@@ -1,7 +1,5 @@
 import { generateIdForType, clone } from '@bpmn-io/form-js-viewer';
 
-import { isUndefined } from 'min-dash';
-
 
 export default class Importer {
 
@@ -16,7 +14,7 @@ export default class Importer {
   }
 
   /**
-   * Import schema adding `_id`, `_parent` and `_path`
+   * Import schema adding `id`, `_parent` and `_path`
    * information to each field and adding it to the
    * form field registry.
    *
@@ -46,9 +44,9 @@ export default class Importer {
   importFormField(formField, parentId, index) {
     const {
       components,
-      id,
       key,
-      type
+      type,
+      id = generateIdForType(type)
     } = formField;
 
     let parent;
@@ -80,19 +78,13 @@ export default class Importer {
       formField._path = [];
     }
 
-    const _id = generateIdForType(type);
-
     // Set form field ID
-    formField._id = _id;
+    formField.id = id;
 
-    if (isUndefined(id)) {
-      formField.id = _id;
-    }
-
-    this._formFieldRegistry.set(_id, formField);
+    this._formFieldRegistry.set(id, formField);
 
     if (components) {
-      this.importFormFields(components, _id);
+      this.importFormFields(components, id);
     }
 
     return formField;

--- a/packages/form-js-editor/src/import/Importer.js
+++ b/packages/form-js-editor/src/import/Importer.js
@@ -71,6 +71,14 @@ export default class Importer {
       });
     }
 
+    if (id) {
+      this._formFieldRegistry.forEach((formField) => {
+        if (formField.id === id) {
+          throw new Error(`form field with id <${ id }> already exists`);
+        }
+      });
+    }
+
     // Set form field path
     if (parent) {
       formField._path = [ ...parent._path, 'components', index ];

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -172,7 +172,9 @@ export default function FormEditor(props) {
         },
         accepts(el, target) {
           return !target.classList.contains('fjs-no-drop');
-        }
+        },
+        slideFactorX: 10,
+        slideFactorY: 5
       });
 
       dragulaInstance.on('drop', (el, target, source, sibling) => {

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -61,7 +61,11 @@ function Element(props) {
   function onClick(event) {
     event.stopPropagation();
 
-    selection.toggle(id);
+    if (field.type === 'default') {
+      selection.set(null);
+    } else {
+      selection.toggle(id);
+    }
   }
 
   const classes = [ 'fjs-element' ];

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -54,7 +54,7 @@ function Element(props) {
   const { field } = props;
 
   const {
-    _id,
+    id,
     type
   } = field;
 
@@ -65,7 +65,7 @@ function Element(props) {
 
     event.stopPropagation();
 
-    selection.set(_id);
+    selection.set(id);
   }
 
   const classes = [ 'fjs-element' ];
@@ -74,7 +74,7 @@ function Element(props) {
     classes.push(...props.class.split(' '));
   }
 
-  if (selection.get() === _id) {
+  if (selection.get() === id) {
     classes.push('fjs-editor-selected');
   }
 
@@ -90,7 +90,7 @@ function Element(props) {
     modeling.removeFormField(parentField, index);
 
     if (selectableField) {
-      selection.set(selectableField._id);
+      selection.set(selectableField.id);
     } else {
       selection.clear();
     }
@@ -99,12 +99,12 @@ function Element(props) {
   return (
     <div
       class={ classes.join(' ') }
-      data-id={ _id }
+      data-id={ id }
       data-field-type={ type }
       onClick={ onClick }>
       <ContextPad>
         {
-          selection.get() === _id ? <button class="fjs-context-pad-item" onClick={ onRemove }><ListDeleteIcon /></button> : null
+          selection.get() === id ? <button class="fjs-context-pad-item" onClick={ onRemove }><ListDeleteIcon /></button> : null
         }
       </ContextPad>
       { props.children }
@@ -115,7 +115,7 @@ function Element(props) {
 function Children(props) {
   const { field } = props;
 
-  const { _id } = field;
+  const { id } = field;
 
   const classes = [ 'fjs-children', 'fjs-drag-container' ];
 
@@ -126,7 +126,7 @@ function Children(props) {
   return (
     <div
       class={ classes.join(' ') }
-      data-id={ _id }>
+      data-id={ id }>
       { props.children }
     </div>
   );
@@ -153,7 +153,7 @@ export default function FormEditor(props) {
     const selectableField = findSelectableField(schema, formFieldRegistry);
 
     if (selectableField) {
-      selection.set(selectableField._id);
+      selection.set(selectableField.id);
     }
   }, []);
 
@@ -201,10 +201,10 @@ export default function FormEditor(props) {
           const formField = formFields.get(type);
 
           const newFormField = formField.create({
-            _parent: targetFormField._id
+            _parent: targetFormField.id
           });
 
-          selection.set(newFormField._id);
+          selection.set(newFormField.id);
 
           modeling.addFormField(targetFormField, targetIndex, newFormField);
         } else {
@@ -212,7 +212,7 @@ export default function FormEditor(props) {
                 sourceFormField = formFieldRegistry.get(source.dataset.id),
                 sourceIndex = getFormFieldIndex(sourceFormField, formField);
 
-          selection.set(formField._id);
+          selection.set(formField.id);
 
           modeling.moveFormField(sourceFormField, targetFormField, sourceIndex, targetIndex);
         }
@@ -318,8 +318,8 @@ export default function FormEditor(props) {
 function getFormFieldIndex(parent, formField) {
   let fieldFormIndex = parent.components.length;
 
-  parent.components.forEach(({ _id }, index) => {
-    if (_id === formField._id) {
+  parent.components.forEach(({ id }, index) => {
+    if (id === formField.id) {
       fieldFormIndex = index;
     }
   });

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -131,7 +131,6 @@ function Children(props) {
 export default function FormEditor(props) {
   const eventBus = useService('eventBus'),
         formEditor = useService('formEditor'),
-        formFields = useService('formFields'),
         formFieldRegistry = useService('formFieldRegistry'),
         injector = useService('injector'),
         modeling = useService('modeling'),
@@ -192,15 +191,9 @@ export default function FormEditor(props) {
         if (source.classList.contains('fjs-palette')) {
           const type = el.dataset.fieldType;
 
-          const formField = formFields.get(type);
+          const newField = modeling.addFormField(targetFormField, targetIndex, { type });
 
-          const newFormField = formField.create({
-            _parent: targetFormField.id
-          });
-
-          selection.set(newFormField.id);
-
-          modeling.addFormField(targetFormField, targetIndex, newFormField);
+          selection.set(newField.id);
         } else {
           const formField = formFieldRegistry.get(el.dataset.id),
                 sourceFormField = formFieldRegistry.get(source.dataset.id),

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -145,8 +145,12 @@ export default function FormEditor(props) {
 
   const [ _, setSelection ] = useState(null);
 
-  eventBus.on('selection.changed', (newSelection) => {
-    setSelection(newSelection);
+  eventBus.on('selection.changed', (event) => {
+    const {
+      selection
+    } = event;
+
+    setSelection(selection);
   });
 
   useEffect(() => {

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -59,13 +59,9 @@ function Element(props) {
   } = field;
 
   function onClick(event) {
-    if (type === 'default') {
-      return;
-    }
-
     event.stopPropagation();
 
-    selection.set(id);
+    selection.toggle(id);
   }
 
   const classes = [ 'fjs-element' ];
@@ -143,29 +139,21 @@ export default function FormEditor(props) {
 
   const { schema } = formEditor._getState();
 
-  const [ _, setSelection ] = useState(null);
-
-  eventBus.on('selection.changed', (event) => {
-    const {
-      selection
-    } = event;
-
-    setSelection(selection);
-  });
+  const [ selectedFormField, setSelection ] = useState(schema);
 
   useEffect(() => {
-    const selectableField = findSelectableField(schema, formFieldRegistry);
-
-    if (selectableField) {
-      selection.set(selectableField.id);
+    function handleSelectionChanged(event) {
+      setSelection(event.selection ? formFieldRegistry.get(event.selection) : schema);
     }
-  }, []);
 
-  let selectedFormField;
+    eventBus.on('selection.changed', handleSelectionChanged);
 
-  if (selection.get()) {
-    selectedFormField = formFieldRegistry.get(selection.get());
-  }
+    setSelection(selection.get() ? formFieldRegistry.get(selection.get()) : schema);
+
+    return () => {
+      eventBus.off('selection.changed', handleSelectionChanged);
+    };
+  }, [ selection, formFieldRegistry, schema ]);
 
   const [ drake, setDrake ] = useState(null);
 

--- a/packages/form-js-editor/src/render/components/palette/icons/index.js
+++ b/packages/form-js-editor/src/render/components/palette/icons/index.js
@@ -15,5 +15,6 @@ export const iconsByType = {
   radio: RadioIcon,
   select: SelectIcon,
   text: TextIcon,
-  textfield: TextfieldIcon
+  textfield: TextfieldIcon,
+  default: TextIcon
 };

--- a/packages/form-js-editor/src/render/components/properties-panel/PropertiesPanel.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/PropertiesPanel.js
@@ -18,7 +18,8 @@ const labelsByType = {
   number: 'NUMBER',
   radio: 'RADIO',
   text: 'TEXT',
-  textfield: 'TEXT FIELD'
+  textfield: 'TEXT FIELD',
+  default: 'FORM'
 };
 
 function getGroups(field, editField) {
@@ -45,7 +46,7 @@ export default function PropertiesPanel(props) {
     field
   } = props;
 
-  if (!field || field.type === 'default') {
+  if (!field) {
     return <div class="fjs-properties-panel-placeholder">Select a form field to edit its properties.</div>;
   }
 
@@ -65,7 +66,9 @@ export default function PropertiesPanel(props) {
         {
           type === 'text'
             ? <div class="fjs-properties-panel-header-label">{ textToLabel(field.text) }</div>
-            : <div class="fjs-properties-panel-header-label">{ field.label }</div>
+            : type === 'default'
+              ? <div class="fjs-properties-panel-header-label">{ field.id }</div>
+              : <div class="fjs-properties-panel-header-label">{ field.label }</div>
         }
       </div>
     </div>

--- a/packages/form-js-editor/src/render/components/properties-panel/PropertiesPanel.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/PropertiesPanel.js
@@ -56,7 +56,7 @@ export default function PropertiesPanel(props) {
 
   const label = labelsByType[ type ];
 
-  return <div class="fjs-properties-panel">
+  return <div class="fjs-properties-panel" data-field={ field.id }>
     <div class="fjs-properties-panel-header">
       <div class="fjs-properties-panel-header-icon">
         <Icon width="36" height="36" viewBox="0 0 54 54" />

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/ColumnsEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/ColumnsEntry.js
@@ -13,7 +13,7 @@ export default function ColumnsEntry(props) {
 
     if (value > components.length) {
       while (value > components.length) {
-        components.push(Default.create({ _parent: field._id }));
+        components.push(Default.create({ _parent: field.id }));
       }
     } else {
       components = components.slice(0, value);

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/IdEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/IdEntry.js
@@ -1,0 +1,74 @@
+import { isUndefined } from 'min-dash';
+
+import useService from '../../../hooks/useService';
+
+import { TextInputEntry } from '../components';
+
+export default function IdEntry(props) {
+  const {
+    editField,
+    field
+  } = props;
+
+  const formFieldRegistry = useService('formFieldRegistry');
+
+  const validate = (value) => {
+    if (isUndefined(value) || !value.length) {
+      return 'Must not be empty.';
+    }
+
+    if (!isUnique(value, field, formFieldRegistry)) {
+      return 'Must be unique.';
+    }
+
+    return validateId(value) || null;
+  };
+
+  return (
+    <TextInputEntry
+      editField={ editField }
+      field={ field }
+      id="id"
+      label="Id"
+      path={ [ 'id' ] }
+      validate={ validate } />
+  );
+}
+
+// helpers //////////
+
+function isUnique(id, field, formFieldRegistry) {
+  return !Array.from(formFieldRegistry.values()).find((formField) => {
+    return formField !== field && formField.id === id;
+  });
+}
+
+// id structural validation /////////////
+
+const SPACE_REGEX = /\s/;
+
+// for QName validation as per http://www.w3.org/TR/REC-xml/#NT-NameChar
+const QNAME_REGEX = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
+
+// for ID validation as per BPMN Schema (QName - Namespace)
+const ID_REGEX = /^[a-z_][\w-.]*$/i;
+
+function validateId(idValue) {
+
+  if (containsSpace(idValue)) {
+    return 'Must not contain spaces.';
+  }
+
+  if (!ID_REGEX.test(idValue)) {
+
+    if (QNAME_REGEX.test(idValue)) {
+      return 'Must not contain prefix.';
+    }
+
+    return 'Must be a valid QName.';
+  }
+}
+
+function containsSpace(value) {
+  return SPACE_REGEX.test(value);
+}

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/index.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/index.js
@@ -1,6 +1,7 @@
 export { default as ActionEntry } from './ActionEntry';
 export { default as ColumnsEntry } from './ColumnsEntry';
 export { default as DescriptionEntry } from './DescriptionEntry';
+export { default as IdEntry } from './IdEntry';
 export { default as KeyEntry } from './KeyEntry';
 export { default as LabelEntry } from './LabelEntry';
 export { default as TextEntry } from './TextEntry';

--- a/packages/form-js-editor/src/render/components/properties-panel/groups/GeneralGroup.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/groups/GeneralGroup.js
@@ -4,6 +4,7 @@ import {
   ActionEntry,
   ColumnsEntry,
   DescriptionEntry,
+  IdEntry,
   KeyEntry,
   LabelEntry,
   TextEntry
@@ -15,6 +16,10 @@ export default function GeneralGroup(field, editField) {
   const { type } = field;
 
   const entries = [];
+
+  if (type === 'default') {
+    entries.push(<IdEntry editField={ editField } field={ field } />);
+  }
 
   if (INPUTS.includes(type) || type === 'button') {
     entries.push(<LabelEntry editField={ editField } field={ field } />);

--- a/packages/form-js-editor/src/render/components/properties-panel/groups/ValuesGroup.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/groups/ValuesGroup.js
@@ -28,7 +28,7 @@ export default function ValuesGroup(field, editField) {
     <Group label="Values" addEntry={ addEntry } hasEntries={ hasEntries }>
       {
         values.map((value, index) => {
-          const { _id } = field;
+          const { id } = field;
 
           const { label } = value;
 
@@ -37,7 +37,7 @@ export default function ValuesGroup(field, editField) {
           };
 
           return (
-            <CollapsibleEntry key={ _id } label={ label } removeEntry={ removeEntry }>
+            <CollapsibleEntry key={ id } label={ label } removeEntry={ removeEntry }>
               <ValueEntry editField={ editField } field={ field } index={ index } />
             </CollapsibleEntry>
           );

--- a/packages/form-js-editor/test/helper/index.js
+++ b/packages/form-js-editor/test/helper/index.js
@@ -103,7 +103,9 @@ export function bootstrapFormEditor(schema, options, locals) {
       return FORM_EDITOR.importSchema(schema).then(function(result) {
         return { error: null, warnings: result.warnings };
       }).catch(function(err) {
-        return { error: err, warnings: err.warnings };
+        console.error('#bootstrapFormEditor failed', err, err.warnings);
+
+        return Promise.reject(err);
       });
     }
   };

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -244,10 +244,10 @@ describe('FormEditor', function() {
     // then
     expect(exportedSchema).to.eql(exportTagged(schema));
 
-    const stringifiedSchema = JSON.stringify(exportedSchema);
+    const exportedString = JSON.stringify(exportedSchema);
 
-    expect(stringifiedSchema).not.to.contain('"_id"');
-    expect(stringifiedSchema).not.to.contain('"_path"');
+    expect(exportedString).not.to.contain('"_path"');
+    expect(exportedString).not.to.contain('"_parent"');
   });
 
 
@@ -365,7 +365,7 @@ describe('FormEditor', function() {
 
       const exportedString = JSON.stringify(exportedSchema);
 
-      expect(exportedString).not.to.contain('"_id"');
+      expect(exportedString).not.to.contain('"_path"');
       expect(exportedString).not.to.contain('"_parent"');
     });
 

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -454,8 +454,11 @@ describe('FormEditor', function() {
         // assume
         expect(form.get('selection').get()).not.to.exist;
 
-        // when
-        await wait();
+        await waitFor(async () => {
+          const input = await screen.getByLabelText('Id');
+
+          expect(input).to.exist;
+        });
 
         // then
         await expectSelected('Form_1');
@@ -473,7 +476,11 @@ describe('FormEditor', function() {
         // when
         form.get('selection').set('text');
 
-        await wait();
+        await waitFor(async () => {
+          const input = await screen.getByLabelText('Text');
+
+          expect(input).to.exist;
+        });
 
         // then
         expectSelected('text');
@@ -650,11 +657,4 @@ function exportTagged(schema, exporter) {
     ...exportDetails,
     ...schema
   };
-}
-
-
-function wait(ms=300) {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms);
-  });
 }

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -15,6 +15,7 @@ import {
 } from '../TestHelper';
 
 import schema from './form.json';
+import schemaNoIds from './form-no-ids.json';
 
 // import schema from './empty.json';
 // import schema from './complex.json';
@@ -343,43 +344,73 @@ describe('FormEditor', function() {
   });
 
 
-  it('should expose schema', async function() {
+  describe('export', function() {
 
-    // given
-    const formEditor = await createFormEditor({
-      container,
-      schema
+    it('should expose schema', async function() {
+
+      // given
+      const formEditor = await createFormEditor({
+        container,
+        schema
+      });
+
+      // when
+      const exportedSchema = formEditor.getSchema();
+
+      // then
+      expect(exportedSchema).to.eql(exportTagged(schema));
+
+      const exportedString = JSON.stringify(exportedSchema);
+
+      expect(exportedString).not.to.contain('"_id"');
+      expect(exportedString).not.to.contain('"_parent"');
     });
 
-    // when
-    const exportedSchema = formEditor.getSchema();
 
-    // then
-    expect(exportedSchema).to.eql(exportTagged(schema));
+    it('should expose custom exporter', async function() {
 
-    expect(JSON.stringify(exportedSchema)).not.to.contain('"_id"');
-  });
+      // given
+      const exporter = {
+        name: 'Foo',
+        version: 'bar'
+      };
 
+      const formEditor = await createFormEditor({
+        container,
+        schema,
+        exporter
+      });
 
-  it('should expose schema with custom exporter', async function() {
+      // when
+      const exportedSchema = formEditor.getSchema();
 
-    // given
-    const exporter = {
-      name: 'Foo',
-      version: 'bar'
-    };
-
-    const formEditor = await createFormEditor({
-      container,
-      schema,
-      exporter
+      // then
+      expect(exportedSchema).to.eql(exportTagged(schema, exporter));
     });
 
-    // when
-    const exportedSchema = formEditor.getSchema();
 
-    // then
-    expect(exportedSchema).to.eql(exportTagged(schema, exporter));
+    it('should generate ids', async function() {
+
+      // assume
+      expect(schemaNoIds.id).not.to.exist;
+
+      // given
+      const formEditor = await createFormEditor({
+        container,
+        schema: schemaNoIds
+      });
+
+      // when
+      const exportedSchema = formEditor.getSchema();
+
+      // then
+      expect(exportedSchema.id).to.exist;
+
+      for (const component of exportedSchema.components) {
+        expect(component.id).to.exist;
+      }
+    });
+
   });
 
 

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -417,75 +417,145 @@ describe('FormEditor', function() {
   });
 
 
-  describe('focus / blur events', function() {
+  describe('properties panel', function() {
 
-    const schema = {
-      type: 'default',
-      components: [
-        {
-          type: 'text',
-          label: 'Text',
-          key: 'text'
-        }
-      ]
-    };
+    describe('selection behavior', function() {
+
+      const schema = {
+        type: 'default',
+        id: 'Form_1',
+        components: [
+          {
+            type: 'text',
+            id: 'text',
+            label: 'Text',
+            key: 'text'
+          }
+        ]
+      };
+
+      function expectSelected(expectedId) {
+        const panelEl = document.querySelector('.fjs-properties-panel');
+
+        const selectedId = panelEl.dataset.field;
+
+        expect(selectedId).to.eql(expectedId);
+      }
 
 
-    it('should emit event on properties panel focus', async function() {
+      it('should show schema per default', async function() {
 
-      // given
-      const formEditor = await createFormEditor({
-        schema,
-        container
+        // when
+        const form = await createFormEditor({
+          container,
+          schema
+        });
+
+        // assume
+        expect(form.get('selection').get()).not.to.exist;
+
+        // when
+        await wait();
+
+        // then
+        await expectSelected('Form_1');
       });
 
-      const focusinSpy = sinon.spy();
 
-      formEditor.on('propertiesPanel.focusin', focusinSpy);
+      it('should update on selection changed', async function() {
 
-      let input;
+        // given
+        const form = await createFormEditor({
+          container,
+          schema
+        });
 
-      await waitFor(async () => {
-        input = await screen.getByLabelText('Text');
+        // when
+        form.get('selection').set('text');
 
-        expect(input).to.exist;
+        await wait();
+
+        // then
+        expectSelected('text');
       });
 
-      // when
-      input.focus();
-
-      // then
-      expect(focusinSpy).to.have.been.called;
     });
 
 
-    it('should emit event on properties panel blur', async function() {
+    describe('focus / blur events', function() {
 
-      // given
-      const formEditor = await createFormEditor({
-        schema,
-        container
+      const schema = {
+        type: 'default',
+        components: [
+          {
+            type: 'text',
+            id: 'text',
+            label: 'Text',
+            key: 'text'
+          }
+        ]
+      };
+
+
+      it('should emit event on properties panel focus', async function() {
+
+        // given
+        const formEditor = await createFormEditor({
+          schema,
+          container
+        });
+
+        const focusinSpy = sinon.spy();
+
+        formEditor.on('propertiesPanel.focusin', focusinSpy);
+        formEditor.get('selection').set('text');
+
+        let input;
+
+        await waitFor(async () => {
+          input = await screen.getByLabelText('Text');
+
+          expect(input).to.exist;
+        });
+
+        // when
+        input.focus();
+
+        // then
+        expect(focusinSpy).to.have.been.called;
       });
 
-      const focusoutSpy = sinon.spy();
 
-      formEditor.on('propertiesPanel.focusout', focusoutSpy);
+      it('should emit event on properties panel blur', async function() {
 
-      let input;
+        // given
+        const formEditor = await createFormEditor({
+          schema,
+          container
+        });
 
-      await waitFor(async () => {
-        input = await screen.getByLabelText('Text');
+        const focusoutSpy = sinon.spy();
 
-        expect(input).to.exist;
+        formEditor.on('propertiesPanel.focusout', focusoutSpy);
+        formEditor.get('selection').set('text');
+
+        let input;
+
+        await waitFor(async () => {
+          input = await screen.getByLabelText('Text');
+
+          expect(input).to.exist;
+        });
+
+        input.focus();
+
+        // when
+        input.blur();
+
+        // then
+        expect(focusoutSpy).to.have.been.called;
       });
 
-      input.focus();
-
-      // when
-      input.blur();
-
-      // then
-      expect(focusoutSpy).to.have.been.called;
     });
 
   });
@@ -580,4 +650,11 @@ function exportTagged(schema, exporter) {
     ...exportDetails,
     ...schema
   };
+}
+
+
+function wait(ms=300) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
 }

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -244,7 +244,10 @@ describe('FormEditor', function() {
     // then
     expect(exportedSchema).to.eql(exportTagged(schema));
 
-    expect(JSON.stringify(exportedSchema)).not.to.contain('"_id"');
+    const stringifiedSchema = JSON.stringify(exportedSchema);
+
+    expect(stringifiedSchema).not.to.contain('"_id"');
+    expect(stringifiedSchema).not.to.contain('"_path"');
   });
 
 
@@ -355,7 +358,7 @@ describe('FormEditor', function() {
       });
 
       // when
-      const exportedSchema = formEditor.getSchema();
+      const exportedSchema = formEditor.saveSchema();
 
       // then
       expect(exportedSchema).to.eql(exportTagged(schema));
@@ -382,7 +385,7 @@ describe('FormEditor', function() {
       });
 
       // when
-      const exportedSchema = formEditor.getSchema();
+      const exportedSchema = formEditor.saveSchema();
 
       // then
       expect(exportedSchema).to.eql(exportTagged(schema, exporter));
@@ -401,7 +404,7 @@ describe('FormEditor', function() {
       });
 
       // when
-      const exportedSchema = formEditor.getSchema();
+      const exportedSchema = formEditor.saveSchema();
 
       // then
       expect(exportedSchema.id).to.exist;
@@ -414,61 +417,77 @@ describe('FormEditor', function() {
   });
 
 
-  it('should emit event on properties panel focus', async function() {
+  describe('focus / blur events', function() {
 
-    // given
-    const formEditor = await createFormEditor({
-      schema,
-      container
+    const schema = {
+      type: 'default',
+      components: [
+        {
+          type: 'text',
+          label: 'Text',
+          key: 'text'
+        }
+      ]
+    };
+
+
+    it('should emit event on properties panel focus', async function() {
+
+      // given
+      const formEditor = await createFormEditor({
+        schema,
+        container
+      });
+
+      const focusinSpy = sinon.spy();
+
+      formEditor.on('propertiesPanel.focusin', focusinSpy);
+
+      let input;
+
+      await waitFor(async () => {
+        input = await screen.getByLabelText('Text');
+
+        expect(input).to.exist;
+      });
+
+      // when
+      input.focus();
+
+      // then
+      expect(focusinSpy).to.have.been.called;
     });
 
-    const focusinSpy = sinon.spy();
 
-    formEditor.on('propertiesPanel.focusin', focusinSpy);
+    it('should emit event on properties panel blur', async function() {
 
-    let input;
+      // given
+      const formEditor = await createFormEditor({
+        schema,
+        container
+      });
 
-    await waitFor(async () => {
-      input = await screen.getByLabelText('Text');
+      const focusoutSpy = sinon.spy();
 
-      expect(input).to.exist;
+      formEditor.on('propertiesPanel.focusout', focusoutSpy);
+
+      let input;
+
+      await waitFor(async () => {
+        input = await screen.getByLabelText('Text');
+
+        expect(input).to.exist;
+      });
+
+      input.focus();
+
+      // when
+      input.blur();
+
+      // then
+      expect(focusoutSpy).to.have.been.called;
     });
 
-    // when
-    input.focus();
-
-    // then
-    expect(focusinSpy).to.have.been.called;
-  });
-
-
-  it('should emit event on properties panel blur', async function() {
-
-    // given
-    const formEditor = await createFormEditor({
-      schema,
-      container
-    });
-
-    const focusoutSpy = sinon.spy();
-
-    formEditor.on('propertiesPanel.focusout', focusoutSpy);
-
-    let input;
-
-    await waitFor(async () => {
-      input = await screen.getByLabelText('Text');
-
-      expect(input).to.exist;
-    });
-
-    input.focus();
-
-    // when
-    input.blur();
-
-    // then
-    expect(focusoutSpy).to.have.been.called;
   });
 
 

--- a/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
+++ b/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
@@ -1,0 +1,124 @@
+import {
+  bootstrapFormEditor,
+  inject
+} from '../../TestHelper';
+
+
+describe('core/FieldFactory', function() {
+
+  const schema = {
+    type: 'default'
+  };
+
+  beforeEach(bootstrapFormEditor(schema));
+
+
+  describe('#create', function() {
+
+    it('Button', testCreate({
+      type: 'button',
+      label: 'Button',
+      keyed: true,
+      defaults: {
+        action: 'submit'
+      }
+    }));
+
+
+    it('Checkbox', testCreate({
+      type: 'checkbox',
+      label: 'Checkbox',
+      keyed: true
+    }));
+
+
+    it('Default', testCreate({
+      type: 'default',
+      keyed: false,
+      defaults: {
+        components: []
+      }
+    }));
+
+
+    it('Number', testCreate({
+      type: 'number',
+      label: 'Number',
+      keyed: true
+    }));
+
+
+    it('Radio', testCreate({
+      type: 'radio',
+      label: 'Radio',
+      keyed: true,
+      defaults: {
+        values: [
+          {
+            label: 'Value',
+            value: 'value'
+          }
+        ]
+      }
+    }));
+
+
+    it('Select', testCreate({
+      type: 'select',
+      label: 'Select',
+      keyed: true,
+      defaults: {
+        values: [
+          {
+            label: 'Value',
+            value: 'value'
+          }
+        ]
+      }
+    }));
+
+
+    it('Text Field', testCreate({
+      type: 'textfield',
+      label: 'Text Field',
+      keyed: true
+    }));
+
+  });
+
+});
+
+
+// helpers //////////////
+
+function testCreate(options) {
+
+  const {
+    type,
+    label,
+    keyed = false,
+    defaults = {}
+  } = options;
+
+  return inject(function(fieldFactory) {
+
+    // when
+    const field = fieldFactory.create({ type });
+
+    // then
+    expect(field.id).to.exist;
+
+    expect(field.type).to.eql(type);
+
+    if (keyed) {
+      expect(field.key).to.exist;
+    }
+
+    if (label) {
+      expect(field.label).to.eql(label);
+    }
+
+    expect(field).to.deep.contain(defaults);
+  });
+
+}

--- a/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
+++ b/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
@@ -86,12 +86,24 @@ describe('core/FieldFactory', function() {
 
   });
 
+
+  describe('#create (no defaults)', function() {
+
+    it('Button', testCreate({
+      type: 'button',
+      defaults: {
+        action: 'submit'
+      }
+    }, false));
+
+  });
+
 });
 
 
 // helpers //////////////
 
-function testCreate(options) {
+function testCreate(options, applyDefaults=true) {
 
   const {
     type,
@@ -103,7 +115,7 @@ function testCreate(options) {
   return inject(function(fieldFactory) {
 
     // when
-    const field = fieldFactory.create({ type });
+    const field = fieldFactory.create({ type }, applyDefaults);
 
     // then
     expect(field.id).to.exist;
@@ -112,10 +124,14 @@ function testCreate(options) {
 
     if (keyed) {
       expect(field.key).to.exist;
+    } else {
+      expect(field.key).not.to.exist;
     }
 
     if (label) {
       expect(field.label).to.eql(label);
+    } else {
+      expect(field.label).not.to.exist;
     }
 
     expect(field).to.deep.contain(defaults);

--- a/packages/form-js-editor/test/spec/core/Modeling.spec.js
+++ b/packages/form-js-editor/test/spec/core/Modeling.spec.js
@@ -17,7 +17,7 @@ import schema from '../form.json';
 insertStyles();
 
 
-describe('Modeling', function() {
+describe('core/Modeling', function() {
 
   beforeEach(bootstrapFormEditor(schema));
 

--- a/packages/form-js-editor/test/spec/core/Modeling.spec.js
+++ b/packages/form-js-editor/test/spec/core/Modeling.spec.js
@@ -37,7 +37,7 @@ describe('Modeling', function() {
     const targetIndex = 0;
 
     const formField = {
-      _id: 'foo',
+      id: 'foo',
       type: 'button'
     };
 
@@ -51,7 +51,7 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      formFieldIds = parent.components.map(({ _id }) => _id);
+      formFieldIds = parent.components.map(({ id }) => id);
 
       // when
       modeling.addFormField(
@@ -69,8 +69,8 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      expect(parent.components.map(({ _id }) => _id)).to.eql([
-        formField._id,
+      expect(parent.components.map(({ id }) => id)).to.eql([
+        formField.id,
         ...formFieldIds
       ]);
     }));
@@ -86,7 +86,7 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      expect(parent.components.map(({ _id }) => _id)).to.eql(formFieldIds);
+      expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds);
     }));
 
 
@@ -101,8 +101,8 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      expect(parent.components.map(({ _id }) => _id)).to.eql([
-        formField._id,
+      expect(parent.components.map(({ id }) => id)).to.eql([
+        formField.id,
         ...formFieldIds
       ]);
     }));
@@ -135,7 +135,7 @@ describe('Modeling', function() {
       it('<do>', inject(function(formFieldRegistry) {
 
         // then
-        expect(formFieldRegistry.get(oldFormField._id)).to.eql({
+        expect(formFieldRegistry.get(oldFormField.id)).to.eql({
           ...oldFormField,
           text: 'foo'
         });
@@ -148,7 +148,7 @@ describe('Modeling', function() {
         commandStack.undo();
 
         // then
-        expect(formFieldRegistry.get(oldFormField._id)).to.eql({
+        expect(formFieldRegistry.get(oldFormField.id)).to.eql({
           ...oldFormField
         });
       }));
@@ -161,7 +161,7 @@ describe('Modeling', function() {
         commandStack.redo();
 
         // then
-        expect(formFieldRegistry.get(oldFormField._id)).to.eql({
+        expect(formFieldRegistry.get(oldFormField.id)).to.eql({
           ...oldFormField,
           text: 'foo'
         });
@@ -195,7 +195,7 @@ describe('Modeling', function() {
       it('<do>', inject(function(formFieldRegistry) {
 
         // then
-        expect(formFieldRegistry.get(oldFormField._id)).to.eql({
+        expect(formFieldRegistry.get(oldFormField.id)).to.eql({
           ...oldFormField,
           key: 'foo',
           label: 'Foo'
@@ -209,7 +209,7 @@ describe('Modeling', function() {
         commandStack.undo();
 
         // then
-        expect(formFieldRegistry.get(oldFormField._id)).to.eql({
+        expect(formFieldRegistry.get(oldFormField.id)).to.eql({
           ...oldFormField
         });
       }));
@@ -222,7 +222,7 @@ describe('Modeling', function() {
         commandStack.redo();
 
         // then
-        expect(formFieldRegistry.get(oldFormField._id)).to.eql({
+        expect(formFieldRegistry.get(oldFormField.id)).to.eql({
           ...oldFormField,
           key: 'foo',
           label: 'Foo'
@@ -253,7 +253,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          formFieldIds = parent.components.map(({ _id }) => _id);
+          formFieldIds = parent.components.map(({ id }) => id);
 
           // when
           modeling.moveFormField(
@@ -272,7 +272,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          expect(parent.components.map(({ _id }) => _id)).to.eql([
+          expect(parent.components.map(({ id }) => id)).to.eql([
             formFieldIds[ 1 ],
             formFieldIds[ 0 ],
             ...formFieldIds.slice(2)
@@ -290,7 +290,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          expect(parent.components.map(({ _id }) => _id)).to.eql(formFieldIds);
+          expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds);
         }));
 
 
@@ -305,7 +305,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          expect(parent.components.map(({ _id }) => _id)).to.eql([
+          expect(parent.components.map(({ id }) => id)).to.eql([
             formFieldIds[ 1 ],
             formFieldIds[ 0 ],
             ...formFieldIds.slice(2)
@@ -330,7 +330,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          formFieldIds = parent.components.map(({ _id }) => _id);
+          formFieldIds = parent.components.map(({ id }) => id);
 
           // when
           modeling.moveFormField(
@@ -349,7 +349,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          expect(parent.components.map(({ _id }) => _id)).to.eql([
+          expect(parent.components.map(({ id }) => id)).to.eql([
             formFieldIds[ 1 ],
             formFieldIds[ 0 ],
             ...formFieldIds.slice(2)
@@ -367,7 +367,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          expect(parent.components.map(({ _id }) => _id)).to.eql(formFieldIds);
+          expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds);
         }));
 
 
@@ -382,7 +382,7 @@ describe('Modeling', function() {
 
           const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-          expect(parent.components.map(({ _id }) => _id)).to.eql([
+          expect(parent.components.map(({ id }) => id)).to.eql([
             formFieldIds[ 1 ],
             formFieldIds[ 0 ],
             ...formFieldIds.slice(2)
@@ -410,7 +410,7 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      formFieldIds = parent.components.map(({ _id }) => _id);
+      formFieldIds = parent.components.map(({ id }) => id);
 
       // when
       modeling.removeFormField(
@@ -427,7 +427,7 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      expect(parent.components.map(({ _id }) => _id)).to.eql(formFieldIds.slice(1));
+      expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds.slice(1));
     }));
 
 
@@ -441,7 +441,7 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      expect(parent.components.map(({ _id }) => _id)).to.eql(formFieldIds);
+      expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds);
     }));
 
 
@@ -456,7 +456,7 @@ describe('Modeling', function() {
 
       const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
-      expect(parent.components.map(({ _id }) => _id)).to.eql(formFieldIds.slice(1));
+      expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds.slice(1));
     }));
 
   });

--- a/packages/form-js-editor/test/spec/core/Modeling.spec.js
+++ b/packages/form-js-editor/test/spec/core/Modeling.spec.js
@@ -41,33 +41,35 @@ describe('Modeling', function() {
       type: 'button'
     };
 
-    let formFieldIds,
+    let parent,
+        formFieldIds,
         formFieldsSize;
 
-    beforeEach(inject(function(formFieldRegistry, modeling) {
+    beforeEach(inject(function(formFieldRegistry) {
 
       // given
       formFieldsSize = formFieldRegistry.size;
 
-      const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
+      parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
       formFieldIds = parent.components.map(({ id }) => id);
+    }));
+
+
+    it('<do>', inject(function(modeling, formFieldRegistry) {
 
       // when
-      modeling.addFormField(
+      const field = modeling.addFormField(
         parent,
         targetIndex,
         formField
       );
-    }));
-
-
-    it('<do>', inject(function(formFieldRegistry) {
 
       // then
-      expect(formFieldRegistry.size).to.equal(formFieldsSize + 1);
+      expect(field.id).to.exist;
 
-      const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
+      expect(formFieldRegistry.size).to.equal(formFieldsSize + 1);
+      expect(formFieldRegistry.get(field.id)).to.equal(field);
 
       expect(parent.components.map(({ id }) => id)).to.eql([
         formField.id,
@@ -76,30 +78,42 @@ describe('Modeling', function() {
     }));
 
 
-    it('<undo>', inject(function(commandStack, formFieldRegistry) {
+    it('<undo>', inject(function(modeling, commandStack, formFieldRegistry) {
+
+      // given
+      const field = modeling.addFormField(
+        parent,
+        targetIndex,
+        formField
+      );
 
       // when
       commandStack.undo();
 
       // then
+      expect(formFieldRegistry.get(field.id)).not.to.exist;
       expect(formFieldRegistry.size).to.equal(formFieldsSize);
-
-      const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
       expect(parent.components.map(({ id }) => id)).to.eql(formFieldIds);
     }));
 
 
-    it('<redo>', inject(function(commandStack, formFieldRegistry) {
+    it('<redo>', inject(function(modeling, commandStack, formFieldRegistry) {
+
+      // given
+      const field = modeling.addFormField(
+        parent,
+        targetIndex,
+        formField
+      );
 
       // when
       commandStack.undo();
       commandStack.redo();
 
       // then
+      expect(formFieldRegistry.get(field.id)).to.equal(field);
       expect(formFieldRegistry.size).to.equal(formFieldsSize + 1);
-
-      const parent = Array.from(formFieldRegistry.values()).find(({ _parent }) => isUndefined(_parent));
 
       expect(parent.components.map(({ id }) => id)).to.eql([
         formField.id,

--- a/packages/form-js-editor/test/spec/core/Selection.spec.js
+++ b/packages/form-js-editor/test/spec/core/Selection.spec.js
@@ -1,0 +1,121 @@
+import {
+  bootstrapFormEditor,
+  inject
+} from '../../TestHelper';
+
+const { spy } = sinon;
+
+
+describe('core/Selection', function() {
+
+  const schema = {
+    type: 'default',
+    components: [
+      {
+        id: 'text1',
+        type: 'text',
+        label: 'Text 1',
+        text: 'TEXT 1'
+      },
+      {
+        id: 'text2',
+        type: 'text',
+        label: 'Text 2',
+        text: 'TEXT 2'
+      }
+    ]
+  };
+
+  beforeEach(bootstrapFormEditor(schema));
+
+
+  it('should get and set', inject(
+    function(selection, eventBus, formFieldRegistry) {
+
+      // given
+      const text1 = formFieldRegistry.get('text1');
+
+      // assume
+      expect(text1).to.exist;
+
+      expect(selection.get()).not.to.exist;
+
+      // when
+      const changedSpy = spy();
+
+      // when
+      eventBus.on('selection.changed', function(event) {
+        changedSpy(event.selection);
+      });
+
+      selection.set('text1');
+
+      // then
+      expect(changedSpy).to.have.been.calledOnceWith('text1');
+
+      expect(selection.get()).to.eq('text1');
+
+      // but when
+      selection.set('text1');
+
+      // then
+      expect(changedSpy).to.have.been.calledOnce;
+
+      // but when
+      selection.set(null);
+
+      // then
+      expect(changedSpy).to.have.been.calledTwice;
+      expect(changedSpy).to.have.been.calledWith(null);
+
+      expect(selection.get()).not.to.exist;
+    }
+  ));
+
+
+  it('should toggle', inject(
+    function(selection, eventBus, formFieldRegistry) {
+
+      // given
+      const text1 = formFieldRegistry.get('text1');
+      const text2 = formFieldRegistry.get('text2');
+
+      // assume
+      expect(text1).to.exist;
+      expect(text2).to.exist;
+
+      // when
+      const changedSpy = spy();
+
+      // when
+      eventBus.on('selection.changed', function(event) {
+        changedSpy(event.selection);
+      });
+
+      selection.toggle('text1');
+
+      // then
+      expect(changedSpy).to.have.been.calledOnceWith('text1');
+
+      expect(selection.get()).to.eq('text1');
+
+      // but when
+      selection.toggle('text2');
+
+      // then
+      expect(changedSpy).to.have.been.calledTwice;
+      expect(changedSpy).to.have.been.calledWith('text2');
+
+
+      // but when
+      selection.toggle('text2');
+
+      // then
+      expect(changedSpy).to.have.been.calledThrice;
+      expect(changedSpy).to.have.been.calledWith(null);
+
+      expect(selection.get()).not.to.exist;
+    }
+  ));
+
+});

--- a/packages/form-js-editor/test/spec/features/editor-actions/FormEditorActions.spec.js
+++ b/packages/form-js-editor/test/spec/features/editor-actions/FormEditorActions.spec.js
@@ -27,7 +27,7 @@ describe('features/editor-actions', function() {
     const targetIndex = 0;
 
     const formField = {
-      _id: 'foo',
+      id: 'foo',
       type: 'button'
     };
 

--- a/packages/form-js-editor/test/spec/form-no-ids.json
+++ b/packages/form-js-editor/test/spec/form-no-ids.json
@@ -1,0 +1,87 @@
+
+{
+  "components": [
+    {
+      "type": "text",
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+    },
+    {
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "key": "amount",
+      "label": "Amount",
+      "type": "number",
+      "validate": {
+        "min": 0,
+        "max": 1000
+      }
+    },
+    {
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "key": "product",
+      "label": "Product",
+      "type": "radio",
+      "values": [
+        {
+          "label": "Camunda Platform",
+          "value": "camunda-platform"
+        },
+        {
+          "label": "Camunda Cloud",
+          "value": "camunda-cloud"
+        }
+      ]
+    },
+    {
+      "key": "language",
+      "label": "Language",
+      "type": "select",
+      "values": [
+        {
+          "label": "German",
+          "value": "german"
+        },
+        {
+          "label": "English",
+          "value": "english"
+        }
+      ]
+    },
+    {
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-editor/test/spec/form-no-ids.json
+++ b/packages/form-js-editor/test/spec/form-no-ids.json
@@ -3,7 +3,7 @@
   "components": [
     {
       "type": "text",
-      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n\nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
     },
     {
       "key": "creditor",

--- a/packages/form-js-editor/test/spec/form-no-ids.json
+++ b/packages/form-js-editor/test/spec/form-no-ids.json
@@ -73,6 +73,7 @@
     },
     {
       "key": "submit",
+      "action": "submit",
       "label": "Submit",
       "type": "button"
     },

--- a/packages/form-js-editor/test/spec/form.json
+++ b/packages/form-js-editor/test/spec/form.json
@@ -1,10 +1,14 @@
 {
+  "id": "Form_1",
+  "type": "default",
   "components": [
     {
+      "id": "Field_1",
       "type": "text",
-      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+      "text": "# Invoice\nLorem _ipsum_ __dolor__ `sit`.\n  \n  \nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
     },
     {
+      "id": "Field_2",
       "key": "creditor",
       "label": "Creditor",
       "type": "textfield",
@@ -13,6 +17,7 @@
       }
     },
     {
+      "id": "Field_3",
       "description": "An invoice number in the format: C-123.",
       "key": "invoiceNumber",
       "label": "Invoice Number",
@@ -22,6 +27,7 @@
       }
     },
     {
+      "id": "Field_4",
       "key": "amount",
       "label": "Amount",
       "type": "number",
@@ -31,16 +37,19 @@
       }
     },
     {
+      "id": "Field_5",
       "key": "approved",
       "label": "Approved",
       "type": "checkbox"
     },
     {
+      "id": "Field_6",
       "key": "approvedBy",
       "label": "Approved By",
       "type": "textfield"
     },
     {
+      "id": "Field_7",
       "key": "product",
       "label": "Product",
       "type": "radio",
@@ -56,6 +65,7 @@
       ]
     },
     {
+      "id": "Field_8",
       "key": "language",
       "label": "Language",
       "type": "select",
@@ -71,16 +81,17 @@
       ]
     },
     {
+      "id": "Field_9",
       "key": "submit",
       "label": "Submit",
       "type": "button"
     },
     {
+      "id": "Field_10",
       "action": "reset",
       "key": "reset",
       "label": "Reset",
       "type": "button"
     }
-  ],
-  "type": "default"
+  ]
 }

--- a/packages/form-js-editor/test/spec/form.json
+++ b/packages/form-js-editor/test/spec/form.json
@@ -82,6 +82,7 @@
     },
     {
       "id": "Field_9",
+      "action": "submit",
       "key": "submit",
       "label": "Submit",
       "type": "button"

--- a/packages/form-js-editor/test/spec/form.json
+++ b/packages/form-js-editor/test/spec/form.json
@@ -5,7 +5,7 @@
     {
       "id": "Field_1",
       "type": "text",
-      "text": "# Invoice\nLorem _ipsum_ __dolor__ `sit`.\n  \n  \nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n\nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
     },
     {
       "id": "Field_2",

--- a/packages/form-js-editor/test/spec/import/Importer.spec.js
+++ b/packages/form-js-editor/test/spec/import/Importer.spec.js
@@ -7,6 +7,7 @@ import {
 import { clone } from '@bpmn-io/form-js-viewer';
 
 import schema from '../form.json';
+import schemaNoIds from '../form-no-ids.json';
 import other from '../other.json';
 
 
@@ -48,6 +49,35 @@ describe('Importer', function() {
     expect(result.warnings).to.be.empty;
     expect(formFieldRegistry.size).to.equal(5);
   }));
+
+
+  describe('import behavior', function() {
+
+    it('should deep enrich fields', inject(async function(formEditor, formFieldRegistry) {
+
+      // when
+      await formEditor.importSchema(schemaNoIds);
+
+      const { schema } = formEditor._getState();
+
+      // then
+      expect(schema.id).to.exist;
+      expect(schema._path).to.eql([]);
+
+      for (const [ key, component ] of Object.entries(schema.components)) {
+        expect(component.id).to.exist;
+        expect(component._path).to.eql([ 'components', parseInt(key) ]);
+        expect(component._parent).to.eql(schema.id);
+      }
+
+      const result = await formEditor.importSchema(other);
+
+      // then
+      expect(result.warnings).to.be.empty;
+      expect(formFieldRegistry.size).to.equal(5);
+    }));
+
+  });
 
 
   describe('error handling', function() {

--- a/packages/form-js-editor/test/spec/import/Importer.spec.js
+++ b/packages/form-js-editor/test/spec/import/Importer.spec.js
@@ -55,36 +55,44 @@ describe('Importer', function() {
     it('should indicate unsupported field type', inject(async function(formEditor) {
 
       // given
-      const error = clone(schema);
+      const errorSchema = {
+        type: 'unknown'
+      };
 
-      error.components.push({
-        type: 'foo'
-      });
+      let error;
 
       // when
       try {
-        await formEditor.importSchema(error);
+        await formEditor.importSchema(errorSchema);
       } catch (err) {
-
-        // then
-        expect(err).to.exist;
-        expect(err.message).to.eql('form field of type <foo> not supported');
-
-        expect(err.warnings).to.exist;
-        expect(err.warnings).to.be.empty;
+        error = err;
       }
+
+      // then
+      expect(error).to.exist;
+      expect(error.message).to.eql('form field of type <unknown> not supported');
+
+      expect(error.warnings).to.exist;
+      expect(error.warnings).to.be.empty;
     }));
 
 
-    it('should indicate duplicate key', inject(async function(formEditor) {
+    it('should indicate duplicate <key>', inject(async function(formEditor) {
 
       // given
-      const errorSchema = clone(schema);
-
-      errorSchema.components.push({
-        type: 'textfield',
-        key: 'creditor'
-      });
+      const errorSchema = {
+        type: 'default',
+        components: [
+          {
+            key: 'creditor',
+            type: 'text'
+          },
+          {
+            key: 'creditor',
+            type: 'text'
+          }
+        ]
+      };
 
       let error;
 
@@ -98,6 +106,41 @@ describe('Importer', function() {
       // then
       expect(error).to.exist;
       expect(error.message).to.eql('form field with key <creditor> already exists');
+
+      expect(error.warnings).to.exist;
+      expect(error.warnings).to.be.empty;
+    }));
+
+
+    it('should indicate duplicate <id>', inject(async function(formEditor) {
+
+      // given
+      const errorSchema = {
+        type: 'default',
+        components: [
+          {
+            id: 'foo',
+            type: 'text'
+          },
+          {
+            id: 'foo',
+            type: 'text'
+          }
+        ]
+      };
+
+      let error;
+
+      // when
+      try {
+        await formEditor.importSchema(errorSchema);
+      } catch (err) {
+        error = err;
+      }
+
+      // then
+      expect(error).to.exist;
+      expect(error.message).to.eql('form field with id <foo> already exists');
 
       expect(error.warnings).to.exist;
       expect(error.warnings).to.be.empty;

--- a/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
@@ -74,6 +74,27 @@ describe('properties panel', function() {
 
   describe('fields', function() {
 
+    it('default', function() {
+
+      // given
+      const field = schema;
+
+      const result = createPropertiesPanel({
+        container,
+        field
+      });
+
+      // then
+      expectGroups(result.container, [
+        'General'
+      ]);
+
+      expectGroupEntries(result.container, 'General', [
+        'Id',
+      ]);
+    });
+
+
     it('button', function() {
 
       // given
@@ -446,7 +467,7 @@ describe('properties panel', function() {
 
         describe('key', function() {
 
-          it('should show error key empty', function() {
+          it('should not be empty', function() {
 
             // given
             const editFieldSpy = spy();
@@ -482,7 +503,7 @@ describe('properties panel', function() {
           });
 
 
-          it('should show error if key contains spaces', function() {
+          it('should not contain spaces', function() {
 
             // given
             const editFieldSpy = spy();
@@ -518,7 +539,7 @@ describe('properties panel', function() {
           });
 
 
-          it('should show error if key is not unique', function() {
+          it('should be unique', function() {
 
             // given
             const editFieldSpy = spy();
@@ -555,6 +576,155 @@ describe('properties panel', function() {
 
         });
 
+
+        describe('id', function() {
+
+          const schema = {
+            type: 'default',
+            id: 'form',
+            components: [
+              { type: 'text', id: 'text', text: 'TEXT' }
+            ]
+          };
+
+
+          it('should not be empty', function() {
+
+            // given
+            const editFieldSpy = spy();
+
+            createPropertiesPanel({
+              container,
+              editField: editFieldSpy,
+              field: schema,
+              services: {
+                formFieldRegistry: new Map([
+                  [ schema.id, schema ],
+                  [ schema.components[0].id, schema.components[0] ]
+                ])
+              }
+            });
+
+            // assume
+            const input = screen.getByLabelText('Id');
+
+            expect(input.value).to.equal(schema.id);
+
+            // when
+            fireEvent.input(input, { target: { value: '' } });
+
+            // then
+            expect(editFieldSpy).not.to.have.been.called;
+
+            const error = screen.getByText('Must not be empty.');
+
+            expect(error).to.exist;
+          });
+
+
+          it('should not contain spaces', function() {
+
+            // given
+            const editFieldSpy = spy();
+
+            createPropertiesPanel({
+              container,
+              editField: editFieldSpy,
+              field: schema,
+              services: {
+                formFieldRegistry: new Map([
+                  [ schema.id, schema ],
+                  [ schema.components[0].id, schema.components[0] ]
+                ])
+              }
+            });
+
+            // assume
+            const input = screen.getByLabelText('Id');
+
+            expect(input.value).to.equal(schema.id);
+
+            // when
+            fireEvent.input(input, { target: { value: 'fo rm' } });
+
+            // then
+            expect(editFieldSpy).not.to.have.been.called;
+
+            const error = screen.getByText('Must not contain spaces.');
+
+            expect(error).to.exist;
+          });
+
+
+          it('should be unique', function() {
+
+            // given
+            const editFieldSpy = spy();
+
+            createPropertiesPanel({
+              container,
+              editField: editFieldSpy,
+              field: schema,
+              services: {
+                formFieldRegistry: new Map([
+                  [ schema.id, schema ],
+                  [ schema.components[0].id, schema.components[0] ]
+                ])
+              }
+            });
+
+            // assume
+            const input = screen.getByLabelText('Id');
+
+            expect(input.value).to.equal(schema.id);
+
+            // when
+            fireEvent.input(input, { target: { value: 'text' } });
+
+            // then
+            expect(editFieldSpy).not.to.have.been.called;
+
+            const error = screen.getByText('Must be unique.');
+
+            expect(error).to.exist;
+          });
+
+
+          it('should be a valid QName', function() {
+
+            // given
+            const editFieldSpy = spy();
+
+            createPropertiesPanel({
+              container,
+              editField: editFieldSpy,
+              field: schema,
+              services: {
+                formFieldRegistry: new Map([
+                  [ schema.id, schema ],
+                  [ schema.components[0].id, schema.components[0] ]
+                ])
+              }
+            });
+
+            // assume
+            const input = screen.getByLabelText('Id');
+
+            expect(input.value).to.equal(schema.id);
+
+            // when
+            fireEvent.input(input, { target: { value: '<HELLO>' } });
+
+            // then
+            expect(editFieldSpy).not.to.have.been.called;
+
+            const error = screen.getByText('Must be a valid QName.');
+
+            expect(error).to.exist;
+          });
+
+        });
+
       });
 
     });
@@ -562,6 +732,9 @@ describe('properties panel', function() {
   });
 
 });
+
+
+// helpers //////////////
 
 function createPropertiesPanel(options = {}) {
   const {

--- a/packages/form-js-viewer/karma.conf.js
+++ b/packages/form-js-viewer/karma.conf.js
@@ -71,7 +71,8 @@ module.exports = function(karma) {
                   [ '@babel/plugin-transform-react-jsx', {
                     'importSource': 'preact',
                     'runtime': 'automatic'
-                  } ]
+                  } ],
+                  '@babel/plugin-transform-react-jsx-source'
                 ]
               }
             }

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -1,7 +1,5 @@
 import { clone, generateIdForType } from '../util';
 
-import { isUndefined } from 'min-dash';
-
 
 export default class Importer {
 
@@ -16,7 +14,7 @@ export default class Importer {
   }
 
   /**
-   * Import schema adding `_id`, `_parent` and `_path`
+   * Import schema adding `id`, `_parent` and `_path`
    * information to each field and adding it to the
    * form field registry.
    *
@@ -56,9 +54,9 @@ export default class Importer {
   importFormField(formField, data = {}, parentId) {
     const {
       components,
-      id,
       key,
-      type
+      type,
+      id = generateIdForType(type)
     } = formField;
 
     if (parentId) {
@@ -82,19 +80,13 @@ export default class Importer {
       formField._path = [ key ];
     }
 
-    const _id = generateIdForType(type);
-
     // Set form field ID
-    formField._id = _id;
+    formField.id = id;
 
-    if (isUndefined(id)) {
-      formField.id = _id;
-    }
-
-    this._formFieldRegistry.set(_id, formField);
+    this._formFieldRegistry.set(id, formField);
 
     if (components) {
-      this.importFormFields(components, data, _id);
+      this.importFormFields(components, data, id);
     }
 
     return formField;

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -1,5 +1,7 @@
 import { generateIdForType } from '../util';
 
+import { isUndefined } from 'min-dash';
+
 export default class Importer {
 
   /**
@@ -41,6 +43,7 @@ export default class Importer {
   importFormField(formField, data = {}, parentId) {
     const {
       components,
+      id,
       key,
       type
     } = formField;
@@ -70,6 +73,10 @@ export default class Importer {
 
     // Set form field ID
     formField._id = _id;
+
+    if (isUndefined(id)) {
+      formField.id = _id;
+    }
 
     this._formFieldRegistry.set(_id, formField);
 

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -1,6 +1,7 @@
-import { generateIdForType } from '../util';
+import { clone, generateIdForType } from '../util';
 
 import { isUndefined } from 'min-dash';
+
 
 export default class Importer {
 
@@ -15,31 +16,43 @@ export default class Importer {
   }
 
   /**
-   * Import schema adding `_id`, `_parent` and `_path` information to each field and adding it to the form field registry.
+   * Import schema adding `_id`, `_parent` and `_path`
+   * information to each field and adding it to the
+   * form field registry.
    *
    * @param {any} schema
-   * @param {any} data
+   * @param {any} [data]
    *
-   * @returns {Promise}
+   * @return { { warnings: Array<any>, schema: any, data: any } }
    */
   importSchema(schema, data = {}) {
 
     // TODO: Add warnings
     const warnings = [];
 
-    return new Promise((resolve, reject) => {
-      try {
-        this.importFormField(schema, data);
-      } catch (err) {
-        err.warnings = warnings;
+    try {
+      const importedData = clone(data);
+      const importedSchema = this.importFormField(clone(schema), importedData);
 
-        reject(err);
-      }
+      return {
+        warnings,
+        schema: importedSchema,
+        data: importedData
+      };
+    } catch (err) {
+      err.warnings = warnings;
 
-      resolve({ warnings });
-    });
+      throw err;
+    }
   }
 
+  /**
+   * @param {any} formField
+   * @param {Object} [data]
+   * @param {string} [parentId]
+   *
+   * @return {any} field
+   */
   importFormField(formField, data = {}, parentId) {
     const {
       components,

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -80,6 +80,14 @@ export default class Importer {
       formField._path = [ key ];
     }
 
+    if (id) {
+      this._formFieldRegistry.forEach((formField) => {
+        if (formField.id === id) {
+          throw new Error(`form field with id <${ id }> already exists`);
+        }
+      });
+    }
+
     // Set form field ID
     formField.id = id;
 

--- a/packages/form-js-viewer/src/index.js
+++ b/packages/form-js-viewer/src/index.js
@@ -3,7 +3,7 @@ import Form from './Form';
 export * from './render';
 export * from './util';
 
-const schemaVersion = 1;
+const schemaVersion = 2;
 
 export {
   Form,

--- a/packages/form-js-viewer/src/render/components/form-fields/Button.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Button.js
@@ -1,8 +1,7 @@
 import { formFieldClasses } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'button';
+
 
 export default function Button(props) {
   const {
@@ -18,18 +17,13 @@ export default function Button(props) {
 }
 
 Button.create = function(options = {}) {
-  const id = generateIdForType(type);
 
   return {
     action: 'submit',
-    id,
-    key: id,
-    label: this.label,
-    type,
     ...options
   };
 };
 
 Button.type = type;
-
 Button.label = 'Button';
+Button.keyed = true;

--- a/packages/form-js-viewer/src/render/components/form-fields/Button.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Button.js
@@ -18,12 +18,12 @@ export default function Button(props) {
 }
 
 Button.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
     action: 'submit',
-    _id,
-    key: _id,
+    id,
+    key: id,
     label: this.label,
     type,
     ...options

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -7,9 +7,8 @@ import {
   prefixId
 } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'checkbox';
+
 
 export default function Checkbox(props) {
   const {
@@ -51,17 +50,11 @@ export default function Checkbox(props) {
 }
 
 Checkbox.create = function(options = {}) {
-  const id = generateIdForType(type);
-
   return {
-    id,
-    key: id,
-    label: this.label,
-    type,
     ...options
   };
 };
 
 Checkbox.type = type;
-
 Checkbox.label = 'Checkbox';
+Checkbox.keyed = true;

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -21,7 +21,7 @@ export default function Checkbox(props) {
 
   const {
     description,
-    _id,
+    id,
     label
   } = field;
 
@@ -34,14 +34,14 @@ export default function Checkbox(props) {
 
   return <div class={ formFieldClasses(type, errors) }>
     <Label
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       label={ label }
       required={ false }>
       <input
         checked={ value }
         class="fjs-input"
         disabled={ disabled }
-        id={ prefixId(_id) }
+        id={ prefixId(id) }
         type="checkbox"
         onChange={ onChange } />
     </Label>
@@ -51,11 +51,11 @@ export default function Checkbox(props) {
 }
 
 Checkbox.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
-    _id,
-    key: _id,
+    id,
+    key: id,
     label: this.label,
     type,
     ...options

--- a/packages/form-js-viewer/src/render/components/form-fields/Default.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Default.js
@@ -22,7 +22,7 @@ export default function Default(props) {
       components.map(childField => {
         return <FormField
           { ...props }
-          key={ childField._id }
+          key={ childField.id }
           field={ childField } />;
       })
     }
@@ -33,11 +33,11 @@ export default function Default(props) {
 }
 
 Default.create = function(options = {}) {
-  const _id = generateIdForType(this.type);
+  const id = generateIdForType(this.type);
 
   return {
     components: [],
-    _id,
+    id,
     label: this.label,
     type: this.type,
     ...options

--- a/packages/form-js-viewer/src/render/components/form-fields/Default.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Default.js
@@ -4,8 +4,6 @@ import FormField from '../FormField';
 
 import { FormRenderContext } from '../../context';
 
-import { generateIdForType } from '../../../util';
-
 
 export default function Default(props) {
   const {
@@ -33,17 +31,11 @@ export default function Default(props) {
 }
 
 Default.create = function(options = {}) {
-  const id = generateIdForType(this.type);
-
   return {
     components: [],
-    id,
-    label: this.label,
-    type: this.type,
     ...options
   };
 };
 
 Default.type = 'default';
-
-Default.label = 'Default';
+Default.keyed = false;

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -21,7 +21,7 @@ export default function Number(props) {
 
   const {
     description,
-    _id,
+    id,
     label,
     validate = {}
   } = field;
@@ -39,13 +39,13 @@ export default function Number(props) {
 
   return <div class={ formFieldClasses(type, errors) }>
     <Label
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       label={ label }
       required={ required } />
     <input
       class="fjs-input"
       disabled={ disabled }
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       onInput={ onChange }
       type="number"
       value={ value } />
@@ -55,11 +55,11 @@ export default function Number(props) {
 }
 
 Number.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
-    _id,
-    key: _id,
+    id,
+    key: id,
     label: this.label,
     type,
     ...options

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -7,9 +7,8 @@ import {
   prefixId
 } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'number';
+
 
 export default function Number(props) {
   const {
@@ -55,17 +54,11 @@ export default function Number(props) {
 }
 
 Number.create = function(options = {}) {
-  const id = generateIdForType(type);
-
   return {
-    id,
-    key: id,
-    label: this.label,
-    type,
     ...options
   };
 };
 
 Number.type = type;
-
+Number.keyed = true;
 Number.label = 'Number';

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -7,9 +7,8 @@ import {
   prefixId
 } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'radio';
+
 
 export default function Radio(props) {
   const {
@@ -65,13 +64,7 @@ export default function Radio(props) {
 }
 
 Radio.create = function(options = {}) {
-  const id = generateIdForType(type);
-
   return {
-    id,
-    key: id,
-    label: this.label,
-    type,
     values: [
       {
         label: 'Value',
@@ -83,5 +76,5 @@ Radio.create = function(options = {}) {
 };
 
 Radio.type = type;
-
 Radio.label = 'Radio';
+Radio.keyed = true;

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -21,7 +21,7 @@ export default function Radio(props) {
 
   const {
     description,
-    _id,
+    id,
     label,
     validate = {},
     values
@@ -44,7 +44,7 @@ export default function Radio(props) {
       values.map((v, index) => {
         return (
           <Label
-            id={ prefixId(`${ _id }-${ index }`) }
+            id={ prefixId(`${ id }-${ index }`) }
             key={ v.value }
             label={ v.label }
             required={ false }>
@@ -52,7 +52,7 @@ export default function Radio(props) {
               checked={ v.value === value }
               class="fjs-input"
               disabled={ disabled }
-              id={ prefixId(`${ _id }-${ index }`) }
+              id={ prefixId(`${ id }-${ index }`) }
               type="radio"
               onClick={ () => onChange(v.value) } />
           </Label>
@@ -65,11 +65,11 @@ export default function Radio(props) {
 }
 
 Radio.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
-    _id,
-    key: _id,
+    id,
+    key: id,
     label: this.label,
     type,
     values: [

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -21,7 +21,7 @@ export default function Select(props) {
 
   const {
     description,
-    _id,
+    id,
     label,
     validate = {},
     values
@@ -38,13 +38,13 @@ export default function Select(props) {
 
   return <div class={ formFieldClasses(type, errors) }>
     <Label
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       label={ label }
       required={ required } />
     <select
       class="fjs-select"
       disabled={ disabled }
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       onChange={ onChange }
       value={ value }>
       <option value=""></option>
@@ -66,11 +66,11 @@ export default function Select(props) {
 }
 
 Select.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
-    _id,
-    key: _id,
+    id,
+    key: id,
     label: this.label,
     type,
     values: [

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -7,8 +7,6 @@ import {
   prefixId
 } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'select';
 
 export default function Select(props) {
@@ -66,13 +64,8 @@ export default function Select(props) {
 }
 
 Select.create = function(options = {}) {
-  const id = generateIdForType(type);
 
   return {
-    id,
-    key: id,
-    label: this.label,
-    type,
     values: [
       {
         label: 'Value',
@@ -84,5 +77,5 @@ Select.create = function(options = {}) {
 };
 
 Select.type = type;
-
 Select.label = 'Select';
+Select.keyed = true;

--- a/packages/form-js-viewer/src/render/components/form-fields/Text.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Text.js
@@ -20,10 +20,10 @@ export default function Text(props) {
 }
 
 Text.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
-    _id,
+    id,
     text: '# Text',
     type,
     ...options

--- a/packages/form-js-viewer/src/render/components/form-fields/Text.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Text.js
@@ -5,9 +5,8 @@ import {
   safeMarkdown
 } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'text';
+
 
 export default function Text(props) {
   const { field } = props;
@@ -20,14 +19,11 @@ export default function Text(props) {
 }
 
 Text.create = function(options = {}) {
-  const id = generateIdForType(type);
-
   return {
-    id,
     text: '# Text',
-    type,
     ...options
   };
 };
 
 Text.type = type;
+Text.keyed = false;

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -21,7 +21,7 @@ export default function Textfield(props) {
 
   const {
     description,
-    _id,
+    id,
     label,
     validate = {}
   } = field;
@@ -37,13 +37,13 @@ export default function Textfield(props) {
 
   return <div class={ formFieldClasses(type, errors) }>
     <Label
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       label={ label }
       required={ required } />
     <input
       class="fjs-input"
       disabled={ disabled }
-      id={ prefixId(_id) }
+      id={ prefixId(id) }
       onInput={ onChange }
       type="text"
       value={ value } />
@@ -53,11 +53,11 @@ export default function Textfield(props) {
 }
 
 Textfield.create = function(options = {}) {
-  const _id = generateIdForType(type);
+  const id = generateIdForType(type);
 
   return {
-    _id,
-    key: _id,
+    id,
+    key: id,
     label: this.label,
     type,
     ...options

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -7,9 +7,8 @@ import {
   prefixId
 } from '../Util';
 
-import { generateIdForType } from '../../../util';
-
 const type = 'textfield';
+
 
 export default function Textfield(props) {
   const {
@@ -53,17 +52,11 @@ export default function Textfield(props) {
 }
 
 Textfield.create = function(options = {}) {
-  const id = generateIdForType(type);
-
   return {
-    id,
-    key: id,
-    label: this.label,
-    type,
     ...options
   };
 };
 
 Textfield.type = type;
-
 Textfield.label = 'Text Field';
+Textfield.keyed = true;

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -15,6 +15,7 @@ import customModule from './custom';
 
 import disabledSchema from './disabled.json';
 import schema from './form.json';
+import schemaNoIds from './form.json';
 import textSchema from './text.json';
 
 import {
@@ -89,6 +90,42 @@ describe('Form', function() {
 
 
   describe('#importSchema', function() {
+
+    it('should generate IDs', async function() {
+
+      // given
+      const data = {
+        creditor: 'John Doe Company',
+        amount: 456,
+        invoiceNumber: 'C-123',
+        approved: true,
+        approvedBy: 'John Doe',
+        product: 'camunda-cloud',
+        language: 'english',
+        documents: [
+          {
+            title: 'invoice.pdf',
+            author: 'John Doe'
+          },
+          {
+            title: 'products.pdf'
+          }
+        ]
+      };
+
+      // when
+      const form = new Form();
+
+      await form.importSchema(schemaNoIds, data);
+
+      // then
+      expect(form.get('formFieldRegistry').size).to.equal(11);
+
+      form.get('formFieldRegistry').forEach(field => {
+        expect(field.id).to.exist;
+      });
+    });
+
 
     it('should import without errors', async function() {
 

--- a/packages/form-js-viewer/test/spec/import/Importer.spec.js
+++ b/packages/form-js-viewer/test/spec/import/Importer.spec.js
@@ -75,95 +75,148 @@ describe('Importer', function() {
   }));
 
 
-  it('should error if form field of type not supported', inject(async function(form) {
+  describe('error handling', function() {
 
-    // given
-    const error = clone(schema);
+    it('should indicate unsupported field type', inject(async function(form) {
 
-    error.components.push({
-      type: 'foo'
-    });
+      // given
+      const errorSchema = {
+        type: 'unknown'
+      };
 
-    // when
-    try {
-      await form.importSchema(error);
-    } catch (err) {
+      let error;
 
-      // then
-      expect(err).to.exist;
-      expect(err.message).to.eql('form field of type <foo> not supported');
-
-      expect(err.warnings).to.exist;
-      expect(err.warnings).to.be.empty;
-    }
-  }));
-
-
-  it('should error if form field with key already exists', inject(async function(form) {
-
-    // given
-    const error = clone(schema);
-
-    error.components.push({
-      type: 'textfield',
-      key: 'creditor'
-    });
-
-    // when
-    try {
-      await form.importSchema(error);
-    } catch (err) {
+      // when
+      try {
+        await form.importSchema(errorSchema);
+      } catch (err) {
+        error = err;
+      }
 
       // then
-      expect(err).to.exist;
-      expect(err.message).to.eql('form field with key <creditor> already exists');
+      expect(error).to.exist;
+      expect(error.message).to.eql('form field of type <unknown> not supported');
 
-      expect(err.warnings).to.exist;
-      expect(err.warnings).to.be.empty;
-    }
-  }));
-
-
-  it('should error if broken JSON is imported', inject(async function(form) {
-
-    // when
-    try {
-      await form.importSchema('foo');
-    } catch (err) {
-
-      // then
-      expect(err).to.exist;
-      expect(err.message).to.equal('form field of type <undefined> not supported');
-
-      expect(err.warnings).to.exist;
-      expect(err.warnings).to.be.empty;
-    }
-  }));
+      expect(error.warnings).to.exist;
+      expect(error.warnings).to.be.empty;
+    }));
 
 
-  // TODO: Catch broken schema errors during import
-  it.skip('should error if broken schema is imported', inject(async function(form) {
+    it('should indicate duplicate <key>', inject(async function(form) {
 
-    // given
-    const error = clone(schema);
+      // given
+      const errorSchema = {
+        type: 'default',
+        components: [
+          {
+            key: 'creditor',
+            type: 'text'
+          },
+          {
+            key: 'creditor',
+            type: 'text'
+          }
+        ]
+      };
 
-    error.components.push({
-      type: 'select',
-      key: 'foo',
-      values: 123
-    });
+      let error;
 
-    // when
-    try {
-      await form.importSchema(error);
-    } catch (err) {
+      // when
+      try {
+        await form.importSchema(errorSchema);
+      } catch (err) {
+        error = err;
+      }
 
       // then
-      expect(err).to.exist;
+      expect(error).to.exist;
+      expect(error.message).to.eql('form field with key <creditor> already exists');
 
-      expect(err.warnings).to.exist;
-      expect(err.warnings).to.be.empty;
-    }
-  }));
+      expect(error.warnings).to.exist;
+      expect(error.warnings).to.be.empty;
+    }));
+
+
+    it('should indicate duplicate <id>', inject(async function(form) {
+
+      // given
+      const errorSchema = {
+        type: 'default',
+        components: [
+          {
+            id: 'foo',
+            type: 'text'
+          },
+          {
+            id: 'foo',
+            type: 'text'
+          }
+        ]
+      };
+
+      let error;
+
+      // when
+      try {
+        await form.importSchema(errorSchema);
+      } catch (err) {
+        error = err;
+      }
+
+      // then
+      expect(error).to.exist;
+      expect(error.message).to.eql('form field with id <foo> already exists');
+
+      expect(error.warnings).to.exist;
+      expect(error.warnings).to.be.empty;
+    }));
+
+
+    it('should handle broken JSON', inject(async function(form) {
+
+      // when
+      try {
+        await form.importSchema('foo');
+      } catch (err) {
+
+        // then
+        expect(err).to.exist;
+        expect(err.message).to.equal('form field of type <undefined> not supported');
+
+        expect(err.warnings).to.exist;
+        expect(err.warnings).to.be.empty;
+      }
+    }));
+
+
+    // TODO: Catch broken schema errors during import
+    it.skip('should error if broken schema is imported', inject(async function(form) {
+
+      // given
+      const errorSchema = clone(schema);
+
+      errorSchema.components.push({
+        type: 'select',
+        key: 'foo',
+        values: 123
+      });
+
+      let error;
+
+      // when
+      try {
+        await form.importSchema(errorSchema);
+      } catch (err) {
+        error = err;
+      }
+
+      // then
+      expect(error).to.exist;
+
+      expect(error.warnings).to.exist;
+      expect(error.warnings).to.be.empty;
+    }));
+
+  });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/Label.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Label.spec.js
@@ -24,7 +24,7 @@ describe('Label', function() {
 
     // when
     const { container } = createLabel({
-      _id: 'foo',
+      id: 'foo',
       label: 'Foo'
     });
 
@@ -40,7 +40,7 @@ describe('Label', function() {
 
     // when
     const { container } = createLabel({
-      _id: 'foo',
+      id: 'foo',
       label: 'Foo'
     }, <span class="foo">Foo</span>);
 
@@ -55,7 +55,7 @@ describe('Label', function() {
 
     // when
     const { container } = createLabel({
-      _id: 'foo',
+      id: 'foo',
       label: 'Foo',
       required: true
     });
@@ -71,7 +71,7 @@ describe('Label', function() {
 
     // when
     const { container } = createLabel({
-      _id: 'foo'
+      id: 'foo'
     });
 
     // then

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
@@ -73,17 +73,28 @@ describe('Button', function() {
 
   it('#create', function() {
 
+    // assume
+    expect(Button.type).to.eql('button');
+    expect(Button.label).to.eql('Button');
+    expect(Button.keyed).to.be.true;
+
     // when
     const field = Button.create();
 
     // then
-    expect(field).to.contain({
-      action: 'submit',
-      label: 'Button',
-      type: 'button'
+    expect(field).to.eql({
+      action: 'submit'
     });
 
-    expect(field.id).to.match(/button\d+/);
+    // but when
+    const customField = Button.create({
+      custom: true
+    });
+
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
@@ -83,7 +83,7 @@ describe('Button', function() {
       type: 'button'
     });
 
-    expect(field._id).to.match(/button\d+/);
+    expect(field.id).to.match(/button\d+/);
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -128,7 +128,7 @@ describe('Checkbox', function() {
       type: 'checkbox'
     });
 
-    expect(field._id).to.match(/checkbox\d+/);
+    expect(field.id).to.match(/checkbox\d+/);
     expect(field.key).to.match(/checkbox\d+/);
   });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -119,17 +119,26 @@ describe('Checkbox', function() {
 
   it('#create', function() {
 
+    // assume
+    expect(Checkbox.type).to.eql('checkbox');
+    expect(Checkbox.label).to.eql('Checkbox');
+    expect(Checkbox.keyed).to.be.true;
+
     // when
     const field = Checkbox.create();
 
     // then
-    expect(field).to.contain({
-      label: 'Checkbox',
-      type: 'checkbox'
+    expect(field).to.eql({});
+
+    // but when
+    const customField = Checkbox.create({
+      custom: true
     });
 
-    expect(field.id).to.match(/checkbox\d+/);
-    expect(field.key).to.match(/checkbox\d+/);
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Default.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Default.spec.js
@@ -1,0 +1,32 @@
+import Default from '../../../../../src/render/components/form-fields/Default';
+
+
+describe('Default', function() {
+
+  it('#create', function() {
+
+    // assume
+    expect(Default.type).to.eql('default');
+    expect(Default.label).not.to.exist;
+    expect(Default.keyed).to.be.false;
+
+    // when
+    const field = Default.create();
+
+    // then
+    expect(field).to.eql({
+      components: []
+    });
+
+    // but when
+    const customField = Default.create({
+      custom: true
+    });
+
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
+  });
+
+});

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -172,17 +172,26 @@ describe('Number', function() {
 
   it('#create', function() {
 
+    // assume
+    expect(Number.type).to.eql('number');
+    expect(Number.label).to.eql('Number');
+    expect(Number.keyed).to.be.true;
+
     // when
     const field = Number.create();
 
     // then
-    expect(field).to.contain({
-      label: 'Number',
-      type: 'number'
+    expect(field).to.eql({});
+
+    // but when
+    const customField = Number.create({
+      custom: true
     });
 
-    expect(field.id).to.match(/number\d+/);
-    expect(field.key).to.match(/number\d+/);
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -181,7 +181,7 @@ describe('Number', function() {
       type: 'number'
     });
 
-    expect(field._id).to.match(/number\d+/);
+    expect(field.id).to.match(/number\d+/);
     expect(field.key).to.match(/number\d+/);
   });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
@@ -163,7 +163,7 @@ describe('Radio', function() {
       ]
     });
 
-    expect(field._id).to.match(/radio\d+/);
+    expect(field.id).to.match(/radio\d+/);
     expect(field.key).to.match(/radio\d+/);
   });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
@@ -148,13 +148,16 @@ describe('Radio', function() {
 
   it('#create', function() {
 
+    // assume
+    expect(Radio.type).to.eql('radio');
+    expect(Radio.label).to.eql('Radio');
+    expect(Radio.keyed).to.be.true;
+
     // when
     const field = Radio.create();
 
     // then
-    expect(field).to.deep.contain({
-      label: 'Radio',
-      type: 'radio',
+    expect(field).to.eql({
       values: [
         {
           label: 'Value',
@@ -163,8 +166,15 @@ describe('Radio', function() {
       ]
     });
 
-    expect(field.id).to.match(/radio\d+/);
-    expect(field.key).to.match(/radio\d+/);
+    // but when
+    const customField = Radio.create({
+      custom: true
+    });
+
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -159,7 +159,7 @@ describe('Select', function() {
       ]
     });
 
-    expect(field._id).to.match(/select\d+/);
+    expect(field.id).to.match(/select\d+/);
     expect(field.key).to.match(/select\d+/);
   });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -144,13 +144,16 @@ describe('Select', function() {
 
   it('#create', function() {
 
+    // assume
+    expect(Select.type).to.eql('select');
+    expect(Select.label).to.eql('Select');
+    expect(Select.keyed).to.be.true;
+
     // when
     const field = Select.create();
 
     // then
-    expect(field).to.deep.contain({
-      label: 'Select',
-      type: 'select',
+    expect(field).to.eql({
       values: [
         {
           label: 'Value',
@@ -159,8 +162,15 @@ describe('Select', function() {
       ]
     });
 
-    expect(field.id).to.match(/select\d+/);
-    expect(field.key).to.match(/select\d+/);
+    // but when
+    const customField = Select.create({
+      custom: true
+    });
+
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -120,16 +120,28 @@ Some _em_ **strong** [text](#text) \`code\`.
 
   it('#create', function() {
 
+    // assume
+    expect(Text.type).to.eql('text');
+    expect(Text.label).not.to.exist;
+    expect(Text.keyed).to.be.false;
+
     // when
     const field = Text.create();
 
     // then
-    expect(field).to.contain({
-      type: 'text',
+    expect(field).to.eql({
       text: '# Text'
     });
 
-    expect(field.id).to.match(/text\d+/);
+    // but when
+    const customField = Text.create({
+      custom: true
+    });
+
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -129,7 +129,7 @@ Some _em_ **strong** [text](#text) \`code\`.
       text: '# Text'
     });
 
-    expect(field._id).to.match(/text\d+/);
+    expect(field.id).to.match(/text\d+/);
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -181,7 +181,7 @@ describe('Textfield', function() {
       type: 'textfield'
     });
 
-    expect(field._id).to.match(/textfield\d+/);
+    expect(field.id).to.match(/textfield\d+/);
     expect(field.key).to.match(/textfield\d+/);
   });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -172,17 +172,26 @@ describe('Textfield', function() {
 
   it('#create', function() {
 
+    // assume
+    expect(Textfield.type).to.eql('textfield');
+    expect(Textfield.label).to.eql('Text Field');
+    expect(Textfield.keyed).to.be.true;
+
     // when
     const field = Textfield.create();
 
     // then
-    expect(field).to.contain({
-      label: 'Text Field',
-      type: 'textfield'
+    expect(field).to.eql({});
+
+    // but when
+    const customField = Textfield.create({
+      custom: true
     });
 
-    expect(field.id).to.match(/textfield\d+/);
-    expect(field.key).to.match(/textfield\d+/);
+    // then
+    expect(customField).to.contain({
+      custom: true
+    });
   });
 
 });

--- a/packages/form-js/test/spec/Form.spec.js
+++ b/packages/form-js/test/spec/Form.spec.js
@@ -87,6 +87,8 @@ describe('viewer exports', function() {
 
   it('should expose schemaVersion', function() {
     expect(typeof schemaVersion).to.eql('number');
+
+    expect(schemaVersion).to.eql(2);
   });
 
 });

--- a/packages/form-js/test/spec/FormEditor.spec.js
+++ b/packages/form-js/test/spec/FormEditor.spec.js
@@ -47,47 +47,101 @@ describe('editor exports', function() {
   });
 
 
-  it('should export schemaVersion', async function() {
+  describe('export', function() {
 
-    // given
-    const formEditor = await createFormEditor({
-      container,
-      schema
+    it('should expose schema', async function() {
+
+      // given
+      const versionedSchema = {
+        ...schema,
+        schemaVersion
+      };
+
+      const formEditor = await createFormEditor({
+        container,
+        schema: versionedSchema
+      });
+
+      // when
+      const savedSchema = formEditor.getSchema();
+
+      // then
+      expect(savedSchema).to.eql(versionedSchema);
     });
 
-    // when
-    const savedSchema = formEditor.getSchema();
 
-    expect(savedSchema).to.have.property('schemaVersion', schemaVersion);
-  });
+    it('should export schemaVersion', async function() {
 
+      // given
+      const formEditor = await createFormEditor({
+        container,
+        schema
+      });
 
-  it('should export, keeping <id>', async function() {
+      // when
+      const savedSchema = formEditor.getSchema();
 
-    // given
-    const schema = {
-      id: 'FOOBAR',
-      type: 'default',
-      schemaVersion,
-      compontents: [
-        {
-          id: 'number',
-          type: 'number',
-          key: 'number'
-        }
-      ]
-    };
-
-    const formEditor = await createFormEditor({
-      container,
-      schema
+      // then
+      expect(savedSchema).to.have.property('schemaVersion', schemaVersion);
     });
 
-    // when
-    const savedSchema = formEditor.getSchema();
 
-    // then
-    expect(savedSchema).to.eql(schema);
+    it('should keep IDs', async function() {
+
+      // given
+      const schema = {
+        id: 'FOOBAR',
+        type: 'default',
+        schemaVersion,
+        compontents: [
+          {
+            id: 'number',
+            type: 'number',
+            key: 'number'
+          }
+        ]
+      };
+
+      const formEditor = await createFormEditor({
+        container,
+        schema
+      });
+
+      // when
+      const savedSchema = formEditor.getSchema();
+
+      // then
+      expect(savedSchema).to.eql(schema);
+    });
+
+
+    it('should assign IDs', async function() {
+
+      // given
+      const schema = {
+        type: 'default',
+        schemaVersion,
+        components: [
+          {
+            type: 'number',
+            key: 'number'
+          }
+        ]
+      };
+
+      const formEditor = await createFormEditor({
+        container,
+        schema
+      });
+
+      // when
+      const savedSchema = formEditor.saveSchema();
+
+      // then
+      expect(savedSchema.id).to.exist;
+      expect(savedSchema.components[0].id).to.exist;
+    });
+
   });
 
 });

--- a/packages/form-js/test/spec/FormEditor.spec.js
+++ b/packages/form-js/test/spec/FormEditor.spec.js
@@ -93,7 +93,7 @@ describe('editor exports', function() {
         id: 'FOOBAR',
         type: 'default',
         schemaVersion,
-        compontents: [
+        components: [
           {
             id: 'number',
             type: 'number',

--- a/packages/form-js/test/spec/form.json
+++ b/packages/form-js/test/spec/form.json
@@ -82,6 +82,7 @@
     },
     {
       "id": "Field_9",
+      "action": "submit",
       "key": "submit",
       "label": "Submit",
       "type": "button"

--- a/packages/form-js/test/spec/form.json
+++ b/packages/form-js/test/spec/form.json
@@ -1,10 +1,14 @@
 {
+  "id": "Form_1",
+  "type": "default",
   "components": [
     {
+      "id": "Field_1",
       "type": "text",
       "text": "# Invoice\nLorem _ipsum_ __dolor__ `sit`.\n  \n  \nA list of BPMN symbols:\n* Start Event\n* Task\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
     },
     {
+      "id": "Field_2",
       "key": "creditor",
       "label": "Creditor",
       "type": "textfield",
@@ -13,6 +17,7 @@
       }
     },
     {
+      "id": "Field_3",
       "description": "An invoice number in the format: C-123.",
       "key": "invoiceNumber",
       "label": "Invoice Number",
@@ -22,6 +27,7 @@
       }
     },
     {
+      "id": "Field_4",
       "key": "amount",
       "label": "Amount",
       "type": "number",
@@ -31,16 +37,19 @@
       }
     },
     {
+      "id": "Field_5",
       "key": "approved",
       "label": "Approved",
       "type": "checkbox"
     },
     {
+      "id": "Field_6",
       "key": "approvedBy",
       "label": "Approved By",
       "type": "textfield"
     },
     {
+      "id": "Field_7",
       "key": "product",
       "label": "Product",
       "type": "radio",
@@ -56,6 +65,7 @@
       ]
     },
     {
+      "id": "Field_8",
       "key": "language",
       "label": "Language",
       "type": "select",
@@ -71,16 +81,17 @@
       ]
     },
     {
+      "id": "Field_9",
       "key": "submit",
       "label": "Submit",
       "type": "button"
     },
     {
+      "id": "Field_10",
       "action": "reset",
       "key": "reset",
       "label": "Reset",
       "type": "button"
     }
-  ],
-  "type": "default"
+  ]
 }


### PR DESCRIPTION
### Gist

* `id` is a new property that is not supposed to be editable by a user (with the exception of the root element in the form schema, the form definition
* `id` property is automatically assigned when importing existing form schemata into the form editor
* for backwards compatibility reasons the `form-js-viewer` does not rely on `id` properties to be present at this point :arrow_backward: 


### UI

![capture kEMqnU_optimized](https://user-images.githubusercontent.com/58601/126775208-6139427a-1451-4b41-9a05-368cfda08d84.gif)

### Work Log

* [x] properly generate ID via `ids` facility
* [x] create a human readable ID for the form definition
* [x] validate ID (format + duplication)
* [x] UI improvements
    * [x] Make selection toggleable
    * [x] Distinguish select and hover on form elements
    * [x] Remove "no element selected" placeholder :arrow_right: if now element is selected, the form itself is selected
* [x] make definitions (form root) editable via properties panel
* [x] make ID on definitions object editable + validate on edit
* [ ] ~~Form Icon~~ (https://github.com/camunda/camunda-modeler-design/issues/28)

### Additional Improvements :ship: 

* `CLEANUP`: use `_id` internally https://github.com/bpmn-io/form-js/pull/137/commits/b42e3c5e7d3706abfb75ca968470f72c3b68cab5
* `CHORE`: make importSchema sync and prevent side effects https://github.com/bpmn-io/form-js/pull/137/commits/0f4cade19fcc75d4785ead4d10837fba56b0f545
* `FEAT`: improve selection + hover styles https://github.com/bpmn-io/form-js/pull/137/commits/44705fc9eef2cd0247da07d09a4ee00f4a70d6bb
* `FEAT`: add drag stickyness https://github.com/bpmn-io/form-js/pull/137/commits/3fbfd56c8847af7fa1592489908517bbaceb5603

---

Closes https://github.com/bpmn-io/form-js/issues/80.