### PR TITLE
Represent Empty Values as Null If There Is No Empty Value

### DIFF
--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -214,6 +214,7 @@
 }
 
 .fjs-container .fjs-form-field.fjs-has-errors .fjs-input,
+.fjs-container .fjs-form-field.fjs-has-errors .fjs-select,
 .fjs-container .fjs-form-field.fjs-has-errors .fjs-textarea {
   border-color: var(--color-warning);
 }

--- a/packages/form-js-viewer/src/core/Validator.js
+++ b/packages/form-js-viewer/src/core/Validator.js
@@ -1,3 +1,5 @@
+import { isNil } from 'min-dash';
+
 export default class Validator {
 
   validateField(field, value) {
@@ -17,7 +19,7 @@ export default class Validator {
       ];
     }
 
-    if (validate.required && (typeof value === 'undefined' || value === '')) {
+    if (validate.required && (isNil(value) || value === '')) {
       errors = [
         ...errors,
         'Field is required.'

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -36,7 +36,7 @@ export default function Number(props) {
 
     props.onChange({
       field,
-      value: isNaN(parsedValue) ? undefined : parsedValue
+      value: isNaN(parsedValue) ? null : parsedValue
     });
   };
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -34,7 +34,7 @@ export default function Select(props) {
   const onChange = ({ target }) => {
     props.onChange({
       field,
-      value: target.value === '' ? undefined : target.value
+      value: target.value === '' ? null : target.value
     });
   };
 

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -288,6 +288,32 @@ describe('Form', function() {
   });
 
 
+  it('should render empty', async function() {
+
+    // given
+    const data = {
+      creditor: null,
+      amount: null,
+      invoiceNumber: null,
+      approved: null,
+      approvedBy: null,
+      product: null,
+      language: null,
+      documents: null
+    };
+
+    // when
+    const form = await createForm({
+      container,
+      data,
+      schema: textSchema
+    });
+
+    // then
+    expect(form).to.exist;
+  });
+
+
   it('#clear', async function() {
 
     // given

--- a/packages/form-js-viewer/test/spec/core/Validator.spec.js
+++ b/packages/form-js-viewer/test/spec/core/Validator.spec.js
@@ -97,6 +97,24 @@ describe('Validator', function() {
       });
 
 
+      it('should be invalid (null)', function() {
+
+        // given
+        const field = {
+          validate: {
+            required: true
+          }
+        };
+
+        // when
+        const errors = validator.validateField(field, null);
+
+        // then
+        expect(errors).to.have.length(1);
+        expect(errors[ 0 ]).to.equal('Field is required.');
+      });
+
+
       it('should be invalid (empty string)', function() {
 
         // given

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -61,6 +61,21 @@ describe('Number', function() {
   });
 
 
+  it('should render <null> value', function() {
+
+    // when
+    const { container } = createNumberField({
+      value: null
+    });
+
+    // then
+    const input = container.querySelector('input[type="number"]');
+
+    expect(input).to.exist;
+    expect(input.value).to.equal('');
+  });
+
+
   it('should render default value on value removed', function() {
 
     // given
@@ -163,7 +178,7 @@ describe('Number', function() {
       // then
       expect(onChangeSpy).to.have.been.calledWith({
         field: defaultField,
-        value: undefined
+        value: null
       });
     });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -63,6 +63,20 @@ describe('Select', function() {
   });
 
 
+  it('should render <null> value', function() {
+
+    // when
+    const { container } = createSelect({
+      value: null
+    });
+
+    // then
+    const select = container.querySelector('select');
+
+    expect(select.value).to.equal('');
+  });
+
+
   it('should render disabled', function() {
 
     // when
@@ -146,7 +160,7 @@ describe('Select', function() {
     });
 
 
-    it('should handle change (undefined)', function() {
+    it('should clear', function() {
 
       // given
       const onChangeSpy = spy();
@@ -164,7 +178,7 @@ describe('Select', function() {
       // then
       expect(onChangeSpy).to.have.been.calledWith({
         field: defaultField,
-        value: undefined
+        value: null
       });
     });
 


### PR DESCRIPTION
# Changes

* if there is no empty value (number, select) empty values will be represented as `null`

---

Closes https://github.com/bpmn-io/form-js/issues/169