### PR TITLE
fix: fix container type

### DIFF
--- a/packages/form-js-editor/src/types.d.ts
+++ b/packages/form-js-editor/src/types.d.ts
@@ -9,7 +9,7 @@ export interface FormEditorProperties {
 
 export interface FormEditorOptions {
   additionalModules?: Module[];
-  container?: Element|string;
+  container?: Element | null | string;
   exporter?: {
     name: string,
     version: string

--- a/packages/form-js-integration/src/application.ts
+++ b/packages/form-js-integration/src/application.ts
@@ -11,11 +11,9 @@ import {
  * A TypeScript application that verifies our type
  * definitions are stable (enough).
  */
-export async function createApp(options: { container: Element }) {
+export async function createApp() {
 
-  const {
-    container
-  } = options;
+  const container = document.querySelector('#app');
 
   await createForm({
     schema: {},
@@ -48,7 +46,7 @@ export async function createApp(options: { container: Element }) {
 
   // eslint-disable-next-line
   const formEditorExtraOpts = new FormEditor({
-    container,
+    container: '#app',
     foo: {
       bar: true
     }

--- a/packages/form-js-viewer/src/types.d.ts
+++ b/packages/form-js-viewer/src/types.d.ts
@@ -20,7 +20,7 @@ export interface FormProperties {
 
 export interface FormOptions {
   additionalModules?: Module[];
-  container?: Element | string;
+  container?: Element | null | string;
   injector?: Injector;
   modules?: Module[];
   properties?: FormProperties;


### PR DESCRIPTION
We are not able to verify this fix automatically using `form-js-integration` since we haven't enabled strict null checks at the moment. I have verified this fix manually.

Closes #144