### PR TITLE
style(editor): inherit font-family for input elements

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -312,6 +312,7 @@
   border-radius: 3px;
   padding: 4px 8px;
   font-size: 14px;
+  font-family: inherit;
 }
 
 .fjs-editor-container .fjs-properties-panel-input[type=number],
@@ -345,7 +346,7 @@
 }
 
 .fjs-editor-container textarea.fjs-properties-panel-input {
-  font-family: sans-serif;
+  font-family: inherit;
   resize: vertical;
 }
 


### PR DESCRIPTION
Ensure input elements in the editor (properties panel) are using the defined font, ignoring the browser default.

Related to https://github.com/camunda/camunda-modeler/issues/2458

----

Comparison when using IBM Plex Sans as font-family (before => after)
![image](https://user-images.githubusercontent.com/9433996/138275807-3249115c-82b2-484b-aef6-4b62cb11d76d.png) ![image](https://user-images.githubusercontent.com/9433996/138276025-0ed048fb-0890-4dde-9279-7ac9e08f79f6.png)
