### PR TITLE
fix(editor): add missing select label

### DIFF
--- a/packages/form-js-editor/src/render/components/properties-panel/PropertiesPanel.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/PropertiesPanel.js
@@ -15,11 +15,12 @@ const labelsByType = {
   button: 'BUTTON',
   checkbox: 'CHECKBOX',
   columns: 'COLUMNS',
+  default: 'FORM',
   number: 'NUMBER',
   radio: 'RADIO',
+  select: 'SELECT',
   text: 'TEXT',
   textfield: 'TEXT FIELD',
-  default: 'FORM'
 };
 
 function getGroups(field, editField) {


### PR DESCRIPTION
### Before

<img width="153" alt="chrome_RmJhv8djBv" src="https://user-images.githubusercontent.com/7633572/129531037-e72366da-295b-4aa4-a20a-5274787158d6.png">

### After

<img width="153" alt="chrome_420EewSfTf" src="https://user-images.githubusercontent.com/7633572/129530920-2e4354a8-a4a2-49b0-8344-b7d2574fc47e.png">
