### PR TITLE
Add Default Values to Form Fields

### DIFF
--- a/packages/form-js-editor/src/render/components/properties-panel/components/SelectEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/components/SelectEntry.js
@@ -1,0 +1,32 @@
+import { get } from 'min-dash';
+
+import Select from './Select';
+
+export default function SelectEntry(props) {
+  const {
+    editField,
+    field,
+    id,
+    description,
+    label,
+    options,
+    path
+  } = props;
+
+  const onChange = (value) => {
+    if (editField && path) {
+      editField(field, path, value);
+    } else {
+      props.onChange(value);
+    }
+  };
+
+  const value = path ? get(field, path, '') : props.value;
+
+  return (
+    <div class="fjs-properties-panel-entry">
+      <Select id={ id } label={ label } onChange={ onChange } options={ options } value={ value } />
+      { description && <div class="fjs-properties-panel-description">{ description }</div> }
+    </div>
+  );
+}

--- a/packages/form-js-editor/src/render/components/properties-panel/components/index.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/components/index.js
@@ -6,6 +6,7 @@ export { default as TextInput } from './TextInput';
 
 export { default as CheckboxInputEntry } from './CheckboxInputEntry';
 export { default as NumberInputEntry } from './NumberInputEntry';
+export { default as SelectEntry } from './SelectEntry';
 export { default as TextareaEntry } from './TextareaEntry';
 export { default as TextInputEntry } from './TextInputEntry';
 

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/ActionEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/ActionEntry.js
@@ -1,16 +1,10 @@
-import { Select } from '../components';
+import { SelectEntry } from '../components';
 
 export default function ActionEntry(props) {
   const {
     editField,
     field
   } = props;
-
-  const onChange = (value) => {
-    editField(field, 'action', value);
-  };
-
-  const value = field.action;
 
   const options = [
     {
@@ -24,8 +18,12 @@ export default function ActionEntry(props) {
   ];
 
   return (
-    <div class="fjs-properties-panel-entry">
-      <Select id="action" label="Action" options={ options } onChange={ onChange } value={ value } />
-    </div>
+    <SelectEntry
+      editField={ editField }
+      field={ field }
+      id="action"
+      label="Action"
+      options={ options }
+      path={ [ 'action' ] } />
   );
 }

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/DefaultValueEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/DefaultValueEntry.js
@@ -19,9 +19,6 @@ export default function DefaultValueEntry(props) {
   if (type === 'checkbox') {
     const options = [
       {
-        label: '<none>'
-      },
-      {
         label: 'Checked',
         value: 'true'
       },
@@ -32,7 +29,7 @@ export default function DefaultValueEntry(props) {
     ];
 
     const onChange = (value) => {
-      editField(field, [ 'defaultValue' ], parseBoolean(value));
+      editField(field, [ 'defaultValue' ], parseStringToBoolean(value));
     };
 
     return (
@@ -41,7 +38,7 @@ export default function DefaultValueEntry(props) {
         label="Default Value"
         onChange={ onChange }
         options={ options }
-        value={ parseString(defaultValue) } />
+        value={ parseBooleanToString(defaultValue) } />
     );
   }
 
@@ -90,22 +87,18 @@ export default function DefaultValueEntry(props) {
   }
 }
 
-function parseBoolean(value) {
+function parseStringToBoolean(value) {
   if (value === 'true') {
     return true;
-  } else if (value === 'false') {
-    return false;
   }
 
-  return undefined;
+  return false;
 }
 
-function parseString(value) {
+function parseBooleanToString(value) {
   if (value === true) {
     return 'true';
-  } else if (value === false) {
-    return 'false';
   }
 
-  return '';
+  return 'false';
 }

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/DefaultValueEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/DefaultValueEntry.js
@@ -1,0 +1,111 @@
+import {
+  NumberInputEntry,
+  SelectEntry,
+  TextInputEntry
+} from '../components';
+
+export default function DefaultValueEntry(props) {
+  const {
+    editField,
+    field
+  } = props;
+
+  const {
+    defaultValue,
+    type,
+    values = []
+  } = field;
+
+  if (type === 'checkbox') {
+    const options = [
+      {
+        label: '<none>'
+      },
+      {
+        label: 'Checked',
+        value: 'true'
+      },
+      {
+        label: 'Not checked',
+        value: 'false'
+      }
+    ];
+
+    const onChange = (value) => {
+      editField(field, [ 'defaultValue' ], parseBoolean(value));
+    };
+
+    return (
+      <SelectEntry
+        id="defaultValue"
+        label="Default Value"
+        onChange={ onChange }
+        options={ options }
+        value={ parseString(defaultValue) } />
+    );
+  }
+
+  if (type === 'number') {
+    return (
+      <NumberInputEntry
+        editField={ editField }
+        field={ field }
+        id="defaultValue"
+        label="Default Value"
+        path={ [ 'defaultValue' ] } />
+    );
+  }
+
+  if (type === 'radio' || type === 'select') {
+    const options = [
+      {
+        label: '<none>'
+      },
+      ...values
+    ];
+
+    const onChange = (value) => {
+      editField(field, [ 'defaultValue' ], value.length ? value : undefined);
+    };
+
+    return (
+      <SelectEntry
+        id="defaultValue"
+        label="Default Value"
+        onChange={ onChange }
+        options={ options }
+        value={ defaultValue } />
+    );
+  }
+
+  if (type === 'textfield') {
+    return (
+      <TextInputEntry
+        editField={ editField }
+        field={ field }
+        id="defaultValue"
+        label="Default Value"
+        path={ [ 'defaultValue' ] } />
+    );
+  }
+}
+
+function parseBoolean(value) {
+  if (value === 'true') {
+    return true;
+  } else if (value === 'false') {
+    return false;
+  }
+
+  return undefined;
+}
+
+function parseString(value) {
+  if (value === true) {
+    return 'true';
+  } else if (value === false) {
+    return 'false';
+  }
+
+  return '';
+}

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/index.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/index.js
@@ -1,6 +1,7 @@
 export { default as ActionEntry } from './ActionEntry';
 export { default as ColumnsEntry } from './ColumnsEntry';
 export { default as DescriptionEntry } from './DescriptionEntry';
+export { default as DefaultValueEntry } from './DefaultValueEntry';
 export { default as DisabledEntry } from './DisabledEntry';
 export { default as IdEntry } from './IdEntry';
 export { default as KeyEntry } from './KeyEntry';

--- a/packages/form-js-editor/src/render/components/properties-panel/groups/GeneralGroup.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/groups/GeneralGroup.js
@@ -4,6 +4,7 @@ import {
   ActionEntry,
   ColumnsEntry,
   DescriptionEntry,
+  DefaultValueEntry,
   DisabledEntry,
   IdEntry,
   KeyEntry,
@@ -17,7 +18,6 @@ export default function GeneralGroup(field, editField) {
   const { type } = field;
 
   const entries = [];
-
   if (type === 'default') {
     entries.push(<IdEntry editField={ editField } field={ field } />);
   }
@@ -32,6 +32,10 @@ export default function GeneralGroup(field, editField) {
 
   if (INPUTS.includes(type)) {
     entries.push(<KeyEntry editField={ editField } field={ field } />);
+  }
+
+  if (INPUTS.includes(type)) {
+    entries.push(<DefaultValueEntry editField={ editField } field={ field } />);
   }
 
   if (type === 'button') {

--- a/packages/form-js-editor/test/spec/defaultValues.json
+++ b/packages/form-js-editor/test/spec/defaultValues.json
@@ -1,0 +1,91 @@
+{
+  "components": [
+    {
+      "type": "text",
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+    },
+    {
+      "defaultValue": "Max Mustermann GmbH",
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "defaultValue": 0,
+      "key": "amount",
+      "label": "Amount",
+      "type": "number",
+      "validate": {
+        "min": 0,
+        "max": 1000
+      }
+    },
+    {
+      "defaultValue": true,
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "defaultValue": "camunda-platform",
+      "key": "product",
+      "label": "Product",
+      "type": "radio",
+      "values": [
+        {
+          "label": "Camunda Platform",
+          "value": "camunda-platform"
+        },
+        {
+          "label": "Camunda Cloud",
+          "value": "camunda-cloud"
+        }
+      ]
+    },
+    {
+      "defaultValue": "english",
+      "key": "language",
+      "label": "Language",
+      "type": "select",
+      "values": [
+        {
+          "label": "German",
+          "value": "german"
+        },
+        {
+          "label": "English",
+          "value": "english"
+        }
+      ]
+    },
+    {
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
@@ -9,6 +9,7 @@ import PropertiesPanel from '../../../src/render/components/properties-panel/Pro
 import { WithFormEditorContext } from './helper';
 
 import schema from '../form.json';
+import defaultValues from '../defaultValues.json';
 
 import { insertStyles } from '../../TestHelper';
 
@@ -117,27 +118,90 @@ describe('properties panel', function() {
     });
 
 
-    it('checkbox', function() {
+    describe('checkbox', function() {
 
-      // given
-      const field = schema.components.find(({ key }) => key === 'approved');
+      it('entries', function() {
 
-      const result = createPropertiesPanel({
-        container,
-        field
+        // given
+        const field = schema.components.find(({ key }) => key === 'approved');
+
+        const result = createPropertiesPanel({
+          container,
+          field
+        });
+
+        // then
+        expectGroups(result.container, [
+          'General'
+        ]);
+
+        expectGroupEntries(result.container, 'General', [
+          'Field Label',
+          'Field Description',
+          'Key',
+          'Default Value',
+          'Disabled'
+        ]);
       });
 
-      // then
-      expectGroups(result.container, [
-        'General'
-      ]);
 
-      expectGroupEntries(result.container, 'General', [
-        'Field Label',
-        'Field Description',
-        'Key',
-        'Disabled'
-      ]);
+      describe('default value', function() {
+
+        it('should add default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = schema.components.find(({ key }) => key === 'approved');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: 'true' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], true);
+        });
+
+
+        it('should remove default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = defaultValues.components.find(({ key }) => key === 'approved');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('true');
+
+          // when
+          fireEvent.input(input, { target: { value: '' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], undefined);
+        });
+
+      });
+
     });
 
 
@@ -164,6 +228,7 @@ describe('properties panel', function() {
           'Field Label',
           'Field Description',
           'Key',
+          'Default Value',
           'Disabled'
         ]);
 
@@ -175,6 +240,64 @@ describe('properties panel', function() {
         expectGroupEntries(result.container, 'Validation', [
           'Required'
         ]);
+      });
+
+
+      describe('default value', function() {
+
+        it('should add default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = schema.components.find(({ key }) => key === 'product');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: 'camunda-platform' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], 'camunda-platform');
+        });
+
+
+        it('should remove default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = defaultValues.components.find(({ key }) => key === 'product');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('camunda-platform');
+
+          // when
+          fireEvent.input(input, { target: { value: '' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], undefined);
+        });
+
       });
 
 
@@ -261,6 +384,7 @@ describe('properties panel', function() {
           'Field Label',
           'Field Description',
           'Key',
+          'Default Value',
           'Disabled'
         ]);
 
@@ -272,6 +396,64 @@ describe('properties panel', function() {
         expectGroupEntries(result.container, 'Validation', [
           'Required'
         ]);
+      });
+
+
+      describe('default value', function() {
+
+        it('should add default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = schema.components.find(({ key }) => key === 'language');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: 'english' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], 'english');
+        });
+
+
+        it('should remove default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = defaultValues.components.find(({ key }) => key === 'language');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('english');
+
+          // when
+          fireEvent.input(input, { target: { value: '' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], undefined);
+        });
+
       });
 
 
@@ -382,6 +564,7 @@ describe('properties panel', function() {
           'Field Label',
           'Field Description',
           'Key',
+          'Default Value',
           'Disabled'
         ]);
 
@@ -391,6 +574,64 @@ describe('properties panel', function() {
           'Maximum Length',
           'Regular Expression Pattern'
         ]);
+      });
+
+
+      describe('default value', function() {
+
+        it('should add default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = schema.components.find(({ key }) => key === 'creditor');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: 'Max Mustermann GmbH' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], 'Max Mustermann GmbH');
+        });
+
+
+        it('should remove default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = defaultValues.components.find(({ key }) => key === 'creditor');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default Value');
+
+          expect(input.value).to.equal('Max Mustermann GmbH');
+
+          // when
+          fireEvent.input(input, { target: { value: '' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], undefined);
+        });
+
       });
 
 

--- a/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
@@ -198,7 +198,7 @@ describe('properties panel', function() {
           // assume
           const input = screen.getByLabelText('Default Value');
 
-          expect(input.value).to.equal('');
+          expect(input.value).to.equal('false');
 
           // when
           fireEvent.input(input, { target: { value: 'true' } });
@@ -206,33 +206,6 @@ describe('properties panel', function() {
           // then
           expect(editFieldSpy).to.have.been.calledOnce;
           expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], true);
-        });
-
-
-        it('should remove default value', function() {
-
-          // given
-          const editFieldSpy = spy();
-
-          const field = defaultValues.components.find(({ key }) => key === 'approved');
-
-          createPropertiesPanel({
-            container,
-            editField: editFieldSpy,
-            field
-          });
-
-          // assume
-          const input = screen.getByLabelText('Default Value');
-
-          expect(input.value).to.equal('true');
-
-          // when
-          fireEvent.input(input, { target: { value: '' } });
-
-          // then
-          expect(editFieldSpy).to.have.been.calledOnce;
-          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], undefined);
         });
 
       });

--- a/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/properties-panel/PropertiesPanel.spec.js
@@ -96,25 +96,60 @@ describe('properties panel', function() {
     });
 
 
-    it('button', function() {
+    describe('button', function() {
 
-      // given
-      const field = schema.components.find(({ key }) => key === 'submit');
+      it('entries', function() {
 
-      const result = createPropertiesPanel({
-        container,
-        field
+        // given
+        const field = schema.components.find(({ key }) => key === 'submit');
+
+        const result = createPropertiesPanel({
+          container,
+          field
+        });
+
+        // then
+        expectGroups(result.container, [
+          'General'
+        ]);
+
+        expectGroupEntries(result.container, 'General', [
+          'Field Label',
+          'Action'
+        ]);
       });
 
-      // then
-      expectGroups(result.container, [
-        'General'
-      ]);
 
-      expectGroupEntries(result.container, 'General', [
-        'Field Label',
-        'Action'
-      ]);
+      describe('action', function() {
+
+        it('should change action', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = schema.components.find(({ action }) => action === 'reset');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Action');
+
+          expect(input.value).to.equal('reset');
+
+          // when
+          fireEvent.input(input, { target: { value: 'submit' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'action' ], 'submit');
+        });
+
+      });
+
     });
 
 

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -1,6 +1,12 @@
-import { get } from 'min-dash';
+import {
+  get,
+  isUndefined
+} from 'min-dash';
 
-import { clone, generateIdForType } from '../util';
+import {
+  clone,
+  generateIdForType
+} from '../util';
 
 
 export default class Importer {
@@ -123,6 +129,7 @@ export default class Importer {
   importData(data) {
     return this._formFieldRegistry.getAll().reduce((importedData, formField) => {
       const {
+        defaultValue,
         _path,
         type
       } = formField;
@@ -131,9 +138,12 @@ export default class Importer {
         return importedData;
       }
 
+      // (1) try to get value from data
+      // (2) try to get default value from form field
+      // (3) get empty value from form field
       return {
         ...importedData,
-        [ _path[ 0 ] ]: get(data, _path, this._formFields.get(type).emptyValue)
+        [ _path[ 0 ] ]: get(data, _path, isUndefined(defaultValue) ? this._formFields.get(type).emptyValue : defaultValue)
       };
     }, {});
   }

--- a/packages/form-js-viewer/src/index.js
+++ b/packages/form-js-viewer/src/index.js
@@ -4,7 +4,7 @@ export { FormFieldRegistry } from './core';
 export * from './render';
 export * from './util';
 
-const schemaVersion = 2;
+const schemaVersion = 3;
 
 export {
   Form,

--- a/packages/form-js-viewer/test/spec/defaultValues.json
+++ b/packages/form-js-viewer/test/spec/defaultValues.json
@@ -1,0 +1,91 @@
+{
+  "components": [
+    {
+      "type": "text",
+      "text": "# Invoice\n\nLorem _ipsum_ __dolor__ `sit`.\n\nA list of BPMN symbols:\n\n* Start Event\n* Task\n\nLearn more about [forms](https://bpmn.io).\n  \n  \nThis [malicious link](javascript:throw onerror=alert,'some string',123,'haha') __should not work__."
+    },
+    {
+      "defaultValue": "Max Mustermann GmbH",
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "description": "An invoice number in the format: C-123.",
+      "key": "invoiceNumber",
+      "label": "Invoice Number",
+      "type": "textfield",
+      "validate": {
+        "pattern": "^C-[0-9]+$"
+      }
+    },
+    {
+      "defaultValue": 0,
+      "key": "amount",
+      "label": "Amount",
+      "type": "number",
+      "validate": {
+        "min": 0,
+        "max": 1000
+      }
+    },
+    {
+      "defaultValue": true,
+      "key": "approved",
+      "label": "Approved",
+      "type": "checkbox"
+    },
+    {
+      "key": "approvedBy",
+      "label": "Approved By",
+      "type": "textfield"
+    },
+    {
+      "defaultValue": "camunda-platform",
+      "key": "product",
+      "label": "Product",
+      "type": "radio",
+      "values": [
+        {
+          "label": "Camunda Platform",
+          "value": "camunda-platform"
+        },
+        {
+          "label": "Camunda Cloud",
+          "value": "camunda-cloud"
+        }
+      ]
+    },
+    {
+      "defaultValue": "english",
+      "key": "language",
+      "label": "Language",
+      "type": "select",
+      "values": [
+        {
+          "label": "German",
+          "value": "german"
+        },
+        {
+          "label": "English",
+          "value": "english"
+        }
+      ]
+    },
+    {
+      "key": "submit",
+      "label": "Submit",
+      "type": "button"
+    },
+    {
+      "action": "reset",
+      "key": "reset",
+      "label": "Reset",
+      "type": "button"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-viewer/test/spec/import/Importer.spec.js
+++ b/packages/form-js-viewer/test/spec/import/Importer.spec.js
@@ -8,6 +8,7 @@ import { clone } from 'src/util';
 
 import schema from '../form.json';
 import other from '../other.json';
+import defaultValues from '../defaultValues.json';
 
 
 describe('Importer', function() {
@@ -272,6 +273,27 @@ describe('Importer', function() {
         approvedBy: '',
         product: null,
         language: null
+      });
+    }));
+
+
+    it('should import data (default values)', inject(async function(form) {
+
+      // given
+      const data = {};
+
+      // when
+      await form.importSchema(defaultValues, data);
+
+      // then
+      expect(form._getState().data).to.eql({
+        creditor: 'Max Mustermann GmbH',
+        invoiceNumber: '',
+        amount: 0,
+        approved: true,
+        approvedBy: '',
+        product: 'camunda-platform',
+        language: 'english'
       });
     }));
 

--- a/packages/form-js/test/spec/Form.spec.js
+++ b/packages/form-js/test/spec/Form.spec.js
@@ -123,7 +123,7 @@ describe('viewer exports', function() {
   it('should expose schemaVersion', function() {
     expect(typeof schemaVersion).to.eql('number');
 
-    expect(schemaVersion).to.eql(2);
+    expect(schemaVersion).to.eql(3);
   });
 
 


### PR DESCRIPTION
### Changes

* form fields have optional `defaultValue` property
* default value will be used during import if no value is set
* value can be changed after import
* default value can be set through properties panel

### Viewer

Default value is `Max Mustermann GmbH`. Resetting form resets form field to default value.

![Vv8tEH9eDw](https://user-images.githubusercontent.com/7633572/149351457-2107921c-f494-45ef-9f82-4b3c7d9af506.gif)

### Editor

Default value can be set through properties panel.

![muTvgPghww](https://user-images.githubusercontent.com/7633572/149351575-886a94cd-081a-4571-9873-eacba63b3015.gif)

---

Closes #191
