### PR TITLE
fix(editor): ensure form fields react to click events

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -83,6 +83,11 @@
   border-color: var(--color-blue-lighten-82) !important;
 }
 
+.fjs-editor-container .fjs-input:disabled,
+.fjs-editor-container .fjs-select:disabled {
+  pointer-events: none;
+}
+
 /**
  * Context Pad
  */


### PR DESCRIPTION
Disabled inputs don't fire events. By setting `pointer-events: none` the events are fired as expected.

![uWTtRe9euy](https://user-images.githubusercontent.com/7633572/137105614-7da502a2-93d8-4396-915c-fbb9409c141a.gif)

Related to https://github.com/camunda/camunda-modeler/issues/2415

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
