### PR TITLE
chore(properties-panel): use more specific selectors

### DIFF
--- a/packages/form-js-editor/src/render/components/properties-panel/components/CheckboxInput.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/components/CheckboxInput.js
@@ -13,7 +13,7 @@ export default function CheckboxInput(props) {
   };
 
   return (
-    <div class="fjs-properties-panel-textfield">
+    <div class="fjs-properties-panel-checkbox">
       <label for={ prefixId(id) } class="fjs-properties-panel-label">{ label }</label>
       <input
         id={ prefixId(id) }

--- a/packages/form-js-editor/src/render/components/properties-panel/components/NumberInput.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/components/NumberInput.js
@@ -28,7 +28,7 @@ export default function NumberInput(props) {
   }, [ _onInput ]);
 
   return (
-    <div class="fjs-properties-panel-textfield">
+    <div class="fjs-properties-panel-numberfield">
       <label for={ prefixId(id) } class="fjs-properties-panel-label">{ label }</label>
       <input
         id={ prefixId(id) }

--- a/packages/form-js-editor/src/render/components/properties-panel/components/Select.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/components/Select.js
@@ -14,7 +14,7 @@ export default function Select(props) {
   };
 
   return (
-    <div class="fjs-properties-panel-textfield">
+    <div class="fjs-properties-panel-select">
       <label for={ prefixId(id) } class="fjs-properties-panel-label">{ label }</label>
       <select id={ prefixId(id) } class="fjs-properties-panel-input" onInput={ handleChange }>
         {

--- a/packages/form-js-editor/src/render/components/properties-panel/components/Textarea.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/components/Textarea.js
@@ -22,7 +22,7 @@ export default function Textarea(props) {
   }, [ _onInput ]);
 
   return (
-    <div class="fjs-properties-panel-textfield">
+    <div class="fjs-properties-panel-textarea">
       <label for={ prefixId(id) } class="fjs-properties-panel-label">{ label }</label>
       <textarea
         id={ prefixId(id) }


### PR DESCRIPTION
Instead of using the `fjs-properties-panel-textfield` class for all properties panel inputs, let's use more specific ones. That would make it easier to override certain field styles (e.g. during https://github.com/camunda/camunda-modeler/issues/2460).

We don't use `fjs-properties-panel-textfield` anywhere so far, so this change shouldn't break anything.