### PR TITLE
Housekeeping

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "plugins": [
-    [ "@babel/plugin-transform-react-jsx", {
-      "importSource": "preact",
-      "runtime": "automatic"
-    } ]
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,157 +23,121 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.14.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-			"integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.14.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-			"integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+			"integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.14.5",
-				"@babel/helper-compilation-targets": "^7.14.5",
-				"@babel/helper-module-transforms": "^7.14.5",
-				"@babel/helpers": "^7.14.6",
-				"@babel/parser": "^7.14.6",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5",
+				"@ampproject/remapping": "^2.1.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.18.13",
+				"@babel/helper-compilation-targets": "^7.18.9",
+				"@babel/helper-module-transforms": "^7.18.9",
+				"@babel/helpers": "^7.18.9",
+				"@babel/parser": "^7.18.13",
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.1.2",
-				"semver": "^6.3.0",
-				"source-map": "^0.5.0"
+				"json5": "^2.2.1",
+				"semver": "^6.3.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+					"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.14.5"
+						"@babel/highlight": "^7.18.6"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+					"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.14.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.14.5",
-						"@babel/template": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
+						"@babel/types": "^7.18.13",
+						"@jridgewell/gen-mapping": "^0.3.2",
+						"jsesc": "^2.5.1"
 					}
 				},
 				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+					"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 					"dev": true
 				},
 				"@babel/highlight": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+					"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.18.6",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
 					}
 				},
 				"@babel/parser": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+					"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
 					"dev": true
 				},
-				"@babel/template": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/parser": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
 				"@babel/traverse": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+					"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.5",
-						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-hoist-variables": "^7.14.5",
-						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.7",
-						"@babel/types": "^7.14.5",
+						"@babel/code-frame": "^7.18.6",
+						"@babel/generator": "^7.18.13",
+						"@babel/helper-environment-visitor": "^7.18.9",
+						"@babel/helper-function-name": "^7.18.9",
+						"@babel/helper-hoist-variables": "^7.18.6",
+						"@babel/helper-split-export-declaration": "^7.18.6",
+						"@babel/parser": "^7.18.13",
+						"@babel/types": "^7.18.13",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+					"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/helper-string-parser": "^7.18.10",
+						"@babel/helper-validator-identifier": "^7.18.6",
 						"to-fast-properties": "^2.0.0"
 					}
 				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+				"@jridgewell/gen-mapping": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
 					"dev": true,
 					"requires": {
-						"ms": "2.1.2"
+						"@jridgewell/set-array": "^1.0.1",
+						"@jridgewell/sourcemap-codec": "^1.4.10",
+						"@jridgewell/trace-mapping": "^0.3.9"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+				"json5": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+					"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
 					"dev": true
 				}
 			}
@@ -248,14 +212,14 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-			"integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
+			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.14.5",
-				"@babel/helper-validator-option": "^7.14.5",
-				"browserslist": "^4.16.6",
+				"@babel/compat-data": "^7.18.8",
+				"@babel/helper-validator-option": "^7.18.6",
+				"browserslist": "^4.20.2",
 				"semver": "^6.3.0"
 			}
 		},
@@ -295,54 +259,28 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-			"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.18.6"
 			},
 			"dependencies": {
 				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+					"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+					"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				}
-			}
-		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.14.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-			"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.14.5"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-					"dev": true
-				},
-				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/helper-string-parser": "^7.18.10",
+						"@babel/helper-validator-identifier": "^7.18.6",
 						"to-fast-properties": "^2.0.0"
 					}
 				}
@@ -376,170 +314,44 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-			"integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
+			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.14.5",
-				"@babel/helper-simple-access": "^7.14.5",
-				"@babel/helper-split-export-declaration": "^7.14.5",
-				"@babel/helper-validator-identifier": "^7.14.5",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-module-imports": "^7.18.6",
+				"@babel/helper-simple-access": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/helper-validator-identifier": "^7.18.6",
+				"@babel/template": "^7.18.6",
+				"@babel/traverse": "^7.18.9",
+				"@babel/types": "^7.18.9"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+				"@babel/helper-module-imports": {
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+					"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
 					"dev": true,
 					"requires": {
-						"@babel/highlight": "^7.14.5"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.14.5",
-						"@babel/template": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
+						"@babel/types": "^7.18.6"
 					}
 				},
 				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-					"dev": true
-				},
-				"@babel/highlight": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/parser": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.5",
-						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-hoist-variables": "^7.14.5",
-						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.7",
-						"@babel/types": "^7.14.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-			"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.14.5"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+					"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+					"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/helper-string-parser": "^7.18.10",
+						"@babel/helper-validator-identifier": "^7.18.6",
 						"to-fast-properties": "^2.0.0"
 					}
 				}
@@ -551,167 +363,29 @@
 			"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
 			"dev": true
 		},
-		"@babel/helper-replace-supers": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-			"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.14.5",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.14.5"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.14.5",
-						"@babel/template": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
-					"dev": true
-				},
-				"@babel/highlight": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/parser": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.5",
-						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-hoist-variables": "^7.14.5",
-						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.7",
-						"@babel/types": "^7.14.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
-		},
 		"@babel/helper-simple-access": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-			"integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
+			"integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.18.6"
 			},
 			"dependencies": {
 				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+					"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+					"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/helper-string-parser": "^7.18.10",
+						"@babel/helper-validator-identifier": "^7.18.6",
 						"to-fast-properties": "^2.0.0"
 					}
 				}
@@ -758,146 +432,38 @@
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.14.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-			"integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
+			"integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/template": "^7.18.6",
+				"@babel/traverse": "^7.18.9",
+				"@babel/types": "^7.18.9"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.14.5"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-					"integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.14.5",
-						"@babel/template": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.14.5"
-					}
-				},
 				"@babel/helper-validator-identifier": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-					"integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+					"version": "7.18.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+					"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 					"dev": true
-				},
-				"@babel/highlight": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-					"integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/parser": "^7.14.5",
-						"@babel/types": "^7.14.5"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.14.7",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-					"integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.14.5",
-						"@babel/generator": "^7.14.5",
-						"@babel/helper-function-name": "^7.14.5",
-						"@babel/helper-hoist-variables": "^7.14.5",
-						"@babel/helper-split-export-declaration": "^7.14.5",
-						"@babel/parser": "^7.14.7",
-						"@babel/types": "^7.14.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0"
-					}
 				},
 				"@babel/types": {
-					"version": "7.14.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-					"integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+					"version": "7.18.13",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+					"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.14.5",
+						"@babel/helper-string-parser": "^7.18.10",
+						"@babel/helper-validator-identifier": "^7.18.6",
 						"to-fast-properties": "^2.0.0"
 					}
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
 				}
 			}
 		},
@@ -1429,6 +995,27 @@
 			"resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
 			"integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
 			"dev": true
+		},
+		"@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
 		},
 		"@istanbuljs/schema": {
 			"version": "0.1.3",
@@ -5071,95 +4658,29 @@
 			"integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
 			"dev": true
 		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"dev": true,
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-					"dev": true
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-					"dev": true
-				}
-			}
-		},
-		"babel-generator": {
-			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-			"dev": true,
-			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"detect-indent": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
-					}
-				},
-				"jsesc": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-					"dev": true
-				}
-			}
-		},
 		"babel-loader": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
-			"integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
+			"version": "8.2.5",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
+			"integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^3.3.1",
-				"loader-utils": "^1.4.0",
+				"loader-utils": "^2.0.0",
 				"make-dir": "^3.1.0",
 				"schema-utils": "^2.6.5"
 			},
 			"dependencies": {
+				"loader-utils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
 				"make-dir": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5171,116 +4692,44 @@
 				}
 			}
 		},
-		"babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+		"babel-plugin-istanbul": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"istanbul-lib-instrument": "^5.0.4",
+				"test-exclude": "^6.0.0"
+			},
+			"dependencies": {
+				"istanbul-lib-coverage": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+					"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
+					"integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.12.3",
+						"@babel/parser": "^7.14.7",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.2.0",
+						"semver": "^6.3.0"
+					}
+				}
 			}
 		},
 		"babel-plugin-react-svg": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/babel-plugin-react-svg/-/babel-plugin-react-svg-3.0.3.tgz",
 			"integrity": "sha512-Pst1RWjUIiV0Ykv1ODSeceCBsFOP2Y4dusjq7/XkjuzJdvS9CjpkPMUIoO4MLlvp5PiLCeMlsOC7faEUA0gm3Q==",
-			"dev": true
-		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
-				}
-			}
-		},
-		"babel-template": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
-			}
-		},
-		"babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-			"dev": true,
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"globals": {
-					"version": "9.18.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-					"dev": true
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"babel-types": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-			"dev": true,
-			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
-			},
-			"dependencies": {
-				"to-fast-properties": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-					"dev": true
-				}
-			}
-		},
-		"babylon": {
-			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -5797,12 +5246,6 @@
 				"mkdirp-infer-owner": "^2.0.0"
 			}
 		},
-		"co": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-			"dev": true
-		},
 		"coa": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -6193,12 +5636,6 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
 			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-			"dev": true
-		},
-		"core-js": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
 			"dev": true
 		},
 		"core-js-pure": {
@@ -8758,9 +8195,9 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
-			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+			"integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
@@ -8768,25 +8205,6 @@
 				"pkg-dir": "^4.1.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
 				"make-dir": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8794,30 +8212,6 @@
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0"
 					}
 				}
 			}
@@ -9139,6 +8533,12 @@
 				"has-symbols": "^1.0.1"
 			}
 		},
+		"get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true
+		},
 		"get-port": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
@@ -9364,15 +8764,6 @@
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true,
-			"requires": {
-				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-bigints": {
@@ -9814,15 +9205,6 @@
 				"side-channel": "^1.0.4"
 			}
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -9899,12 +9281,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
-		},
-		"is-finite": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
 			"dev": true
 		},
 		"is-fullwidth-code-point": {
@@ -10114,80 +9490,6 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
-		},
-		"istanbul-instrumenter-loader": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz",
-			"integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
-			"dev": true,
-			"requires": {
-				"convert-source-map": "^1.5.0",
-				"istanbul-lib-instrument": "^1.7.3",
-				"loader-utils": "^1.1.0",
-				"schema-utils": "^0.3.0"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "5.5.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-					"dev": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"fast-deep-equal": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-					"dev": true
-				},
-				"istanbul-lib-coverage": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
-					"dev": true
-				},
-				"istanbul-lib-instrument": {
-					"version": "1.10.2",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-					"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
-					"dev": true,
-					"requires": {
-						"babel-generator": "^6.18.0",
-						"babel-template": "^6.16.0",
-						"babel-traverse": "^6.18.0",
-						"babel-types": "^6.18.0",
-						"babylon": "^6.18.0",
-						"istanbul-lib-coverage": "^1.2.1",
-						"semver": "^5.3.0"
-					}
-				},
-				"json-schema-traverse": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-					"dev": true
-				},
-				"schema-utils": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-					"dev": true,
-					"requires": {
-						"ajv": "^5.0.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
-			}
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.0.0",
@@ -13897,15 +13199,6 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
-		},
 		"request": {
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -14487,12 +13780,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
 			"integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-			"dev": true
-		},
-		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
 		"source-map-js": {
@@ -15196,6 +14483,17 @@
 				}
 			}
 		},
+		"test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			}
+		},
 		"text-extensions": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -15306,12 +14604,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz",
 			"integrity": "sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==",
-			"dev": true
-		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
 			"dev": true
 		},
 		"tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     }
   ],
   "devDependencies": {
-    "@babel/core": "^7.14.6",
+    "@babel/core": "^7.18.10",
     "@babel/plugin-transform-react-jsx": "^7.14.5",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
     "@bpmn-io/properties-panel": "^0.14.0",
@@ -63,7 +63,8 @@
     "@types/sinon": "^9.0.11",
     "@types/sinon-chai": "^3.2.5",
     "axe-core": "^4.4.3",
-    "babel-loader": "^8.2.2",
+    "babel-loader": "^8.2.5",
+    "babel-plugin-istanbul": "^6.1.1",
     "chai": "^4.3.5",
     "cross-env": "^7.0.3",
     "del-cli": "^4.0.0",
@@ -72,7 +73,6 @@
     "eslint-plugin-bpmn-io": "^0.14.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^6.3.20",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.3",

--- a/packages/form-js-editor/karma.conf.js
+++ b/packages/form-js-editor/karma.conf.js
@@ -77,7 +77,17 @@ module.exports = function(karma) {
                     'runtime': 'automatic'
                   } ],
                   '@babel/plugin-transform-react-jsx-source'
-                ]
+                ].concat(
+                  coverage ? [
+                    [
+                      'istanbul', {
+                        include: [
+                          'src/**'
+                        ]
+                      }
+                    ]
+                  ] : []
+                )
               }
             }
           },
@@ -85,18 +95,7 @@ module.exports = function(karma) {
             test: /\.svg$/,
             use: [ 'react-svg-loader' ]
           }
-        ].concat(coverage ?
-          {
-            test: /\.js$/,
-            use: {
-              loader: 'istanbul-instrumenter-loader',
-              options: { esModules: true }
-            },
-            enforce: 'post',
-            include: /src\.*/,
-            exclude: /node_modules/
-          } : []
-        )
+        ]
       },
       plugins: [
         new NormalModuleReplacementPlugin(

--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -46,8 +46,8 @@
     "array-move": "^3.0.1",
     "dragula": "^3.7.3",
     "ids": "^1.0.0",
-    "min-dash": "^3.7.0",
-    "min-dom": "^3.1.3",
+    "min-dash": "^3.8.1",
+    "min-dom": "^3.2.1",
     "preact": "^10.5.14"
   },
   "sideEffects": [

--- a/packages/form-js-playground/karma.conf.js
+++ b/packages/form-js-playground/karma.conf.js
@@ -74,22 +74,21 @@ module.exports = function(karma) {
                     'importSource': 'preact',
                     'runtime': 'automatic'
                   } ]
-                ]
+                ].concat(
+                  coverage ? [
+                    [
+                      'istanbul', {
+                        include: [
+                          'src/**'
+                        ]
+                      }
+                    ]
+                  ] : []
+                )
               }
             }
           }
-        ].concat(coverage ?
-          {
-            test: /\.js$/,
-            use: {
-              loader: 'istanbul-instrumenter-loader',
-              options: { esModules: true }
-            },
-            enforce: 'post',
-            include: /src\.*/,
-            exclude: /node_modules/
-          } : []
-        )
+        ]
       },
       devtool: 'eval-source-map'
     }

--- a/packages/form-js-viewer/karma.conf.js
+++ b/packages/form-js-viewer/karma.conf.js
@@ -82,7 +82,17 @@ module.exports = function(karma) {
                     'runtime': 'automatic'
                   } ],
                   '@babel/plugin-transform-react-jsx-source'
-                ]
+                ].concat(
+                  coverage ? [
+                    [
+                      'istanbul', {
+                        include: [
+                          'src/**'
+                        ]
+                      }
+                    ]
+                  ] : []
+                )
               }
             }
           },
@@ -90,18 +100,7 @@ module.exports = function(karma) {
             test: /\.svg$/,
             use: [ 'react-svg-loader' ]
           }
-        ].concat(coverage ?
-          {
-            test: /\.js$/,
-            use: {
-              loader: 'istanbul-instrumenter-loader',
-              options: { esModules: true }
-            },
-            enforce: 'post',
-            include: /src\.*/,
-            exclude: /node_modules/
-          } : []
-        )
+        ]
       },
       devtool: 'eval-source-map'
     }

--- a/packages/form-js-viewer/package.json
+++ b/packages/form-js-viewer/package.json
@@ -42,7 +42,7 @@
     "classnames": "^2.3.1",
     "didi": "^8.0.1",
     "ids": "^1.0.0",
-    "min-dash": "^3.7.0",
+    "min-dash": "^3.8.1",
     "preact": "^10.5.14",
     "preact-markup": "^2.1.1"
   },

--- a/packages/form-js/test/config/karma.unit.js
+++ b/packages/form-js/test/config/karma.unit.js
@@ -57,16 +57,22 @@ module.exports = function(karma) {
             test: /\.css$/,
             use: 'raw-loader'
           }
-        ].concat(coverage ?
-          {
+        ].concat(
+          coverage ? {
             test: /\.js$/,
+            exclude: /node_modules/,
             use: {
-              loader: 'istanbul-instrumenter-loader',
-              options: { esModules: true }
-            },
-            enforce: 'post',
-            include: /src\.*/,
-            exclude: /node_modules/
+              loader: 'babel-loader',
+              options: {
+                plugins: [
+                  [ 'istanbul', {
+                    include: [
+                      'src/**'
+                    ]
+                  } ]
+                ],
+              }
+            }
           } : []
         )
       },


### PR DESCRIPTION
* use babel-plugin-istanbul for coverage reporting
* fix some audit errors; the rest will be resolved once we migrate to `lerna@5` (cf. https://github.com/bpmn-io/internal-docs/issues/482)
* editor: bump `min-dom` and `min-dash`
* viewer: bump `min-dash`

-----

This suppresses a warning regarding `istanbul-instrumenter-loader`. Switching to the recommended alternative.