### PR TITLE
fix(viewer): filter out invalid dynamic taglist options

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -64,7 +64,7 @@ export default function Taglist(props) {
 
   useEffect(() => {
     if (loadState === LOAD_STATES.LOADED) {
-      setFilteredValues(options.filter((o) => o.label && (o.label.toLowerCase().includes(filter.toLowerCase())) && !values.includes(o.value)));
+      setFilteredValues(options.filter((o) => o.label && o.value && (o.label.toLowerCase().includes(filter.toLowerCase())) && !values.includes(o.value)));
     }
     else {
       setFilteredValues([]);

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -368,6 +368,45 @@ describe('Taglist', function() {
 
   describe('dropdown', function() {
 
+    describe('items', function() {
+
+      it('should not render invalid items', function() {
+
+        // when
+        const { container } = createTaglist({
+          onchange: () => { },
+          field: dynamicField,
+          initialData: {
+            dynamicValues: [
+              {
+                value: 'dynamicValue1'
+              },
+              {
+                label: 'Dynamic Value 2',
+              }
+            ] }
+        });
+
+        // then
+        const filterInput = container.querySelector('input[type="text"]');
+
+        fireEvent.focus(filterInput);
+
+        // then
+        const taglistAnchor = container.querySelector('.fjs-taglist-anchor');
+        expect(taglistAnchor).to.exist;
+
+        const dropdownList = taglistAnchor.querySelector('.fjs-dropdownlist');
+        expect(dropdownList).to.exist;
+
+        const dropdownItems = dropdownList.querySelectorAll('.fjs-dropdownlist-item');
+        expect(dropdownItems).to.have.length(0);
+
+      });
+
+    });
+
+
     describe('filtering', function() {
 
       it ('should render no results state', function() {


### PR DESCRIPTION
Related to #303

For the properties panel hint: #305 is for adding a more sophisticated solution, but for now we decided to improve the existing description:

<img width="293" alt="Screenshot 2022-08-18 at 14 41 32" src="https://user-images.githubusercontent.com/25825387/185409720-9ee8b0a5-73e9-4278-a73a-f68d98da082a.png">

