### PR TITLE
fix(viewer): always render label

### DIFF
--- a/packages/form-js-viewer/src/render/components/Label.js
+++ b/packages/form-js-viewer/src/render/components/Label.js
@@ -5,15 +5,13 @@ export default function Label(props) {
     required = false
   } = props;
 
-  if (!label) {
-    return null;
-  }
-
-  return <label for={ id } class="fjs-form-field-label">
-    { props.children }
-    { label }
-    {
-      required && <span class="fjs-asterix">*</span>
-    }
-  </label>;
+  return (
+    <label for={ id } class="fjs-form-field-label">
+      { props.children }
+      { label || '' }
+      {
+        required && <span class="fjs-asterix">*</span>
+      }
+    </label>
+  );
 }

--- a/packages/form-js-viewer/test/spec/render/components/Label.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Label.spec.js
@@ -67,17 +67,20 @@ describe('Label', function() {
   });
 
 
-  it('should not render if no label', function() {
+  it('should render empty also without text', function() {
 
     // when
     const { container } = createLabel({
-      id: 'foo'
+      id: 'foo',
+      required: true
     });
 
     // then
     const label = container.querySelector('.fjs-form-field-label');
+    const requiredIndicator = container.querySelector('.fjs-asterix');
 
-    expect(label).not.to.exist;
+    expect(label).to.exist;
+    expect(requiredIndicator).to.exist;
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -76,6 +76,23 @@ describe('Checkbox', function() {
   });
 
 
+  it('should render without label', function() {
+
+    // when
+    const { container } = createCheckbox({
+      field: {
+        ...defaultField,
+        label: ''
+      }
+    });
+
+    // then
+    const label = container.querySelector('label');
+
+    expect(label).to.exist;
+  });
+
+
   it('should render description', function() {
 
     // when


### PR DESCRIPTION
Prevents components wrapped in labels and the required indicator from disappearing.

Closes https://github.com/bpmn-io/form-js/issues/168

----

![capture hbE7uD_optimized](https://user-images.githubusercontent.com/58601/133444318-68086c24-d579-43ea-b3e6-9cac36508b09.gif)
