### PR TITLE
fix(playground): fix overflowing palette container

### DIFF
--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -47,9 +47,12 @@
   width: auto;
   background-color: var(--color-palette-container-background);
   border-right: solid 1px var(--color-palette-container-border);
+  overflow-y: scroll;
+  flex-shrink: 0;
 }
 
 .fjs-pgl-palette-container .fjs-palette-container {
+  height: 100%;
   border-right: none;
   width: auto;
 }


### PR DESCRIPTION
Found this in the playground when testing #347 and relates to #337.
Depends on #347 for sticky palette header "LIBRARY".

### Before Change
![pg-bug](https://user-images.githubusercontent.com/10350864/193897626-b2d8c452-8983-4f9d-a6ea-6453d53c11b6.gif)

### After Change
![pg-fix-pre](https://user-images.githubusercontent.com/10350864/193897656-45d76623-5210-457b-9e4c-9bac42699291.gif)

- [x] Ran `npm run all` to verify tests

**Dev Environment**

- Node: v16 LTS
- Browser: Chrome 106,105; Firefox 105
- OS: Windows 11 22H2
