### PR TITLE
feat(editor): add editor action to select form field

### DIFF
--- a/packages/form-js-editor/src/features/editor-actions/FormEditorActions.js
+++ b/packages/form-js-editor/src/features/editor-actions/FormEditorActions.js
@@ -15,18 +15,38 @@ export default class FormEditorActions extends EditorActions {
   }
 
   _registerDefaultActions(injector) {
-    const commandStack = injector.get('commandStack', false);
+    const commandStack = injector.get('commandStack', false),
+          formFieldRegistry = injector.get('formFieldRegistry', false),
+          selection = injector.get('selection', false);
 
     if (commandStack) {
 
       // @ts-ignore
-      this.register('undo', function() {
+      this.register('undo', () => {
         commandStack.undo();
       });
 
       // @ts-ignore
-      this.register('redo', function() {
+      this.register('redo', () => {
         commandStack.redo();
+      });
+    }
+
+    if (formFieldRegistry && selection) {
+
+      // @ts-ignore
+      this.register('selectFormField', (options = {}) => {
+        const { id } = options;
+
+        if (!id) {
+          return;
+        }
+
+        const formField = formFieldRegistry.get(id);
+
+        if (formField) {
+          selection.set(formField);
+        }
       });
     }
   }

--- a/packages/form-js-editor/test/spec/features/editor-actions/FormEditorActions.spec.js
+++ b/packages/form-js-editor/test/spec/features/editor-actions/FormEditorActions.spec.js
@@ -67,4 +67,17 @@ describe('features/editor-actions', function() {
     expect(formFieldRegistry.size).to.equal(formFieldsSize + 1);
   }));
 
+
+  it('should select form field', inject(function(editorActions, formFieldRegistry, selection) {
+
+    // given
+    const formField = formFieldRegistry.get('Field_1');
+
+    // when
+    editorActions.trigger('selectFormField', { id: 'Field_1' });
+
+    // then
+    expect(selection.get()).to.equal(formField);
+  }));
+
 });


### PR DESCRIPTION
Select form fields through editor action:

```javascript
editorActions.trigger('selectFormField', { id: 'Field_1' });
```