### PR TITLE
test(viewer): add basic a11y unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4742,6 +4742,12 @@
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
+		"axe-core": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+			"integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+			"dev": true
+		},
 		"babel-code-frame": {
 			"version": "6.26.0",
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/node": "^14.17.4",
     "@types/sinon": "^9.0.11",
     "@types/sinon-chai": "^3.2.5",
+    "axe-core": "^4.4.3",
     "babel-loader": "^8.2.2",
     "chai": "^4.3.4",
     "cross-env": "^7.0.3",

--- a/packages/form-js-viewer/test/helper/index.js
+++ b/packages/form-js-viewer/test/helper/index.js
@@ -4,6 +4,8 @@ import {
   merge
 } from 'min-dash';
 
+import axe from 'axe-core';
+
 import TestContainer from 'mocha-test-container-support';
 
 import Form from '../../src/Form';
@@ -17,6 +19,16 @@ function cleanup() {
 
   FORM.destroy();
 }
+
+/**
+ * https://www.deque.com/axe/core-documentation/api-documentation/#axe-core-tags
+ */
+const DEFAULT_AXE_RULES = [
+  'best-practice',
+  'wcag2a',
+  'wcag2aa',
+  'cat.semantics'
+];
 
 /**
  * Bootstrap the form given the specified options and a number of locals (i.e. services)
@@ -162,4 +174,19 @@ export function insertCSS(name, css) {
   style.appendChild(document.createTextNode(css));
 
   head.appendChild(style);
+}
+
+export async function expectNoViolations(node, options = {}) {
+  const {
+    rules,
+    ...rest
+  } = options;
+
+  const results = await axe.run(node, {
+    runOnly: rules || DEFAULT_AXE_RULES,
+    ...rest
+  });
+
+  expect(results.passes).to.be.not.empty;
+  expect(results.violations).to.be.empty;
 }

--- a/packages/form-js-viewer/test/spec/render/components/Label.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Label.spec.js
@@ -4,7 +4,10 @@ import {
 
 import Label from '../../../../src/render/components/Label';
 
-import { createFormContainer } from '../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../TestHelper';
 
 let container;
 
@@ -81,6 +84,25 @@ describe('Label', function() {
 
     expect(label).to.exist;
     expect(requiredIndicator).to.exist;
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createLabel({
+        id: 'foo',
+        label: 'Foo'
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
@@ -2,7 +2,10 @@ import { render } from '@testing-library/preact/pure';
 
 import Button from '../../../../../src/render/components/form-fields/Button';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 let container;
 
@@ -95,6 +98,28 @@ describe('Button', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createButton({
+        field: {
+          ...defaultField,
+          action: 'reset',
+          label: 'Reset'
+        }
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Checkbox from '../../../../../src/render/components/form-fields/Checkbox';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 const spy = sinon.spy;
 
@@ -156,6 +159,24 @@ describe('Checkbox', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createCheckbox({
+        value: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Checklist from '../../../../../src/render/components/form-fields/Checklist';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 import { WithFormContext } from './helper';
 
@@ -276,6 +279,24 @@ describe('Checklist', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createChecklist({
+        value: [ 'approver' ]
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Number from '../../../../../src/render/components/form-fields/Number';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 const spy = sinon.spy;
 
@@ -207,6 +210,24 @@ describe('Number', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createNumberField({
+        value: 123
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Radio from '../../../../../src/render/components/form-fields/Radio';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 import { WithFormContext } from './helper';
 
@@ -280,6 +283,24 @@ describe('Radio', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createRadio({
+        value: 'camunda-platform'
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Select from '../../../../../src/render/components/form-fields/Select';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 import { WithFormContext } from './helper';
 
@@ -272,6 +275,24 @@ describe('Select', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createSelect({
+        value: 'foo'
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Taglist from '../../../../../src/render/components/form-fields/Taglist';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 import { WithFormContext } from './helper';
 
@@ -575,6 +578,24 @@ describe('Taglist', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createTaglist({
+        value: [ 'tag1', 'tag2', 'tag3' ]
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -2,7 +2,10 @@ import { render } from '@testing-library/preact/pure';
 
 import Text from '../../../../../src/render/components/form-fields/Text';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 let container;
 
@@ -142,6 +145,22 @@ Some _em_ **strong** [text](#text) \`code\`.
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createText();
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -5,7 +5,10 @@ import {
 
 import Textfield from '../../../../../src/render/components/form-fields/Textfield';
 
-import { createFormContainer } from '../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../TestHelper';
 
 import { WithFormContext } from './helper';
 
@@ -196,6 +199,24 @@ describe('Textfield', function() {
     expect(customField).to.contain({
       custom: true
     });
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createTextfield({
+        value: 'John Doe Company'
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/parts/DropdownList.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/parts/DropdownList.spec.js
@@ -5,7 +5,10 @@ import {
 
 import DropdownList from '../../../../../../src/render/components/form-fields/parts/DropdownList';
 
-import { createFormContainer } from '../../../../../TestHelper';
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../../../TestHelper';
 
 let formContainer;
 
@@ -147,6 +150,24 @@ describe('DropdownList', function() {
       fireEvent.mouseMove(toFocus);
       expect(toFocus.classList.contains('focused')).to.be.true;
 
+    });
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createDropdownList({
+        values: [ 'item1', 'item2' ]
+      });
+
+      // then
+      await expectNoViolations(container);
     });
 
   });


### PR DESCRIPTION
Adds the same unit test styles as we already have in `properties-panel` and `bpmn-js-properties-panel`. I think this helps us a lot to verify that our form fields validate against basic standards.
