### PR TITLE
fix(editor): scroll only palette fields

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -157,6 +157,11 @@
   font-family: var(--font-family);
 }
 
+.fjs-editor-container .fjs-palette-container .fjs-palette {
+  height: 100%;
+  overflow: hidden;
+}
+
 .fjs-palette-container .fjs-palette-header {
   font-size: 12px;
   font-weight: bold;
@@ -164,6 +169,12 @@
   padding: 10px;
   border-bottom: solid 1px var(--color-palette-header-border);
   background-color: var(--color-palette-header-background);
+}
+
+.fjs-palette-container .fjs-palette-fields {
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .fjs-palette-container .fjs-palette-field {

--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -159,7 +159,9 @@
 
 .fjs-editor-container .fjs-palette-container .fjs-palette {
   height: 100%;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 .fjs-palette-container .fjs-palette-header {

--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -158,8 +158,6 @@
 }
 
 .fjs-palette-container .fjs-palette-header {
-  position: sticky;
-  top: 0;
   font-size: 12px;
   font-weight: bold;
   color: var(--color-palette-header-color);

--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -158,6 +158,8 @@
 }
 
 .fjs-palette-container .fjs-palette-header {
+  position: sticky;
+  top: 0;
   font-size: 12px;
   font-weight: bold;
   color: var(--color-palette-header-color);


### PR DESCRIPTION
Closes #337 

### Before Changes
![pre-pr](https://user-images.githubusercontent.com/10350864/193873312-c74fa589-6b3e-45df-afd9-1dace91f80a5.gif)


### After Changes
![pr-fjs](https://user-images.githubusercontent.com/10350864/193871313-246ae91a-a16b-4dca-a0d7-376fd0c09750.gif)

- [x] Ran `npm run all` to verify tests

**Dev Environment**

- Node: v16 LTS
- Browser: Chrome 106,105; Firefox 105
- OS: Windows 11 22H2