### PR TITLE
Fix CI scripts

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Wait for published
       env:
         PKG: '@bpmn-io/form-js@${{ env.TAG }}'
-      run: bash tasks/await-published
+      run: tasks/await-published
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
@@ -47,18 +47,18 @@ jobs:
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
         BPMN_IO_DEMO_ENDPOINT: ${{ secrets.BPMN_IO_DEMO_ENDPOINT }}
-      run: bash tasks/stages/update-demo
+      run: tasks/stages/update-demo
     - name: Update examples
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
-      run: bash tasks/stages/update-examples
+      run: tasks/stages/update-examples
     - name: Update website
       if: ${{ env.STABLE_RELEASE == 'true' }}
       env:
         BPMN_IO_TOKEN: ${{ secrets.BPMN_IO_TOKEN }}
         BPMN_IO_EMAIL: ${{ secrets.BPMN_IO_EMAIL }}
         BPMN_IO_USERNAME: ${{ secrets.BPMN_IO_USERNAME }}
-      run: bash tasks/stages/update-website
+      run: tasks/stages/update-website

--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -19,23 +19,9 @@ jobs:
     - name: Set TAG
       run: echo "TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
     - name: Wait for published
-      run: |
-        i=0
-        pkg="@bpmn-io/form-js@${{ env.TAG }}"
-
-        until [ $i -gt 10 ]
-        do
-          echo "Checking for $pkg in npm registry..."
-
-          info=$(npm info $pkg)
-          if [[ "$info" != "" ]]; then
-            echo "Found."
-            break
-          fi
-
-          ((i++))
-          sleep 15s
-        done
+      env:
+        PKG: '@bpmn-io/form-js@${{ env.TAG }}'
+      run: bash tasks/await-published
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:

--- a/tasks/await-published
+++ b/tasks/await-published
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eo pipefail
+shopt -s inherit_errexit nullglob
+
+i=0
+pkg="$PKG"
+until [ $i -gt 10 ]
+do
+  echo "Checking for $pkg in npm registry ($((i+1))/10)"
+  info=$(npm info $pkg)
+  if [[ "$info" != "" ]]; then
+    echo "Found."
+    break
+  fi
+
+  i=$((var+1))
+  sleep 15s
+done

--- a/tasks/stages/update-demo
+++ b/tasks/stages/update-demo
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -euo pipefail
+set -eo pipefail
 shopt -s inherit_errexit nullglob
 
 # bumps form-js dependencies in bpmn-io-demo
@@ -18,14 +18,19 @@ cd "$CLONE_DIR"
 
 npm install --save @bpmn-io/form-js@$TAG diagram-js@latest
 
-git config user.email "$BPMN_IO_EMAIL"
-git config user.name "$BPMN_IO_USERNAME"
-git config push.default simple
+if [[ "x$SKIP_COMMIT" = "x" ]]; then
 
-git add -A
-git commit -m "deps: bump to form-js@$TAG"
-git tag "form-js-$TAG"
-git push -q &2>/dev/null
-git push --tags -q &2>/dev/null
+  git config user.email "$BPMN_IO_EMAIL"
+  git config user.name "$BPMN_IO_USERNAME"
+  git config push.default simple
+
+  git add -A
+  git commit -m "deps: bump to @bpmn-io/form-js@$TAG"
+  git tag "form-js-$TAG"
+  git push -q &2>/dev/null
+  git push --tags -q &2>/dev/null
+else
+  echo "Skipping commit (SKIP_COMMIT=$SKIP_COMMIT)"
+fi
 
 cd "$PWD"

--- a/tasks/stages/update-demo
+++ b/tasks/stages/update-demo
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -eo pipefail
 shopt -s inherit_errexit nullglob

--- a/tasks/stages/update-examples
+++ b/tasks/stages/update-examples
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -euo pipefail
+set -eo pipefail
 shopt -s inherit_errexit nullglob
 
 # update form-js version in the <form-js-examples> project
@@ -24,7 +24,9 @@ sed -i -E "s#/form-js@[^/]+/#/form-js@$TOOLKIT_VERSION/#" **/*.{html,md}
 # update via npm if possible
 for dir in $(ls -d */)
 do
-  (cd $dir && [[ -f "package.json" ]] && npm install "@bpmn-io/form-js@$TOOLKIT_VERSION")
+  if [[ -f "$dir/package.json" ]]; then
+    (cd $dir && npm install "@bpmn-io/form-js@$TOOLKIT_VERSION")
+  fi
 done
 
 if [[ "x$SKIP_COMMIT" = "x" ]]; then
@@ -35,7 +37,7 @@ if [[ "x$SKIP_COMMIT" = "x" ]]; then
 
   # add all resources
   git add -A
-  git commit -m "deps: bump to form-js@$TAG"
+  git commit -m "deps: bump to @bpmn-io/form-js@$TAG"
   git tag "$TAG"
   git push -q &2>/dev/null
   git push --tags -q &2>/dev/null

--- a/tasks/stages/update-examples
+++ b/tasks/stages/update-examples
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -eo pipefail
 shopt -s inherit_errexit nullglob

--- a/tasks/stages/update-website
+++ b/tasks/stages/update-website
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -euo pipefail
+set -eo pipefail
 shopt -s inherit_errexit nullglob
 
 # update dmn-js version in the <bpmn.io> project
@@ -29,7 +29,7 @@ if [[ "x$SKIP_COMMIT" = "x" ]]; then
 
   # add all resources
   git add -A
-  git commit -m "deps: bump to form-js@$TAG"
+  git commit -m "deps: bump to @bpmn-io/form-js@$TAG"
   git push -q &2>/dev/null
 else
   echo "Skipping commit (SKIP_COMMIT=$SKIP_COMMIT)"

--- a/tasks/stages/update-website
+++ b/tasks/stages/update-website
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -eo pipefail
 shopt -s inherit_errexit nullglob


### PR DESCRIPTION
This should resolve our `POST_RELEASE` CI failures, e.g. [this one](https://github.com/bpmn-io/form-js/actions/runs/1198257674).

---

* Move `await-published` to own task (https://github.com/bpmn-io/form-js/commit/6d7a2cb71cdc1a68acab3f1b93787e47924731c5)
* Fix `await-published` to properly increment on wait
* Correct `update-example` and `update-website` hooks to work with strict error handling