### PR TITLE
fix: explicitly declare Validator deps

### DIFF
--- a/packages/form-js-viewer/src/core/Validator.js
+++ b/packages/form-js-viewer/src/core/Validator.js
@@ -57,3 +57,5 @@ export default class Validator {
     return errors;
   }
 }
+
+Validator.$inject = [];


### PR DESCRIPTION
Without `$inject`, in some configurations the minification results in invalid dependencies array.

Closes #240