### PR TITLE
chore: allow local HTML coverage reports to be generated

### DIFF
--- a/packages/form-js-editor/karma.conf.js
+++ b/packages/form-js-editor/karma.conf.js
@@ -37,7 +37,7 @@ module.exports = function(karma) {
 
     coverageReporter: {
       reporters: [
-        { type: 'lcovonly', subdir: '.' },
+        { type: 'lcov', subdir: '.' }
       ]
     },
 

--- a/packages/form-js-playground/karma.conf.js
+++ b/packages/form-js-playground/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(karma) {
 
     coverageReporter: {
       reporters: [
-        { type: 'lcovonly', subdir: '.' },
+        { type: 'lcov', subdir: '.' }
       ]
     },
 

--- a/packages/form-js-viewer/karma.conf.js
+++ b/packages/form-js-viewer/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(karma) {
 
     coverageReporter: {
       reporters: [
-        { type: 'lcovonly', subdir: '.' },
+        { type: 'lcov', subdir: '.' }
       ]
     },
 

--- a/packages/form-js/test/config/karma.unit.js
+++ b/packages/form-js/test/config/karma.unit.js
@@ -35,7 +35,7 @@ module.exports = function(karma) {
 
     coverageReporter: {
       reporters: [
-        { type: 'lcovonly', subdir: '.' },
+        { type: 'lcov', subdir: '.' }
       ]
     },
 


### PR DESCRIPTION
Related to https://github.com/bpmn-io/form-js/issues/123#issuecomment-1075594064.

----


You can now generate local HTML coverage reports via 

```
COVERAGE=1 npm test
```