### PR TITLE
ci: wait for published before executing post release steps

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -16,6 +16,26 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set TAG
+      run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+    - name: Wait for published
+      run: |
+        i=0
+        pkg="@bpmn-io/form-js@${{ env.TAG }}"
+
+        until [ $i -gt 10 ]
+        do
+          echo "Checking for $pkg in npm registry..."
+
+          info=$(npm info $pkg)
+          if [[ "$info" != "" ]]; then
+            echo "Found."
+            break
+          fi
+
+          ((i++))
+          sleep 15s
+        done
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
@@ -29,8 +49,6 @@ jobs:
         restore-keys: |
           ${{ runner.OS }}-node-
           ${{ runner.OS }}-
-    - name: Set TAG
-      run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
     - name: Check for stable release
       run: |
         if [[ ${{ env.TAG }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]


### PR DESCRIPTION
Basically the idea is to wait in a loop for npm to make published packages available, which may take some time.

Maximum time we wait is 2:30 min.

Closes https://github.com/bpmn-io/form-js/issues/141