### PR TITLE
Externalize type definitions

### DIFF
--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -26,7 +26,7 @@
     "example:dev": "cd example && npm start",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint .",
-    "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --outDir dist/types src/index.js",
+    "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --outDir dist/types src/index.js && cp src/**.d.ts dist/types",
     "test": "cross-env NODE_ENV=test karma start",
     "prepublishOnly": "npm run build"
   },

--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -16,25 +16,22 @@ import EditorActionsModule from './features/editor-actions';
 import KeyboardModule from './features/keyboard';
 
 /**
- * @typedef { import('didi').Injector } Injector
- * @typedef { any[] } Modules
- * @typedef { { [x: string]: any } } FormEditorProperties
- * @typedef { any } Schema
+ * @typedef { import('./types').Injector } Injector
+ * @typedef { import('./types').Module } Module
+ * @typedef { import('./types').Schema } Schema
+ *
+ * @typedef { import('./types').FormEditorOptions } FormEditorOptions
+ * @typedef { import('./types').FormEditorProperties } FormEditorProperties
  *
  * @typedef { {
- *   additionalModules?: Modules,
- *   container?: Element|string,
- *   exporter?: any,
- *   injector?: Injector,
- *   modules?: Modules,
- *   properties?: FormEditorProperties,
- *   [x: string]: any
- * } } FormEditorOptions
- *
- * @typedef { { properties: FormEditorProperties, schema: Schema } } State
+ *   properties: FormEditorProperties,
+ *   schema: Schema
+ * } } State
  */
 
-
+/**
+ * The form editor.
+ */
 export default class FormEditor {
 
   /**
@@ -183,6 +180,8 @@ export default class FormEditor {
   }
 
   /**
+   * @internal
+   *
    * @param {boolean} [emit]
    */
   _detach(emit = true) {
@@ -228,10 +227,12 @@ export default class FormEditor {
   }
 
   /**
+   * @internal
+   *
    * @param {FormEditorOptions} options
    * @param {Element} container
    *
-   * @returns {import('didi').Injector}
+   * @returns {Injector}
    */
   _createInjector(options, container) {
     const {
@@ -257,14 +258,23 @@ export default class FormEditor {
     ]);
   }
 
+  /**
+   * @internal
+   */
   _emit(type, data) {
     this.get('eventBus').fire(type, data);
   }
 
+  /**
+   * @internal
+   */
   _getState() {
     return this._state;
   }
 
+  /**
+   * @internal
+   */
   _setState(state) {
     this._state = {
       ...this._state,
@@ -274,6 +284,9 @@ export default class FormEditor {
     this._emit('changed', this._getState());
   }
 
+  /**
+   * @internal
+   */
   _getModules() {
     return [
       EditorActionsModule,

--- a/packages/form-js-editor/src/index.js
+++ b/packages/form-js-editor/src/index.js
@@ -8,26 +8,13 @@ export {
 };
 
 /**
- * @typedef { import('didi').Injector } Injector
- * @typedef { any[] } Modules
- * @typedef { { [x: string]: any } } FormEditorProperties
- * @typedef { any } Schema
- *
- * @typedef { {
- *   additionalModules?: Modules,
- *   container?: Element|string,
- *   exporter?: { name: string, version: string },
- *   injector?: Injector,
- *   modules?: Modules,
- *   properties?: FormEditorProperties,
- *   schema?: Schema
- * } } FormEditorOptions
+ * @typedef { import('./types').CreateFormEditorOptions } CreateFormEditorOptions
  */
 
 /**
  * Create a form editor.
  *
- * @param {FormEditorOptions} options
+ * @param {CreateFormEditorOptions} options
  *
  * @return {Promise<FormEditor>}
  */

--- a/packages/form-js-editor/src/types.d.ts
+++ b/packages/form-js-editor/src/types.d.ts
@@ -1,0 +1,29 @@
+import { Injector } from 'didi';
+
+export type Module = any;
+export type Schema = any;
+
+export interface FormEditorProperties {
+  [x: string]: any
+}
+
+export interface FormEditorOptions {
+  additionalModules?: Module[];
+  container?: Element|string;
+  exporter?: {
+    name: string,
+    version: string
+  };
+  injector?: Injector;
+  modules?: Module[];
+  properties?: FormEditorProperties;
+  [x:string]: any;
+}
+
+export interface CreateFormEditorOptions extends FormEditorOptions {
+  schema?: Schema
+}
+
+export {
+  Injector
+};

--- a/packages/form-js-integration/package.json
+++ b/packages/form-js-integration/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@bpmn-io/form-js-integration",
+  "version": "0.3.0",
+  "description": "A set of form-js integration testing resources",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bpmn-io/form-js.git",
+    "directory": "packages/form-js-integration"
+  },
+  "author": {
+    "name": "bpmn.io contributors",
+    "url": "https://github.com/bpmn-io"
+  },
+  "dependencies": {
+    "@bpmn-io/form-js": "^0.3.0"
+  }
+}

--- a/packages/form-js-integration/src/application.ts
+++ b/packages/form-js-integration/src/application.ts
@@ -1,0 +1,59 @@
+import {
+  createForm,
+  createFormEditor,
+  Form,
+  FormEditor,
+  schemaVersion
+} from '@bpmn-io/form-js';
+
+
+/**
+ * A TypeScript application that verifies our type
+ * definitions are stable (enough).
+ */
+export async function createApp(options: { container: Element }) {
+
+  const {
+    container
+  } = options;
+
+  await createForm({
+    schema: {},
+    data: {},
+    container
+  });
+
+  await createFormEditor({
+    schema: {},
+    container
+  });
+
+  if (schemaVersion > 1) {
+    console.log('schemaVersion > 1');
+  }
+
+  const form = new Form({ container });
+
+  await form.importSchema({});
+  await form.importSchema({}, {});
+
+  form.setProperty('readonly', true);
+
+  // eslint-disable-next-line
+  const detachedForm = new Form();
+
+  const formEditor = new FormEditor({ container });
+
+  await formEditor.importSchema({});
+
+  // eslint-disable-next-line
+  const formEditorExtraOpts = new FormEditor({
+    container,
+    foo: {
+      bar: true
+    }
+  });
+
+  // eslint-disable-next-line
+  const detachedFormEditor = new FormEditor();
+}

--- a/packages/form-js-viewer/package.json
+++ b/packages/form-js-viewer/package.json
@@ -23,7 +23,7 @@
     "bundle": "rollup -c",
     "bundle:watch": "rollup -c -w",
     "dev": "npm test -- --auto-watch --no-single-run",
-    "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --outDir dist/types src/index.js",
+    "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --outDir dist/types src/index.js && cp src/*.d.ts dist/types",
     "test": "karma start",
     "prepublishOnly": "npm run build"
   },

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -14,23 +14,14 @@ import {
 import core from './core';
 
 /**
- * @typedef { import('didi').Injector } Injector
- *
- * @typedef { { [x: string]: any } } Data
- * @typedef { { [x: string]: string[] } } Errors
- * @typedef { any[] } Modules
- * @typedef { ('readOnly' | string) } FormProperty
- * @typedef { ('submit' | 'changed' | string) } FormEvent
- * @typedef { { [x: string]: any } } FormProperties
- * @typedef { any } Schema
- *
- * @typedef { {
- *   additionalModules?: Modules,
- *   container?: Element|string,
- *   injector?: Injector,
- *   modules?: Modules,
- *   properties?: FormProperties
- * } } FormOptions
+ * @typedef { import('./types').Injector } Injector
+ * @typedef { import('./types').Data } Data
+ * @typedef { import('./types').Errors } Errors
+ * @typedef { import('./types').Schema } Schema
+ * @typedef { import('./types').FormProperties } FormProperties
+ * @typedef { import('./types').FormProperty } FormProperty
+ * @typedef { import('./types').FormEvent } FormEvent
+ * @typedef { import('./types').FormOptions } FormOptions
  *
  * @typedef { {
  *   data: Data,
@@ -42,6 +33,9 @@ import core from './core';
  */
 
 
+/**
+ * The form.
+ */
 export default class Form {
 
   /**

--- a/packages/form-js-viewer/src/index.js
+++ b/packages/form-js-viewer/src/index.js
@@ -11,28 +11,13 @@ export {
 };
 
 /**
- * @typedef { import('didi').Injector } Injector
- *
- * @typedef { { [x: string]: any } } Data
- * @typedef { any } Schema
- * @typedef { any[] } Modules
- * @typedef { { [x: string]: any } } FormPropertyOptions
- *
- * @typedef { {
- *   additionalModules?: Modules,
- *   container?: Element|string,
- *   data?: Data,
- *   injector?: Injector,
- *   modules?: Modules,
- *   properties?: FormPropertyOptions,
- *   schema: Schema
- * } } FormViewerOptions
+ * @typedef { import('./types').CreateFormOptions } CreateFormOptions
  */
 
 /**
  * Create a form.
  *
- * @param {FormViewerOptions} options
+ * @param {CreateFormOptions} options
  *
  * @return {Promise<Form>}
  */

--- a/packages/form-js-viewer/src/types.d.ts
+++ b/packages/form-js-viewer/src/types.d.ts
@@ -1,0 +1,36 @@
+import { Injector } from 'didi';
+
+export type Module = any;
+export type Schema = any;
+
+export interface Data {
+  [x: string]: any;
+}
+
+export interface Errors {
+  [x: string]: string[];
+}
+
+export type FormProperty = ('readOnly' | string);
+export type FormEvent = ('submit' | 'changed' | string);
+
+export interface FormProperties {
+  [x: string]: any;
+}
+
+export interface FormOptions {
+  additionalModules?: Module[];
+  container?: Element | string;
+  injector?: Injector;
+  modules?: Module[];
+  properties?: FormProperties;
+}
+
+export interface CreateFormOptions extends FormOptions {
+  data?: Data;
+  schema: Schema;
+}
+
+export {
+  Injector
+};

--- a/packages/form-js/test/spec/Form.spec.js
+++ b/packages/form-js/test/spec/Form.spec.js
@@ -11,6 +11,11 @@ import {
   isSingleStart
 } from '../TestHelper';
 
+import {
+  expect
+} from 'chai';
+
+
 insertStyles();
 
 const singleStart = isSingleStart('basic');
@@ -113,6 +118,7 @@ describe('viewer exports', function() {
       expect(field).to.have.property('id');
     });
   });
+
 
   it('should expose schemaVersion', function() {
     expect(typeof schemaVersion).to.eql('number');

--- a/packages/form-js/test/spec/FormEditor.spec.js
+++ b/packages/form-js/test/spec/FormEditor.spec.js
@@ -8,6 +8,10 @@ import schema from './form.json';
 
 import { insertStyles } from '../TestHelper';
 
+import {
+  expect
+} from 'chai';
+
 insertStyles();
 
 
@@ -41,6 +45,21 @@ describe('editor exports', function() {
     const formEditor = new FormEditor({ container });
 
     await formEditor.importSchema(schema);
+
+    // then
+    expect(formEditor).to.exist;
+  });
+
+
+  it('should instantiate with additional options', async function() {
+
+    // when
+    const formEditor = new FormEditor({
+      container,
+      foo: {
+        bar: true
+      }
+    });
 
     // then
     expect(formEditor).to.exist;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
   "include": [
     "packages/form-js-viewer/src",
     "packages/form-js-editor/src",
-    "packages/form-js-example/src",
-    "packages/form-js/src"
+    "packages/form-js/src",
+    "packages/form-js/test/spec"
   ],
   "exclude": [
     "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "packages/form-js-viewer/src",
     "packages/form-js-editor/src",
     "packages/form-js/src",
-    "packages/form-js/test/spec"
+    "packages/form-js/test/spec",
+    "packages/form-js-integration/src"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
This PR externalizes our type definitions as TypeScript apparently [strips types in the weirdest of ways](https://github.com/bpmn-io/form-js/issues/142).

As part of the PR we also ensure we got more test coverage on the existing API surface we expose (https://github.com/bpmn-io/form-js/commit/4e0a2d108a27681919ea6d7d921076046b37a0af). Breaking APIs is bad, breaking APIs + type definitions is even worse.

---

Closes #142 