### PR TITLE
Allowing option values to be loaded from imported data

### DIFF
--- a/packages/form-js-editor/src/render/components/properties-panel/Util.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/Util.js
@@ -41,3 +41,8 @@ export const INPUTS = [
   'select',
   'textfield'
 ];
+
+export const INPUTSWITHOPTIONS = [
+  'select',
+  'radio'
+];

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/OptionsFromKeyEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/OptionsFromKeyEntry.js
@@ -1,0 +1,43 @@
+import { CheckboxInput, TextInput } from '../components';
+
+export default function OptionsFromKeyEntry(props) {
+  const {
+    editField,
+    field
+  } = props;
+
+
+  const onInput = (value) => {
+    if (editField) {
+      editField(field, 'optionsKey', value);
+    }
+
+  };
+
+  const onChange = (value) => {
+    if (editField) {
+      editField(field, ['optionsFromKey'], value);
+      if (value) {
+        editField(field, ['values'], []);
+      } else {
+        editField(field, ['optionsKey'], '');
+      }
+    }
+  };
+
+  const validate = (value) => {
+    if (field.optionsFromKey && value === '') {
+      return 'Please enter key to use for options';
+    }
+  };
+
+
+
+  return (
+    <div class="fjs-properties-panel-entry">
+      <CheckboxInput id="optionsFromKey" label="Option Values From Key" onChange={ onChange } value={ field.optionsFromKey } />
+      {field.optionsFromKey ? <TextInput id="optionsKey" label="Options Key" onInput={ onInput } validate={ validate } value={ field.optionsKey } /> : null}
+    </div>
+  );
+
+}

--- a/packages/form-js-editor/src/render/components/properties-panel/entries/index.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/index.js
@@ -9,3 +9,4 @@ export { default as LabelEntry } from './LabelEntry';
 export { default as TextEntry } from './TextEntry';
 export { default as ValueEntry } from './ValueEntry';
 export { default as CustomValueEntry } from './CustomValueEntry';
+export { default as OptionsFromKeyEntry } from './OptionsFromKeyEntry';

--- a/packages/form-js-editor/src/render/components/properties-panel/groups/GeneralGroup.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/groups/GeneralGroup.js
@@ -1,18 +1,17 @@
 import { Group } from '../components';
-
 import {
   ActionEntry,
   ColumnsEntry,
-  DescriptionEntry,
   DefaultValueEntry,
+  DescriptionEntry,
   DisabledEntry,
   IdEntry,
   KeyEntry,
   LabelEntry,
-  TextEntry
+  OptionsFromKeyEntry,
+  TextEntry,
 } from '../entries';
-
-import { INPUTS } from '../Util';
+import { INPUTS, INPUTSWITHOPTIONS } from '../Util';
 
 export default function GeneralGroup(field, editField) {
   const { type } = field;
@@ -50,9 +49,14 @@ export default function GeneralGroup(field, editField) {
     entries.push(<TextEntry editField={ editField } field={ field } />);
   }
 
+  if (INPUTSWITHOPTIONS.includes(type)) {
+    entries.push(<OptionsFromKeyEntry editField={ editField } field={ field } />);
+  }
+
   if (INPUTS.includes(type)) {
     entries.push(<DisabledEntry editField={ editField } field={ field } />);
   }
+
 
   return (
     <Group label="General">

--- a/packages/form-js-editor/src/render/components/properties-panel/groups/ValuesGroup.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/groups/ValuesGroup.js
@@ -1,24 +1,15 @@
-import {
-  CollapsibleEntry,
-  Group
-} from '../components';
+import { isUndefined } from 'min-dash';
 
+import { CollapsibleEntry, Group } from '../components';
 import { ValueEntry } from '../entries';
-
-import {
-  arrayAdd,
-  arrayRemove
-} from '../Util';
-
-import {
-  isUndefined
-} from 'min-dash';
+import { arrayAdd, arrayRemove } from '../Util';
 
 
 export default function ValuesGroup(field, editField) {
   const {
     id,
-    values = []
+    values = [],
+    optionsFromKey
   } = field;
 
   const addEntry = () => {
@@ -52,7 +43,8 @@ export default function ValuesGroup(field, editField) {
 
   const hasEntries = values.length > 0;
 
-  return (
+  // do not show values group if field is obtaining values from a key
+  return !optionsFromKey ? (
     <Group label="Values" addEntry={ addEntry } hasEntries={ hasEntries }>
       {
         values.map((value, index) => {
@@ -70,5 +62,5 @@ export default function ValuesGroup(field, editField) {
         })
       }
     </Group>
-  );
+  ): <></>;
 }

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -1,16 +1,9 @@
 import 'preact/debug';
 
-import {
-  Playground
-} from '../../src';
-
+import { Playground } from '../../src';
+import { insertCSS, isSingleStart } from '../TestHelper';
 import schema from './form.json';
 import otherSchema from './other-form.json';
-
-import {
-  insertCSS,
-  isSingleStart
-} from '../TestHelper';
 
 insertCSS('Test.css', `
   body, html {
@@ -47,7 +40,11 @@ describe('playground', function() {
       approved: true,
       approvedBy: 'John Doe',
       product: 'camunda-cloud',
-      language: 'english'
+      language: 'english',
+      options: [
+        { label: 'Label1', value: 'Value1' },
+        { label: 'Label2', value: 'Value2' }
+      ]
     };
 
     // when

--- a/packages/form-js-playground/test/spec/form.json
+++ b/packages/form-js-playground/test/spec/form.json
@@ -36,9 +36,13 @@
       "type": "checkbox"
     },
     {
-      "key": "approvedBy",
-      "label": "Approved By",
-      "type": "textfield"
+      "values": [],
+      "label": "Select",
+      "type": "select",
+      "id": "Field_08qjd33",
+      "key": "selectOptionFromKey",
+      "optionsFromKey": true,
+      "optionsKey": "options"
     },
     {
       "key": "product",

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -1,12 +1,6 @@
-import {
-  get,
-  isUndefined
-} from 'min-dash';
+import { get, isUndefined } from 'min-dash';
 
-import {
-  clone,
-  generateIdForType
-} from '../util';
+import { clone, generateIdForType } from '../util';
 
 
 export default class Importer {
@@ -131,7 +125,9 @@ export default class Importer {
       const {
         defaultValue,
         _path,
-        type
+        type,
+        optionsFromKey,
+        optionsKey
       } = formField;
 
       if (!_path) {
@@ -141,9 +137,20 @@ export default class Importer {
       // (1) try to get value from data
       // (2) try to get default value from form field
       // (3) get empty value from form field
+      // (4) return data for keys that are used by other elements (i.e. Select using values from key)
+      if (optionsFromKey) return {
+        ...importedData,
+        [_path[0]]: get(data, _path, isUndefined(defaultValue) ? this._formFields.get(type).emptyValue : defaultValue),
+        [optionsKey]: optionsFromKey ?
+          (typeof get(data, [optionsKey], null) === 'string' ?
+            JSON.parse(get(data, [optionsKey], null)) :
+            get(data, [optionsKey], null))
+          : undefined
+      };
+
       return {
         ...importedData,
-        [ _path[ 0 ] ]: get(data, _path, isUndefined(defaultValue) ? this._formFields.get(type).emptyValue : defaultValue)
+        [_path[0]]: get(data, _path, isUndefined(defaultValue) ? this._formFields.get(type).emptyValue : defaultValue),
       };
     }, {});
   }

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -1,18 +1,14 @@
 import { useContext } from 'preact/hooks';
 
 import { FormContext } from '../../context';
-
+import useService from '../../hooks/useService';
 import Description from '../Description';
 import Errors from '../Errors';
 import Label from '../Label';
-
-import {
-  formFieldClasses,
-  prefixId
-} from '../Util';
+import { formFieldClasses, prefixId } from '../Util';
 
 const type = 'radio';
-
+const placeholderForEditor = [{ label: 'Placeholder 1', value: '' }, { label: 'Placeholder 2', value: '' }];
 
 export default function Radio(props) {
   const {
@@ -27,7 +23,9 @@ export default function Radio(props) {
     id,
     label,
     validate = {},
-    values
+    values,
+    optionsFromKey,
+    optionsKey
   } = field;
 
   const { required } = validate;
@@ -39,6 +37,14 @@ export default function Radio(props) {
     });
   };
 
+  let _values = values;
+  const form = useService('form');
+
+  if (optionsFromKey && optionsKey) {
+    const options = form?._getState()?.initialData && form._getState().initialData[optionsKey];
+    _values = options ? options : placeholderForEditor;
+  }
+
   const { formId } = useContext(FormContext);
 
   return <div class={ formFieldClasses(type, errors) }>
@@ -46,23 +52,24 @@ export default function Radio(props) {
       label={ label }
       required={ required } />
     {
-      values.map((v, index) => {
+      (_values.map((v, index) => {
         return (
           <Label
-            id={ prefixId(`${ id }-${ index }`, formId) }
-            key={ `${ id }-${ index }` }
+            id={ prefixId(`${id}-${index}`, formId) }
+            key={ `${id}-${index}` }
             label={ v.label }
             required={ false }>
             <input
               checked={ v.value === value }
               class="fjs-input"
               disabled={ disabled }
-              id={ prefixId(`${ id }-${ index }`, formId) }
+              id={ prefixId(`${id}-${index}`, formId) }
               type="radio"
               onClick={ () => onChange(v.value) } />
           </Label>
         );
-      })
+      }
+      ))
     }
     <Description description={ description } />
     <Errors errors={ errors } />

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -1,15 +1,11 @@
 import { useContext } from 'preact/hooks';
 
 import { FormContext } from '../../context';
-
+import useService from '../../hooks/useService';
 import Description from '../Description';
 import Errors from '../Errors';
 import Label from '../Label';
-
-import {
-  formFieldClasses,
-  prefixId
-} from '../Util';
+import { formFieldClasses, prefixId } from '../Util';
 
 const type = 'select';
 
@@ -18,7 +14,7 @@ export default function Select(props) {
     disabled,
     errors = [],
     field,
-    value
+    value,
   } = props;
 
   const {
@@ -26,7 +22,9 @@ export default function Select(props) {
     id,
     label,
     validate = {},
-    values
+    values,
+    optionsFromKey,
+    optionsKey
   } = field;
 
   const { required } = validate;
@@ -37,6 +35,13 @@ export default function Select(props) {
       value: target.value === '' ? null : target.value
     });
   };
+  let _values = values;
+  const form = useService('form');
+
+  if (optionsFromKey && optionsKey) {
+    const options = form?._getState()?.initialData && form._getState().initialData[optionsKey];
+    _values = options ? options : [];
+  }
 
   const { formId } = useContext(FormContext);
 
@@ -53,7 +58,7 @@ export default function Select(props) {
       value={ value || '' }>
       <option value=""></option>
       {
-        values.map((v, index) => {
+        _values.map((v, index) => {
           return (
             <option
               key={ `${ id }-${ index }` }


### PR DESCRIPTION
* Adding OptionsFromKeyEntry to GeneralGroup
* added optionFromKey:boolean, optionsKey:string field properties to allow select and radio to load their options form imported data.
* updated importer to import initialData for keys used by selects and radios
* Also refactored playground submit data to properly filter to only fields that are present.

Implements and closes #197 
