### PR TITLE
chore(package): add `build:watch` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "all": "run-s lint build lint:types test test:distro",
     "build": "lerna run build --sort --stream",
+    "build:watch": "npm run build-watch -- @bpmn-io/form-js",
     "build-distro": "lerna run prepublishOnly --sort",
     "build-watch": "run-s \"lerna-build-watch -- {@}\" -- ",
     "clean": "del-cli \"{node_modules,dist}\" \"packages/*/{node_modules,dist}\"",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "form-js",
   "scripts": {
     "all": "run-s lint build lint:types test test:distro",
+    "build": "lerna run build --sort --stream",
     "build-distro": "lerna run prepublishOnly --sort",
+    "build-watch": "run-s \"lerna-build-watch -- {@}\" -- ",
     "clean": "del-cli \"{node_modules,dist}\" \"packages/*/{node_modules,dist}\"",
     "distro": "run-s clean reinstall build-distro",
     "dev": "run-s build \"lerna-dev -- {@}\" -- ",
@@ -10,7 +12,7 @@
     "dev:editor": "npm run dev -- @bpmn-io/form-js-editor",
     "dev:playground": "npm run dev -- @bpmn-io/form-js-playground",
     "lerna-dev": "lerna run dev --stream --scope",
-    "build": "lerna run build --sort --stream",
+    "lerna-build-watch": "lerna run bundle:watch --stream --scope",
     "lerna-publish": "lerna publish -m \"chore(project): publish %s\"",
     "lint": "eslint packages",
     "lint:types": "tsc --noEmit --pretty",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:editor": "npm run dev -- @bpmn-io/form-js-editor",
     "dev:playground": "npm run dev -- @bpmn-io/form-js-playground",
     "lerna-dev": "lerna run dev --stream --scope",
-    "lerna-build-watch": "lerna run bundle:watch --stream --scope",
+    "lerna-build-watch": "lerna run bundle:watch --stream --parallel --include-dependencies --scope",
     "lerna-publish": "lerna publish -m \"chore(project): publish %s\"",
     "lint": "eslint packages",
     "lint:types": "tsc --noEmit --pretty",


### PR DESCRIPTION
In case you work in a specific library.

```sh
npm run build-watch -- @bpmn-io/form-js-editor
npm run build-watch -- @bpmn-io/form-js-viewer
npm run build-watch -- @bpmn-io/form-js-playground
```


Or to build (watch) the whole library:

```
npm run build:watch
```