### PR TITLE
Update color scheme

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -1,5 +1,46 @@
 .fjs-editor-container {
-  --color-blue-lighten-99: #fafcff;
+  --color-children-border: var(--color-grey-225-10-75);
+  --color-children-selected-border: var(--color-blue-205-100-50);
+  --color-children-selected-background: var(--color-blue-205-100-95);
+  --color-children-hover-border: var(--color-blue-205-100-50);
+  
+  --color-context-pad-item-background: var(--color-white);
+  --color-context-pad-item-fill: var(--color-grey-225-10-35);
+  --color-context-pad-item-hover-fill: var(--color-black);
+
+  --color-palette-container-background: var(--color-grey-225-10-97);
+  --color-palette-container-border: var(--color-grey-225-10-80);
+  --color-palette-header-color: var(--color-text);
+  --color-palette-header-background: var(--color-grey-225-10-95);
+  --color-palette-header-border: var(--color-grey-225-10-80);
+  --color-palette-field-border: var(--color-grey-225-10-80);
+  --color-palette-field-hover-background: var(--color-grey-225-10-95);
+
+  --color-properties-container-background: var(--color-grey-225-10-97);
+  --color-properties-container-border: var(--color-grey-225-10-80);
+  --color-properties-header-background: var(--color-grey-225-10-95);
+  --color-properties-header-border: var(--color-grey-225-10-80);
+  --color-properties-header-icon-fill: var(--color-grey-225-10-35);
+  --color-properties-group-background: var(--color-grey-225-10-95);
+  --color-properties-group-border: var(--color-grey-225-10-80);
+  --color-properties-group-button-fill: var(--color-grey-225-10-35);
+  --color-properties-group-button-hover-fill: var(--color-black);
+  --color-properties-entries-border: var(--color-grey-225-10-80);
+  --color-properties-collapsible-remove-fill: var(--color-grey-225-10-35);
+  --color-properties-collapsible-remove-hover-fill: var(--color-black);
+  --color-properties-description: var(--color-grey-225-10-15);
+  --color-properties-error: var(--color-warning);
+  --color-properties-input-background: var(--color-white);
+  --color-properties-input-border: var(--color-grey-225-10-75);
+  --color-properties-input-error-border: var(--color-warning);
+  --color-properties-input-error-hover-border: var(--color-warning);
+  --color-properties-input-focus-border: var(--color-blue-205-100-50);
+  --color-properties-placeholder: var(--color-grey-225-10-80);
+
+  --color-dragula-background: var(--color-blue-205-100-45);
+  --color-dragula-border: var(--color-blue-205-100-45);
+  --color-dragula-mirror-background: var(--color-white);
+  --color-dragula-mirror-border: var(--color-grey-225-10-80);
 }
 
 .fjs-editor-container {
@@ -41,7 +82,7 @@
 }
 
 .fjs-editor-container .fjs-children .fjs-children {
-  border: dashed 2px var(--color-silver-darken-80);
+  border: dashed 2px var(--color-children-border);
   border-radius: 3px;
 }
 
@@ -75,12 +116,12 @@
 }
 
 .fjs-editor-container .fjs-children > .fjs-element.fjs-editor-selected {
-  border-color: var(--color-blue-lighten-75);
-  background-color: var(--color-blue-lighten-93);
+  border-color: var(--color-children-selected-border);
+  background-color: var(--color-children-selected-background);
 }
 
 .fjs-editor-container .fjs-children > .fjs-element:hover {
-  border-color: var(--color-blue-lighten-82) !important;
+  border-color: var(--color-children-hover-border) !important;
 }
 
 .fjs-editor-container .fjs-input:disabled,
@@ -101,18 +142,18 @@
 .fjs-editor-container .fjs-context-pad-item {
   border: none;
   border-radius: 3px;
-  background-color: var(--color-white);
+  background-color: var(--color-context-pad-item-background);
   padding: 0;
   width: 24px;
   height: 24px;
-  fill: var(--color-grey-base-40);
+  fill: var(--color-context-pad-item-fill);
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
 .fjs-editor-container .fjs-context-pad-item:hover {
-  fill: var(--color-black);
+  fill: var(--color-context-pad-item-hover-fill);
 }
 
 /**
@@ -120,16 +161,17 @@
  */
 .fjs-editor-container .fjs-palette-container {
   width: 200px;
-  background-color: var(--color-silver-base-97);
-  border-right: solid 1px var(--color-silver-darken-80);
+  background-color: var(--color-palette-container-background);
+  border-right: solid 1px var(--color-palette-container-border);
 }
 
 .fjs-editor-container .fjs-palette-header {
   font-size: 12px;
   font-weight: bold;
+  color: var(--color-palette-header-color);
   padding: 10px;
-  border-bottom: solid 1px var(--color-silver-darken-80);
-  background-color: var(--color-silver-darken-94);
+  border-bottom: solid 1px var(--color-palette-header-border);
+  background-color: var(--color-palette-header-background);
 }
 
 .fjs-editor-container .fjs-palette-field {
@@ -139,8 +181,9 @@
   justify-content: flex-start;
   align-items: center;
   flex-direction: row;
-  border-bottom: solid 1px var(--color-silver-darken-80);
+  border-bottom: solid 1px var(--color-palette-field-border);
   font-size: 14px;
+  color: var(--color-text);
 }
 
 .fjs-editor-container .fjs-palette-field-icon {
@@ -148,7 +191,7 @@
 }
 
 .fjs-editor-container .fjs-palette-field:hover {
-  background-color: var(--color-silver-darken-94);
+  background-color: var(--color-palette-field-hover-background);
   cursor: default;
 }
 
@@ -157,9 +200,10 @@
  */
 .fjs-editor-container .fjs-properties-container {
   width: 300px;
-  background-color: var(--color-silver-base-97);
-  border-left: solid 1px var(--color-silver-darken-80);
+  background-color: var(--color-properties-container-background);
+  border-left: solid 1px var(--color-properties-container-border);
   height: 100%;
+  color: var(--color-text);
 }
 
 .fjs-editor-container .fjs-properties-panel * {
@@ -172,8 +216,8 @@
   align-items: center;
   font-size: 14px;
   padding: 10px;
-  background-color: var(--color-silver-darken-94);
-  border-bottom: solid 1px var(--color-silver-darken-80);
+  background-color: var(--color-properties-header-background);
+  border-bottom: solid 1px var(--color-properties-header-border);
 }
 
 .fjs-editor-container .fjs-properties-panel-header-icon {
@@ -181,6 +225,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  fill: var(--color-properties-header-icon-fill);
 }
 
 .fjs-editor-container .fjs-properties-panel-header-type {
@@ -195,8 +240,8 @@
   align-items: center;
   font-size: 14px;
   padding: 10px;
-  border-bottom: solid 1px var(--color-silver-darken-80);
-  background-color: var(--color-silver-darken-94);
+  border-bottom: solid 1px var(--color-properties-group-border);
+  background-color: var(--color-properties-group-background);
 }
 
 .fjs-editor-container .fjs-properties-panel-group-header-buttons .fjs-properties-panel-group-header-button {
@@ -207,7 +252,7 @@
   height: 20px;
   margin-right: 10px;
   padding: 0;
-  fill: var(--color-grey-base-40);
+  fill: var(--color-properties-group-button-fill);
   border: none;
   background: none;
 }
@@ -217,11 +262,11 @@
 }
 
 .fjs-editor-container .fjs-properties-panel-group-header-buttons .fjs-properties-panel-group-header-button:hover {
-  fill: var(--color-black);
+  fill: var(--color-properties-group-button-hover-fill);
 }
 
 .fjs-editor-container .fjs-properties-panel-group-entries {
-  border-bottom: solid 1px var(--color-silver-darken-80);
+  border-bottom: solid 1px var(--color-properties-entries-border);
 }
 
 .fjs-editor-container .fjs-properties-panel-group:last-child .fjs-properties-panel-group-entries {
@@ -266,11 +311,11 @@
   height: 22px;
   width: 22px;
   padding: 0;
-  fill: var(--color-grey-base-40);
+  fill: var(--color-properties-collapsible-remove-fill);
 }
 
 .fjs-editor-container .fjs-properties-panel-collapsible-entry-header-remove-entry:hover {
-  fill: var(--color-black);
+  fill: var(--color-properties-collapsible-remove-hover-fill);
 }
 
 .fjs-editor-container .fjs-properties-panel-collapsible-entry-entries {
@@ -294,11 +339,11 @@
 
 .fjs-editor-container .fjs-properties-panel-label,
 .fjs-editor-container .fjs-properties-panel-description {
-  color: var(--color-grey-base-40);
+  color: var(--color-properties-description);
 }
 
 .fjs-editor-container .fjs-properties-panel-error {
-  color: var(--color-warning);
+  color: var(--color-properties-error);
 }
 
 .fjs-editor-container .fjs-properties-panel-description,
@@ -307,8 +352,8 @@
 }
 
 .fjs-editor-container .fjs-properties-panel-input {
-  background-color: var(--color-white);
-  border: solid 1px var(--color-silver-darken-80);
+  background-color: var(--color-properties-input-background);
+  border: solid 1px var(--color-properties-input-border);
   border-radius: 3px;
   padding: 4px 8px;
   font-size: 14px;
@@ -324,23 +369,23 @@
 }
 
 .fjs-editor-container .fjs-properties-panel-input.fjs-has-error {
-  border-color: var(--color-warning);
+  border-color: var(--color-properties-input-error-border);
 }
 
 .fjs-editor-container .fjs-properties-panel-input.fjs-has-error:focus {
-  border-color: var(--color-warning);
-  box-shadow: 0 0 0 4px var(--color-red-lighten-85), 0 0 0 1px var(--color-silver-darken-80) inset;
+  border-color: var(--color-properties-input-error-hover-border);
+  box-shadow: 0 0 0 4px var(--color-red-360-100-92), 0 0 0 1px var(--color-grey-225-10-75) inset;
 }
 
 .fjs-editor-container .fjs-properties-panel-input:focus {
   outline: none;
-  box-shadow: 0 0 0 4px var(--color-blue-lighten-82), 0 0 0 1px var(--color-silver-darken-80) inset;
-  border: solid 1px var(--color-blue-darken-55);
+  box-shadow: 0 0 0 4px var(--color-blue-205-100-80), 0 0 0 1px var(--color-grey-225-10-75) inset;
+  border: solid 1px var(--color-properties-input-focus-border);
 }
 
 .fjs-editor-container .fjs-properties-panel-placeholder {
   padding: 10px;
-  color: var(--color-silver-darken-80);
+  color: var(--color-properties-placeholder);
   font-size: 14px;
   text-align: center;
 }
@@ -354,8 +399,8 @@
  * Custom Dragula Styles
  */
 .gu-transit {
-  background: var(--color-blue-darken-62) !important;
-  border: solid 2px var(--color-blue-darken-62) !important;
+  background: var(--color-dragula-background) !important;
+  border: solid 2px var(--color-dragula-border) !important;
   border-radius: 3px !important;
   filter: none !important;
   height: 0 !important;
@@ -368,8 +413,8 @@
 }
 
 .gu-mirror {
-  background-color: white !important;
-  border: solid 1px var(--color-silver-darken-80) !important;
+  background-color: var(--color-dragula-mirror-background) !important;
+  border: solid 1px var(--color-dragula-mirror-border) !important;
   border-radius: 3px !important;
   box-shadow: 1px 1px 1px 1px rgb(0 0 0 / 10%) !important;
   display: flex !important;

--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -2,45 +2,42 @@
  * Theming
  */
 .fjs-container {
-  --color-blue-base-65: #4d90ff;
-  --color-blue-base-65-opacity-10: rgba(77, 144, 255, 0.1);
-  --color-blue-darken-48: #005df7;
-  --color-blue-darken-55: #1a70ff;
-  --color-blue-darken-62: #3c85ff;
-  --color-blue-lighten-75: #80b0ff;
-  --color-blue-lighten-82: #a2c5ff;
-  --color-blue-lighten-93: #dbe9ff;
+  --color-grey-225-10-15: hsl(225, 10%, 15%);
+  --color-grey-225-10-35: hsl(225, 10%, 35%);
+  --color-grey-225-10-55: hsl(225, 10%, 55%);
+  --color-grey-225-10-75: hsl(225, 10%, 75%);
+  --color-grey-225-10-80: hsl(225, 10%, 80%);
+  --color-grey-225-10-85: hsl(225, 10%, 85%);
+  --color-grey-225-10-90: hsl(225, 10%, 90%);
+  --color-grey-225-10-95: hsl(225, 10%, 95%); 
+  --color-grey-225-10-97: hsl(225, 10%, 97%);
 
-  --color-silver-base-97: #f8f8f8;
-  --color-silver-lighten-99: #fcfcfc;
-  --color-silver-darken-80: #cdcdcd;
-  --color-silver-darken-87: #dedede;
-  --color-silver-darken-94: #efefef;
+  --color-blue-205-100-45: hsl(205, 100%, 45%);
+  --color-blue-205-100-50: hsl(205, 100%, 50%);
+  --color-blue-205-100-80: hsl(205, 100%, 80%);
+  --color-blue-205-100-95: hsl(205, 100%, 95%);
 
-  --color-grey-base-40: #666666;
-  --color-grey-lighten-56: #909090;
-  --color-grey-darken-23: #3b3b3b;
-  --color-grey-darken-30: #4c4c4c;
-  --color-grey-darken-33: #535353;
+  --color-green-150-86-44: hsl(150, 86%, 44%);
 
-  --color-red-base-62: #ff3d3d;
-  --color-red-darken-38: #C20000;
-  --color-red-lighten-85: #ffb3b3;
+  --color-red-360-100-40: hsl(360, 100%, 40%);
+  --color-red-360-100-45: hsl(360, 100%, 45%);
+  --color-red-360-100-92: hsl(360, 100%, 92%);
+  --color-red-360-100-97: hsl(360, 100%, 97%);
 
-  --color-black: #000000;
-  --color-white: #ffffff;
+  --color-white: hsl(0, 0%, 100%);
+  --color-black: hsl(0, 0%, 0%); 
 
   --color-background: var(--color-white);
-  --color-background-disabled: var(--color-silver-darken-94);
-  --color-text: var(--color-grey-darken-23);
-  --color-text-light: var(--color-grey-lighten-56);
-  --color-text-lighter: var(--color-grey-base-40);
+  --color-background-disabled: var(--color-grey-225-10-95);
+  --color-text: var(--color-grey-225-10-15);
+  --color-text-light: var(--color-grey-225-10-35);
+  --color-text-lighter: var(--color-grey-225-10-55);
   --color-text-inverted: var(--color-white);
-  --color-borders: var(--color-grey-lighten-56);
-  --color-borders-disabled: var(--color-silver-darken-80);
-  --color-warning: var(--color-red-base-62);
-  --color-accent: var(--color-blue-darken-62);
-  --color-accent-dark: var(--color-blue-darken-48);
+  --color-borders: var(--color-grey-225-10-55);
+  --color-borders-disabled: var(--color-grey-225-10-75);
+  --color-warning: var(--color-red-360-100-45);
+  --color-accent: var(--color-blue-205-100-45);
+  --color-accent-dark: var(--color-blue-205-100-45);
 
   --font-family: 'IBM Plex Sans', sans-serif;
 
@@ -108,7 +105,7 @@
   font-style: italic;
   letter-spacing: .25px;
 
-  color: var(--color-text-light);
+  color: var(--color-text-lighter);
 }
 
 .fjs-container .fjs-form-field-label {
@@ -236,5 +233,5 @@
 }
 
 .fjs-container .fjs-form-field-text a {
-  color: var(--color-blue-darken-48);
+  color: var(--color-blue-205-100-45);
 }


### PR DESCRIPTION
Closes #192

This replaces the existing color scheme with the new, reduced one [of the Camunda Modeler](https://github.com/camunda/camunda-modeler/issues/2459#issuecomment-951977843).

To try it out

```sh
npx @bpmn-io/sr bpmn-io/form-js#192-update-color-scheme -c 'npm run start:editor'
```

**After**
![image](https://user-images.githubusercontent.com/9433996/140322346-51de53bd-4fc5-4644-833c-c0f0a01ab339.png)

**Before**
![image](https://user-images.githubusercontent.com/9433996/140322212-4ecf8b97-cfcc-41d1-ab53-0d05ecc5d137.png)


-----

Note: I had to add one color for properties panel input box shadows on focus state. I'd propose to use this one until we add the unified form styles (cf. https://github.com/camunda/camunda-modeler/issues/2460). I'm open to discussions for finding better alternatives in the meanwhile.

```css
--color-blue-205-100-80: hsl(205, 100%, 80%);
```
