### PR TITLE
fix(editor): override existing `exportDetails`

### DIFF
--- a/packages/form-js-editor/src/FormEditor.js
+++ b/packages/form-js-editor/src/FormEditor.js
@@ -327,8 +327,8 @@ export function exportSchema(schema, exporter, schemaVersion) {
   });
 
   return {
-    schemaVersion,
+    ...cleanedSchema,
     ...exportDetails,
-    ...cleanedSchema
+    schemaVersion
   };
 }

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -411,6 +411,36 @@ describe('FormEditor', function() {
     });
 
 
+    it('should override custom exporter', async function() {
+
+      // given
+      const oldExporter = {
+        name: 'Foo',
+        version: 'bar'
+      };
+
+      const newExporter = {
+        name: 'Baz',
+        version: 'qux'
+      };
+
+      const taggedSchema = exportTagged(schema, oldExporter);
+
+      formEditor = await createFormEditor({
+        container,
+        schema: taggedSchema,
+        exporter: newExporter
+      });
+
+      // when
+      const exportedSchema = formEditor.saveSchema();
+
+      // then
+      expect(exportedSchema.exporter).to.eql(newExporter);
+      expect(exportedSchema).to.eql(exportTagged(schema, newExporter));
+    });
+
+
     it('should generate ids', async function() {
 
       // assume
@@ -721,9 +751,9 @@ function exportTagged(schema, exporter) {
   } : {};
 
   return {
-    schemaVersion,
+    ...schema,
     ...exportDetails,
-    ...schema
+    schemaVersion
   };
 }
 


### PR DESCRIPTION
closes #219

Fix is straight-forward, we just have to use the correct ordering when assigning export attributes so the exporter property does not get overwritten
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
