### PR TITLE
Fail builds

### DIFF
--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "all": "run-s lint test build",
     "build": "run-p bundle generate-types",
-    "bundle": "rollup -c",
+    "bundle": "rollup -c --failAfterWarnings",
     "bundle:watch": "rollup -c -w",
     "dev": "npm test -- --auto-watch --no-single-run",
     "example:dev": "cd example && npm start",

--- a/packages/form-js-playground/package.json
+++ b/packages/form-js-playground/package.json
@@ -17,7 +17,7 @@
   "umd:main": "dist/form-playground.umd.js",
   "scripts": {
     "all": "run-s test build",
-    "build": "rollup -c",
+    "build": "rollup -c --failAfterWarnings",
     "start": "SINGLE_START=basic npm run dev",
     "dev": "npm test -- --auto-watch --no-single-run",
     "test": "karma start",

--- a/packages/form-js-playground/rollup.config.js
+++ b/packages/form-js-playground/rollup.config.js
@@ -41,7 +41,19 @@ export default [
         file: pkg.module
       }
     ],
-    plugins: pgl()
+    plugins: pgl(),
+    external: [
+      'preact',
+      'preact/hooks',
+      'file-drops',
+      'mitt',
+      'downloadjs',
+      '@bpmn-io/form-js',
+      'preact/jsx-runtime',
+      '@codemirror/basic-setup',
+      '@codemirror/state',
+      '@codemirror/lang-json'
+    ]
   },
   {
     input: 'src/index.js',

--- a/packages/form-js-viewer/package.json
+++ b/packages/form-js-viewer/package.json
@@ -20,7 +20,7 @@
     "all": "run-s test build",
     "build": "run-p bundle generate-types",
     "start": "SINGLE_START=basic npm run dev",
-    "bundle": "rollup -c",
+    "bundle": "rollup -c --failAfterWarnings",
     "bundle:watch": "rollup -c -w",
     "dev": "npm test -- --auto-watch --no-single-run",
     "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --outDir dist/types src/index.js && cp src/*.d.ts dist/types",

--- a/packages/form-js/package.json
+++ b/packages/form-js/package.json
@@ -30,7 +30,7 @@
     "all": "run-s test build test:distro",
     "build": "run-p bundle generate-types",
     "start": "SINGLE_START=basic npm run dev",
-    "bundle": "rollup -c",
+    "bundle": "rollup -c --failAfterWarnings",
     "bundle:watch": "rollup -c -w",
     "dev": "npm test -- --auto-watch --no-single-run",
     "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --removeComments --outDir dist/types src/index.js",


### PR DESCRIPTION
This silences a warning during bundling and ensures these warnings will fail the build.

(They usually do warn on something meaningful).