### PR TITLE
Make `Number` and `Select` controlled components

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -15,7 +15,7 @@ export default function Number(props) {
     disabled,
     errors = [],
     field,
-    value = ''
+    value
   } = props;
 
   const {
@@ -47,7 +47,7 @@ export default function Number(props) {
       id={ prefixId(id) }
       onInput={ onChange }
       type="number"
-      value={ value } />
+      value={ value || '' } />
     <Description description={ description } />
     <Errors errors={ errors } />
   </div>;

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -44,7 +44,7 @@ export default function Select(props) {
       disabled={ disabled }
       id={ prefixId(id) }
       onChange={ onChange }
-      value={ value }>
+      value={ value || '' }>
       <option value=""></option>
       {
         values.map((v) => {

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -77,7 +77,7 @@ describe('Number', function() {
     const { rerender } = render(<Number { ...props } value={ 123 } />, options);
 
     // when
-    rerender(<Number { ...props } value={ undefined } />, options);
+    rerender(<Number { ...props } value={ null } />, options);
 
     // then
     const input = container.querySelector('input[type="number"]');

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -73,6 +73,32 @@ describe('Select', function() {
   });
 
 
+  it('should render default value on value removed', function() {
+
+    // given
+    const props = {
+      disabled: false,
+      errors: [],
+      field: defaultField,
+      onChange: () => {},
+      path: [ defaultField.key ]
+    };
+
+    const options = { container: container.querySelector('.fjs-form') };
+
+    const { rerender } = render(<Select { ...props } value={ 'german' } />, options);
+
+    // when
+    rerender(<Select { ...props } value={ null } />, options);
+
+    // then
+    const input = container.querySelector('select');
+
+    expect(input).to.exist;
+    expect(input.value).to.equal('');
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -174,6 +200,7 @@ describe('Select', function() {
   });
 
 });
+
 
 // helpers //////////
 


### PR DESCRIPTION
Ensures tha `Number` and `Select` elements are properly reset on the UI if the form state is reset:

![capture fJWtot_optimized](https://user-images.githubusercontent.com/58601/133619282-46be6f90-87f0-4883-a6a3-051523313db1.gif)

---

Closes https://github.com/bpmn-io/form-js/issues/155