### PR TITLE
fix(styling): add border radius to context pad

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -90,13 +90,12 @@
   position: absolute;
   top: 3px;
   right: 3px;
-  background-color: white;
-  border-radius: 3px;
   box-shadow: 1px 1px 1px 1px rgb(0 0 0 / 10%);
 }
 
 .fjs-editor-container .fjs-context-pad-item {
   border: none;
+  border-radius: 3px;
   background-color: var(--color-white);
   padding: 0;
   width: 24px;


### PR DESCRIPTION
Closes #167

- move `border-radius` form parent to context pad button itself
- remove unnecessary `background-color` that hides the border radius of the button 

Screenshot:
<img width="171" alt="Screenshot 2021-10-11 at 14 09 03" src="https://user-images.githubusercontent.com/25825387/136787613-0afeeec8-19e9-40df-8fa7-ba4d027fe57a.png">


