### PR TITLE
chore(form-js-playground): add build script

### DIFF
--- a/packages/form-js-playground/package.json
+++ b/packages/form-js-playground/package.json
@@ -16,10 +16,12 @@
   "module": "dist/index.es.js",
   "umd:main": "dist/form-playground.umd.js",
   "scripts": {
-    "all": "run-s test",
+    "all": "run-s test build",
+    "build": "rollup -c",
     "start": "SINGLE_START=basic npm run dev",
     "dev": "npm test -- --auto-watch --no-single-run",
-    "test": "karma start"
+    "test": "karma start",
+    "prepublishOnly": "npm run build"
   },
   "license": "SEE LICENSE IN LICENSE",
   "repository": {


### PR DESCRIPTION
Just as any other package, the form-js-playground shall have a `build` task. Without, e.g. the styles won't be packaged. 
