### PR TITLE
style(viewer): increase description color contrast

### DIFF
--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -114,7 +114,7 @@
 
 .fjs-container .fjs-form-field-description {
   display: block;
-  color: var(--color-text-lighter);
+  color: var(--color-text-light);
 }
 
 .fjs-container .fjs-form-field-label,

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -186,7 +186,8 @@ describe('Checkbox', function() {
 const defaultField = {
   key: 'approved',
   label: 'Approved',
-  type: 'checkbox'
+  type: 'checkbox',
+  description: 'checkbox'
 };
 
 function createCheckbox(options = {}) {

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
@@ -308,6 +308,7 @@ const defaultField = {
   key: 'mailto',
   label: 'Email data to',
   type: 'checklist',
+  description: 'checklist',
   values: [
     {
       label: 'Approver',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -237,7 +237,8 @@ describe('Number', function() {
 const defaultField = {
   key: 'amount',
   label: 'Amount',
-  type: 'number'
+  type: 'number',
+  description: 'number'
 };
 
 function createNumberField(options = {}) {

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
@@ -312,6 +312,7 @@ const defaultField = {
   key: 'product',
   label: 'Product',
   type: 'radio',
+  description: 'radio',
   values: [
     {
       label: 'Camunda Platform',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -305,6 +305,7 @@ const defaultField = {
   key: 'language',
   label: 'Language',
   type: 'select',
+  description: 'select',
   values: [
     {
       label: 'German',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -646,6 +646,7 @@ const defaultField = {
   key: 'tags',
   label: 'Taglist',
   type: 'taglist',
+  description: 'taglist',
   'values': [
     {
       'label': 'Tag1',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -227,6 +227,7 @@ const defaultField = {
   id: 'Textfield_1',
   key: 'creditor',
   label: 'Creditor',
+  description: 'textfield',
   type: 'textfield'
 };
 


### PR DESCRIPTION
Closes https://github.com/bpmn-io/form-js/issues/334

* Increases the description color contrast (cf. https://dequeuniversity.com/rules/axe/4.4/color-contrast)
* Adjust a11y tests to verify it works

![image](https://user-images.githubusercontent.com/9433996/191201901-7536b126-24fa-4e36-9679-a79bfdc6b0a8.png)

![image](https://user-images.githubusercontent.com/9433996/191201645-8a57876d-9364-4720-a58d-47a1a6981136.png)

I'm happy to receive feedback regarding this 👍 