### PR TITLE
Use package.json#files in playground

### DIFF
--- a/packages/form-js-playground/package.json
+++ b/packages/form-js-playground/package.json
@@ -2,6 +2,9 @@
   "name": "@bpmn-io/form-js-playground",
   "version": "0.7.2",
   "description": "A form-js playground",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.es.js",


### PR DESCRIPTION
Previously, we would publish almost all of the files in the repo:

```
❯ npm publish --dry-run --ignore-scripts
npm notice
npm notice 📦  @bpmn-io/form-js-playground@0.7.2
npm notice === Tarball Contents ===
npm notice 88B     test/.eslintrc
npm notice 1.4kB   LICENSE
npm notice 11.9kB  dist/index.cjs
npm notice 431B    src/FileDrop.css
npm notice 2.9kB   dist/assets/form-js-playground.css
npm notice 2.4kB   src/Playground.css
npm notice 100B    test/test.css
npm notice 246B    test/coverageBundle.js
npm notice 1.1MB   dist/form-playground.umd.js
npm notice 10.9kB  dist/index.es.js
npm notice 53B     src/index.js
npm notice 1.7kB   src/JSONView.js
npm notice 2.2kB   karma.conf.js
npm notice 8.9kB   src/Playground.js
npm notice 1.4kB   test/spec/Playground.spec.js
npm notice 1.0kB   rollup.config.js
npm notice 118B    test/testBundle.js
npm notice 716B    test/TestHelper.js
npm notice 1.9kB   test/spec/form.json
npm notice 152B    test/spec/other-form.json
npm notice 1.4kB   package.json
npm notice 23.3kB  dist/index.cjs.map
npm notice 23.3kB  dist/index.es.js.map
npm notice 1.1kB   README.md
npm notice 351.8kB resources/screenshot.png
npm notice === Tarball Details ===
npm notice name:          @bpmn-io/form-js-playground
npm notice version:       0.7.2
npm notice package size:  585.5 kB
npm notice unpacked size: 1.6 MB
npm notice shasum:        de0f0bdb00eef9c00e4a4956c0190f1cd89265cd
npm notice integrity:     sha512-c096TAe+52i2q[...]08ngtlNk3x2Rg==
npm notice total files:   25
npm notice
+ @bpmn-io/form-js-playground@0.7.2
```

Now, it's just the `dist` directory:

```
❯ npm publish --dry-run --ignore-scripts
npm notice
npm notice 📦  @bpmn-io/form-js-playground@0.7.2
npm notice === Tarball Contents ===
npm notice 1.4kB  LICENSE
npm notice 11.9kB dist/index.cjs
npm notice 2.9kB  dist/assets/form-js-playground.css
npm notice 1.1MB  dist/form-playground.umd.js
npm notice 10.9kB dist/index.es.js
npm notice 1.4kB  package.json
npm notice 23.3kB dist/index.cjs.map
npm notice 23.3kB dist/index.es.js.map
npm notice 1.1kB  README.md
npm notice === Tarball Details ===
npm notice name:          @bpmn-io/form-js-playground
npm notice version:       0.7.2
npm notice package size:  281.9 kB
npm notice unpacked size: 1.2 MB
npm notice shasum:        33094fc31366a237197f5f8bbd9670d70bfb2b73
npm notice integrity:     sha512-NFZuty5Fm96Os[...]rRf00HsAqgnlA==
npm notice total files:   9
npm notice
+ @bpmn-io/form-js-playground@0.7.2
```