### PR TITLE
feat: use template engine mustache to render textfield

### DIFF
--- a/packages/form-js-editor/src/render/components/properties-panel/entries/TextEntry.js
+++ b/packages/form-js-editor/src/render/components/properties-panel/entries/TextEntry.js
@@ -51,7 +51,7 @@ function Text(props) {
 
   return TextAreaEntry({
     debounce,
-    description: 'Use Markdown or basic HTML to format.',
+    description: 'Use Markdown or basic HTML to format. You may also use Mustache Template Language.',
     element: field,
     getValue,
     id,

--- a/packages/form-js-viewer/package-lock.json
+++ b/packages/form-js-viewer/package-lock.json
@@ -29,6 +29,11 @@
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.8.0.tgz",
       "integrity": "sha512-a0TLbmL6p4RlNGblZcLd2yjPORp+bCYRlNGvwK5OMwWaMROWh1DlRgN9W8jJm2x9gVuscvD38BEosV7cnikKnw=="
     },
+    "mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
+    },
     "preact": {
       "version": "10.5.14",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",

--- a/packages/form-js-viewer/package.json
+++ b/packages/form-js-viewer/package.json
@@ -43,6 +43,7 @@
     "didi": "^5.2.1",
     "ids": "^1.0.0",
     "min-dash": "^3.7.0",
+    "mustache": "^4.2.0",
     "preact": "^10.5.14",
     "preact-markup": "^2.1.1"
   },

--- a/packages/form-js-viewer/src/render/components/Util.js
+++ b/packages/form-js-viewer/src/render/components/Util.js
@@ -1,5 +1,6 @@
 import snarkdown from '@bpmn-io/snarkdown';
 import { get } from 'min-dash';
+import mustache from 'mustache';
 
 import { sanitizeHTML } from './Sanitizer';
 
@@ -45,6 +46,19 @@ export function safeMarkdown(markdown) {
   const html = markdownToHTML(markdown);
 
   return sanitizeHTML(html);
+}
+
+export function safeTemplateMarkdown(markdown,templateContext) {
+  let templatedMarkdown = markdown;
+  if (templateContext) {
+    try {
+      templatedMarkdown = mustache.render(markdown,templateContext);
+      console.log('Successfully applied template!');
+    } catch (error) {
+      console.log(error);
+    }
+  }
+  return safeMarkdown(templatedMarkdown);
 }
 
 export function sanitizeSingleSelectValue(options) {

--- a/packages/form-js-viewer/src/render/components/form-fields/Text.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Text.js
@@ -2,19 +2,19 @@ import Markup from 'preact-markup';
 
 import {
   formFieldClasses,
-  safeMarkdown
+  safeTemplateMarkdown
 } from '../Util';
 
 const type = 'text';
 
 
 export default function Text(props) {
-  const { field } = props;
+  const { field,value } = props;
 
   const { text = '' } = field;
 
   return <div class={ formFieldClasses(type) }>
-    <Markup markup={ safeMarkdown(text) } trim={ false } />
+    <Markup markup={ safeTemplateMarkdown(text,value) } trim={ false } />
   </div>;
 }
 


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
Closes #247 

Markdown coming from the text area will now be rended against a template context if available.

[Mustache](https://github.com/janl/mustache.js/) is used as template engine which is also stated in the description of the text area now.

