### PR TITLE
Form Playground adjustments

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -260,8 +260,13 @@
 
 .fjs-editor-compact .fjs-palette-field {
   justify-content: center;
+  flex-direction: column;
 }
 
 .fjs-editor-compact .fjs-palette-field-icon {
   margin: 0;
+}
+
+.fjs-editor-compact .fjs-palette-header {
+  text-align: center;
 }

--- a/packages/form-js-editor/src/features/palette/components/Palette.js
+++ b/packages/form-js-editor/src/features/palette/components/Palette.js
@@ -59,7 +59,7 @@ export default function Palette(props) {
               {
                 Icon ? <Icon class="fjs-palette-field-icon" width="36" height="36" viewBox="0 0 54 54" /> : null
               }
-              <span class="fjs-palette-field-text fjs-hide-compact">{ label }</span>
+              <span class="fjs-palette-field-text">{ label }</span>
             </div>
           );
         })

--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -8,11 +8,12 @@ import { PlaygroundRoot } from './components/PlaygroundRoot';
 
 /**
  * @typedef { {
- *  container?: Element,
- *  schema: any,
- *  data: any,
- *  editor?: { inlinePropertiesPanel: Boolean }
  *  actions?: { display: Boolean }
+ *  container?: Element
+ *  data: any
+ *  editor?: { inlinePropertiesPanel: Boolean }
+ *  exporter?: { name: String, version: String }
+ *  schema: any
  * } } FormPlaygroundOptions
  */
 
@@ -73,11 +74,11 @@ export default function Playground(options) {
 
   render(
     <PlaygroundRoot
-      schema={ schema }
       data={ data }
-      onStateChanged={ (_state) => state = _state }
-      onInit={ onInit }
       emit={ emitter.emit }
+      onInit={ onInit }
+      onStateChanged={ (_state) => state = _state }
+      schema={ schema }
       { ...rest }
     />,
     container

--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -64,6 +64,11 @@ export default function Playground(options) {
     };
   };
 
+  const onInit = function(_ref) {
+    ref = _ref;
+    emitter.emit('formPlayground.init');
+  };
+
   container.addEventListener('dragover', handleDrop);
 
   render(
@@ -71,7 +76,7 @@ export default function Playground(options) {
       schema={ schema }
       data={ data }
       onStateChanged={ (_state) => state = _state }
-      onInit={ _ref => ref = _ref }
+      onInit={ onInit }
       emit={ emitter.emit }
       { ...rest }
     />,

--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -60,7 +60,7 @@ export default function Playground(options) {
         throw new Error('Playground is not initialized.');
       }
 
-      fn(...args);
+      return fn(...args);
     };
   };
 
@@ -95,13 +95,25 @@ export default function Playground(options) {
     return state;
   };
 
-  this.setSchema = function(schema) {
-    return ref.setSchema(schema);
-  };
+  this.getSchema = withRef(function() {
+    return ref.getSchema();
+  });
 
-  this.get = function(name, strict) {
+  this.setSchema = withRef(function(schema) {
+    return ref.setSchema(schema);
+  });
+
+  this.saveSchema = withRef(function() {
+    return ref.saveSchema();
+  });
+
+  this.get = withRef(function(name, strict) {
     return ref.get(name, strict);
-  };
+  });
+
+  this.getEditor = withRef(function() {
+    return ref.getEditor();
+  });
 
   this.destroy = function() {
     this.emit('destroy');

--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -60,6 +60,11 @@
 
 .fjs-pgl-palette-container .fjs-palette-container .fjs-palette-field {
   justify-content: center;
+  flex-direction: column;
+}
+
+.fjs-pgl-palette-container .fjs-palette-container .fjs-palette-header {
+  text-align: center;
 }
 
 .fjs-pgl-palette-container .fjs-palette-container .fjs-palette-field-icon {

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -156,11 +156,11 @@ export function PlaygroundRoot(props) {
   }, [ initialData ]);
 
   useEffect(() => {
-    formEditorRef.current.importSchema(initialSchema);
+    initialSchema && formEditorRef.current.importSchema(initialSchema);
   }, [ initialSchema ]);
 
   useEffect(() => {
-    formRef.current.importSchema(schema, data);
+    schema && formRef.current.importSchema(schema, data);
   }, [ schema, data ]);
 
   useEffect(() => {

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -71,7 +71,10 @@ export function PlaygroundRoot(props) {
       attachPropertiesPanelContainer: (node) => propertiesPanelRef.current.attachTo(node),
       attachResultContainer: (node) => resultViewRef.current.attachTo(node),
       get: (name, strict) => formEditorRef.current.get(name, strict),
-      setSchema: setInitialSchema
+      getEditor: () => formEditorRef.current,
+      getSchema: () => formEditorRef.current.getSchema(),
+      setSchema: setInitialSchema,
+      saveSchema: () => formEditorRef.current.saveSchema()
     });
   });
 

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -26,7 +26,8 @@ export function PlaygroundRoot(props) {
   const {
     actions: actionsConfig = {},
     editor: editorConfig = {},
-    emit
+    emit,
+    exporter: exporterConfig = {}
   } = props;
 
   const {
@@ -102,7 +103,8 @@ export function PlaygroundRoot(props) {
       },
       propertiesPanel: {
         parent: !inlinePropertiesPanel && propertiesPanelContainerRef.current
-      }
+      },
+      exporter: exporterConfig
     });
 
     paletteRef.current = formEditor.get('palette');

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -282,6 +282,20 @@ describe('playground', function() {
   });
 
 
+  it('should not blow up on empty schema', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container
+      });
+    });
+
+    // then
+    expect(playground.getState().schema).to.be.undefined;
+  });
+
+
   it('#getSchema', async function() {
 
     // given

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -240,7 +240,7 @@ describe('playground', function() {
   });
 
 
-  it('should set schema', async function() {
+  it('#setSchema', async function() {
 
     // given
     await act(() => {
@@ -255,6 +255,40 @@ describe('playground', function() {
 
     // then
     expect(playground.getState().schema).to.deep.include(otherSchema);
+  });
+
+
+  it('#getSchema', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    await act(() => playground.setSchema(otherSchema));
+
+    // then
+    expect(playground.getSchema()).to.deep.include(otherSchema);
+  });
+
+
+  it('#saveSchema', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    await act(() => playground.setSchema(otherSchema));
+
+    // then
+    expect(playground.saveSchema()).to.deep.include(otherSchema);
   });
 
 
@@ -273,6 +307,26 @@ describe('playground', function() {
 
     // then
     expect(eventBus).to.exist;
+  });
+
+
+  it('#getEditor', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    // when
+    const editor = playground.getEditor();
+
+    // then
+    expect(editor).to.exist;
+    expect(editor.on).to.exist;
+    expect(editor.off).to.exist;
   });
 
 

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -240,6 +240,30 @@ describe('playground', function() {
   });
 
 
+  it('should configure exporter', async function() {
+
+    // given
+    const exporter = {
+      name: 'Foo',
+      version: 'bar'
+    };
+
+    // when
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema,
+        exporter
+      });
+    });
+
+    const editor = playground.getEditor();
+
+    // then
+    expect(editor.exporter).to.eql(exporter);
+  });
+
+
   it('#setSchema', async function() {
 
     // given

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -330,27 +330,55 @@ describe('playground', function() {
   });
 
 
-  it('should emit <formPlayground.rendered>', async function() {
+  describe('event emitting', function() {
 
-    // given
-    const spy = sinon.spy();
+    it('should emit <formPlayground.rendered>', async function() {
 
-    await act(() => {
-      playground = new Playground({
-        container,
-        schema
+      // given
+      const spy = sinon.spy();
+
+      await act(() => {
+        playground = new Playground({
+          container,
+          schema
+        });
       });
+
+      playground.on('formPlayground.rendered', spy);
+
+      const eventBus = playground.get('eventBus');
+
+      // when
+      eventBus.fire('formEditor.rendered');
+
+      // then
+      expect(spy).to.have.been.called;
     });
 
-    playground.on('formPlayground.rendered', spy);
 
-    const eventBus = playground.get('eventBus');
+    it('should emit <formPlayground.init>', async function() {
 
-    // when
-    eventBus.fire('formEditor.rendered');
+      // given
+      const spy = sinon.spy();
 
-    // then
-    expect(spy).to.have.been.called;
+      await act(() => {
+        playground = new Playground({
+          container,
+          schema
+        });
+      });
+
+      playground.on('formPlayground.init', spy);
+
+      // when
+      await act(() => {
+        playground.setSchema(otherSchema);
+      });
+
+      // then
+      expect(spy).to.have.been.called;
+    });
+
   });
 
 


### PR DESCRIPTION
Closes #331 

---

This includes some adjustments required by https://github.com/camunda/form-playground/pull/1 and https://github.com/camunda/camunda-modeler/issues/3126.

### Playground

* Pipe necessary FormEditor API via FormPlayground. This is needed when integrating it into the Desktop Modeler via [camunda/camunda-modeler#3126](https://github.com/camunda/camunda-modeler/issues/3126).
  * `formPlayground#getEditor`
  * `formPlayground#getSchema`
  * `formPlayground#saveSchema`
* Emit `formPlayground.init`. This is needed to inform interested parties once the playground has been initialized. 
* Make it possible to configure `exporter` (#331) 
* Make initial schema optional

### Editor

* Display palette action names in compact mode (cf. [bpmn-io/internal-docs#617 (comment)](https://github.com/bpmn-io/internal-docs/issues/617#issuecomment-1237906881))

<p align="center">
<img height=500 src="https://user-images.githubusercontent.com/9433996/189912472-9447712f-4c04-47c7-912e-9f6dbb77aa30.png" />
</p>
