### PR TITLE
Updated chai version to ^4.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,36 @@ See [editor documentation](./packages/form-js-editor) for further details.
 * [Form schema](./docs/FORM_SCHEMA.md)
 
 
+## Build and Run
+
+Prepare the project by installing all dependencies:
+
+```sh
+npm install
+```
+
+Then, depending on your use-case you may run any of the following commands:
+
+```sh
+# build the library and run all tests
+npm run all
+
+# spin up a single local form-js instance
+npm start
+
+# spin up a specific instance
+
+## viewer
+npm run start:viewer
+
+## editor
+npm run start:editor
+
+## playground
+npm run start:playground
+```
+
+
 ## License
 
 Use under the terms of the [bpmn.io license](http://bpmn.io/license).

--- a/package-lock.json
+++ b/package-lock.json
@@ -5122,16 +5122,15 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.16.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+			"version": "4.21.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001219",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.723",
-				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
+				"caniuse-lite": "^1.0.30001370",
+				"electron-to-chromium": "^1.4.202",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.5"
 			}
 		},
 		"buffer": {
@@ -5295,9 +5294,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001240",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001240.tgz",
-			"integrity": "sha512-nb8mDzfMdxBDN7ZKx8chWafAdBp5DAAlpWvNyUGe5tcDWd838zpzDN3Rah9cjCqhfOKkrvx40G2SDtP0qiWX/w==",
+			"version": "1.0.30001374",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
+			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
 			"dev": true
 		},
 		"caseless": {
@@ -5307,15 +5306,16 @@
 			"dev": true
 		},
 		"chai": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-			"integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
+			"integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
+				"loupe": "^2.3.1",
 				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
@@ -6764,9 +6764,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.759",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.759.tgz",
-			"integrity": "sha512-nM76xH0t2FBH5iMEZDVc3S/qbdKjGH7TThezxC8k1Q7w7WHvIAyJh8lAe2UamGfdRqBTjHfPDn82LJ0ksCiB9g==",
+			"version": "1.4.211",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
+			"integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -7412,40 +7412,10 @@
 						"to-fast-properties": "^2.0.0"
 					}
 				},
-				"browserslist": {
-					"version": "4.21.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
-					"integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30001359",
-						"electron-to-chromium": "^1.4.172",
-						"node-releases": "^2.0.5",
-						"update-browserslist-db": "^1.0.4"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30001363",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
-					"integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.4.182",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.182.tgz",
-					"integrity": "sha512-OpEjTADzGoXABjqobGhpy0D2YsTncAax7IkER68ycc4adaq0dqEG9//9aenKPy7BGA90bqQdLac0dPp6uMkcSg==",
-					"dev": true
-				},
 				"json5": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
 					"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-					"dev": true
-				},
-				"node-releases": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-					"integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
 					"dev": true
 				}
 			}
@@ -10484,6 +10454,15 @@
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
+		"loupe": {
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
+			"integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.0"
+			}
+		},
 		"lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -11506,9 +11485,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.73",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-			"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
 			"dev": true
 		},
 		"nopt": {
@@ -15063,9 +15042,9 @@
 			"dev": true
 		},
 		"update-browserslist-db": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
-			"integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+			"integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
 			"dev": true,
 			"requires": {
 				"escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/sinon-chai": "^3.2.5",
     "axe-core": "^4.4.3",
     "babel-loader": "^8.2.2",
-    "chai": "^4.3.4",
+    "chai": "^4.3.5",
     "cross-env": "^7.0.3",
     "del-cli": "^4.0.0",
     "diagram-js": "^7.5.0",


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
Closes #300

The issue was caused by a faulty `exports` entry in the `package.json` ([Ticket](https://github.com/chaijs/chai/issues/1387)) and resolved in `4.3.5` of chai.

After upgrading, it ran as usual. For inspection what changed, look [here](https://github.com/chaijs/chai/compare/v4.3.4...v4.3.5).

