### PR TITLE
fix(viewer): do not submit data without corresponding field

### DIFF
--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -169,21 +169,24 @@ export default class Form {
 
     const formFieldRegistry = this.get('formFieldRegistry');
 
-    // do not submit disabled form fields
     const data = formFieldRegistry.getAll().reduce((data, field) => {
       const {
         disabled,
         _path
       } = field;
 
-      if (disabled) {
-
-        // strip disabled field value
-        set(data, _path, undefined);
+      // do not submit disabled form fields
+      if (disabled || !_path) {
+        return data;
       }
 
-      return data;
-    }, clone(this._getState().data));
+      const value = get(this._getState().data, _path);
+
+      return {
+        ...data,
+        [ _path[ 0 ] ]: value
+      };
+    }, {});
 
     const errors = this.validate();
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -64,3 +64,4 @@ Checkbox.create = function(options = {}) {
 Checkbox.type = type;
 Checkbox.label = 'Checkbox';
 Checkbox.keyed = true;
+Checkbox.emptyValue = false;

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -68,3 +68,4 @@ Number.create = function(options = {}) {
 Number.type = type;
 Number.keyed = true;
 Number.label = 'Number';
+Number.emptyValue = null;

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -84,3 +84,4 @@ Radio.create = function(options = {}) {
 Radio.type = type;
 Radio.label = 'Radio';
 Radio.keyed = true;
+Radio.emptyValue = null;

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -85,3 +85,4 @@ Select.create = function(options = {}) {
 Select.type = type;
 Select.label = 'Select';
 Select.keyed = true;
+Select.emptyValue = null;

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -66,3 +66,4 @@ Textfield.create = function(options = {}) {
 Textfield.type = type;
 Textfield.label = 'Text Field';
 Textfield.keyed = true;
+Textfield.emptyValue = '';

--- a/packages/form-js-viewer/test/spec/import/Importer.spec.js
+++ b/packages/form-js-viewer/test/spec/import/Importer.spec.js
@@ -19,202 +19,260 @@ describe('Importer', function() {
   });
 
 
-  it('should import without errors', inject(async function(form, formFieldRegistry) {
+  describe('form fields', function() {
 
-    // given
-    const data = {
-      creditor: 'John Doe Company',
-      amount: 456,
-      invoiceNumber: 'C-123',
-      approved: true,
-      approvedBy: 'John Doe',
-      product: 'camunda-cloud',
-      language: 'english'
-    };
-
-    // when
-    const { err, warnings } = await form.importSchema(schema, data);
-
-    // then
-    expect(err).not.to.exist;
-    expect(warnings).to.be.empty;
-
-    expect(formFieldRegistry.getAll()).to.have.length(11);
-  }));
-
-
-  it('should reimport without errors', inject(async function(form, formFieldRegistry) {
-
-    // given
-    const data = {
-      creditor: 'John Doe Company',
-      amount: 456,
-      invoiceNumber: 'C-123',
-      approved: true,
-      approvedBy: 'John Doe',
-      product: 'camunda-cloud',
-      language: 'english'
-    };
-
-    let result = await form.importSchema(schema, data);
-
-    // assume
-    expect(result.err).not.to.exist;
-    expect(result.warnings).to.be.empty;
-
-    expect(formFieldRegistry.getAll()).to.have.length(11);
-
-    // when
-    result = await form.importSchema(other, data);
-
-    // then
-    expect(result.err).not.to.exist;
-    expect(result.warnings).to.be.empty;
-
-    expect(formFieldRegistry.getAll()).to.have.length(5);
-  }));
-
-
-  describe('error handling', function() {
-
-    it('should indicate unsupported field type', inject(async function(form) {
+    it('should import without errors', inject(async function(form, formFieldRegistry) {
 
       // given
-      const errorSchema = {
-        type: 'unknown'
+      const data = {
+        creditor: 'John Doe Company',
+        amount: 456,
+        invoiceNumber: 'C-123',
+        approved: true,
+        approvedBy: 'John Doe',
+        product: 'camunda-cloud',
+        language: 'english'
       };
 
-      let error;
-
       // when
-      try {
-        await form.importSchema(errorSchema);
-      } catch (err) {
-        error = err;
-      }
+      const { err, warnings } = await form.importSchema(schema, data);
 
       // then
-      expect(error).to.exist;
-      expect(error.message).to.eql('form field of type <unknown> not supported');
+      expect(err).not.to.exist;
+      expect(warnings).to.be.empty;
 
-      expect(error.warnings).to.exist;
-      expect(error.warnings).to.be.empty;
+      expect(formFieldRegistry.getAll()).to.have.length(11);
     }));
 
 
-    it('should indicate duplicate <key>', inject(async function(form) {
+    it('should reimport without errors', inject(async function(form, formFieldRegistry) {
 
       // given
-      const errorSchema = {
-        type: 'default',
-        components: [
-          {
-            key: 'creditor',
-            type: 'textfield'
-          },
-          {
-            key: 'creditor',
-            type: 'textfield'
-          }
-        ]
+      const data = {
+        creditor: 'John Doe Company',
+        amount: 456,
+        invoiceNumber: 'C-123',
+        approved: true,
+        approvedBy: 'John Doe',
+        product: 'camunda-cloud',
+        language: 'english'
       };
 
-      let error;
+      let result = await form.importSchema(schema, data);
+
+      // assume
+      expect(result.err).not.to.exist;
+      expect(result.warnings).to.be.empty;
+
+      expect(formFieldRegistry.getAll()).to.have.length(11);
 
       // when
-      try {
-        await form.importSchema(errorSchema);
-      } catch (err) {
-        error = err;
-      }
+      result = await form.importSchema(other, data);
 
       // then
-      expect(error).to.exist;
-      expect(error.message).to.eql('form field with key <creditor> already exists');
+      expect(result.err).not.to.exist;
+      expect(result.warnings).to.be.empty;
 
-      expect(error.warnings).to.exist;
-      expect(error.warnings).to.be.empty;
+      expect(formFieldRegistry.getAll()).to.have.length(5);
     }));
 
 
-    it('should indicate duplicate <id>', inject(async function(form) {
+    describe('error handling', function() {
 
-      // given
-      const errorSchema = {
-        type: 'default',
-        components: [
-          {
-            id: 'foo',
-            type: 'text'
-          },
-          {
-            id: 'foo',
-            type: 'text'
-          }
-        ]
-      };
+      it('should indicate unsupported field type', inject(async function(form) {
 
-      let error;
+        // given
+        const errorSchema = {
+          type: 'unknown'
+        };
 
-      // when
-      try {
-        await form.importSchema(errorSchema);
-      } catch (err) {
-        error = err;
-      }
+        let error;
 
-      // then
-      expect(error).to.exist;
-      expect(error.message).to.eql('form field with id <foo> already exists');
-
-      expect(error.warnings).to.exist;
-      expect(error.warnings).to.be.empty;
-    }));
-
-
-    it('should handle broken JSON', inject(async function(form) {
-
-      // when
-      try {
-        await form.importSchema('foo');
-      } catch (err) {
+        // when
+        try {
+          await form.importSchema(errorSchema);
+        } catch (err) {
+          error = err;
+        }
 
         // then
-        expect(err).to.exist;
-        expect(err.message).to.equal('form field of type <undefined> not supported');
+        expect(error).to.exist;
+        expect(error.message).to.eql('form field of type <unknown> not supported');
 
-        expect(err.warnings).to.exist;
-        expect(err.warnings).to.be.empty;
-      }
+        expect(error.warnings).to.exist;
+        expect(error.warnings).to.be.empty;
+      }));
+
+
+      it('should indicate duplicate <key>', inject(async function(form) {
+
+        // given
+        const errorSchema = {
+          type: 'default',
+          components: [
+            {
+              key: 'creditor',
+              type: 'textfield'
+            },
+            {
+              key: 'creditor',
+              type: 'textfield'
+            }
+          ]
+        };
+
+        let error;
+
+        // when
+        try {
+          await form.importSchema(errorSchema);
+        } catch (err) {
+          error = err;
+        }
+
+        // then
+        expect(error).to.exist;
+        expect(error.message).to.eql('form field with key <creditor> already exists');
+
+        expect(error.warnings).to.exist;
+        expect(error.warnings).to.be.empty;
+      }));
+
+
+      it('should indicate duplicate <id>', inject(async function(form) {
+
+        // given
+        const errorSchema = {
+          type: 'default',
+          components: [
+            {
+              id: 'foo',
+              type: 'text'
+            },
+            {
+              id: 'foo',
+              type: 'text'
+            }
+          ]
+        };
+
+        let error;
+
+        // when
+        try {
+          await form.importSchema(errorSchema);
+        } catch (err) {
+          error = err;
+        }
+
+        // then
+        expect(error).to.exist;
+        expect(error.message).to.eql('form field with id <foo> already exists');
+
+        expect(error.warnings).to.exist;
+        expect(error.warnings).to.be.empty;
+      }));
+
+
+      it('should handle broken JSON', inject(async function(form) {
+
+        // when
+        try {
+          await form.importSchema('foo');
+        } catch (err) {
+
+          // then
+          expect(err).to.exist;
+          expect(err.message).to.equal('form field of type <undefined> not supported');
+
+          expect(err.warnings).to.exist;
+          expect(err.warnings).to.be.empty;
+        }
+      }));
+
+
+      // TODO: Catch broken schema errors during import
+      it.skip('should error if broken schema is imported', inject(async function(form) {
+
+        // given
+        const errorSchema = clone(schema);
+
+        errorSchema.components.push({
+          type: 'select',
+          key: 'foo',
+          values: 123
+        });
+
+        let error;
+
+        // when
+        try {
+          await form.importSchema(errorSchema);
+        } catch (err) {
+          error = err;
+        }
+
+        // then
+        expect(error).to.exist;
+
+        expect(error.warnings).to.exist;
+        expect(error.warnings).to.be.empty;
+      }));
+
+    });
+
+  });
+
+
+  describe('data', function() {
+
+    it('should import data', inject(async function(form, formFieldRegistry) {
+
+      // given
+      const data = {
+        creditor: 'John Doe Company',
+        amount: 456,
+        invoiceNumber: 'C-123',
+        approved: true,
+        approvedBy: 'John Doe',
+        product: 'camunda-cloud',
+        language: 'english'
+      };
+
+      // when
+      await form.importSchema(schema, data);
+
+      // then
+      expect(form._getState().data).to.eql({
+        creditor: 'John Doe Company',
+        invoiceNumber: 'C-123',
+        amount: 456,
+        approved: true,
+        approvedBy: 'John Doe',
+        product: 'camunda-cloud',
+        language: 'english'
+      });
     }));
 
 
-    // TODO: Catch broken schema errors during import
-    it.skip('should error if broken schema is imported', inject(async function(form) {
+    it('should import data (empty)', inject(async function(form) {
 
       // given
-      const errorSchema = clone(schema);
-
-      errorSchema.components.push({
-        type: 'select',
-        key: 'foo',
-        values: 123
-      });
-
-      let error;
+      const data = {};
 
       // when
-      try {
-        await form.importSchema(errorSchema);
-      } catch (err) {
-        error = err;
-      }
+      await form.importSchema(schema, data);
 
       // then
-      expect(error).to.exist;
-
-      expect(error.warnings).to.exist;
-      expect(error.warnings).to.be.empty;
+      expect(form._getState().data).to.eql({
+        creditor: '',
+        invoiceNumber: '',
+        amount: null,
+        approved: false,
+        approvedBy: '',
+        product: null,
+        language: null
+      });
     }));
 
   });


### PR DESCRIPTION
As discussed with @marstamm, @MaxTru and @nikku we consider the current behavior to be a bug. No data should be submitted if there is no corresponding form field.

### Changes

* instead of creating submitted data based on imported data and edited data submitted data is now created based on form fields
* data will be submitted for every form field that is not disabled
* no other data will be submitted
* initial data for every form field will be created during import

### Example

```javascript
const data = {
  name: 'John',
  surname: 'Doe'
};

const schema = {
  "components": [
    {
      "key": "name",
      "type": "textfield"
    }.
    {
      "key": "email",
      "type": "textfield"
    },
    {
      "key": "retired",
      "type": "boolean"
    }
  ],
  "type": "default"
}

const form = await createForm({
  container,
  data,
  schema
});

const { data } = form.submit();

console.log(data); // { name: 'John Doe', email: '', retired: false }
```

No form field exists for `surname`. Therefore no data will be submitted for `surname`.
No data exists for `email` but a form field of the type text exists. Thus, empty data (`''`) for `email` will be submitted.
No data exists for `retired` but a form field exists. Thus, empty data (`false`) for `retired` will be submitted.

---

Closes #209
Related to https://github.com/camunda/camunda-modeler/issues/2541
