### PR TITLE
fix(editor): align default static values

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/StaticValuesSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/StaticValuesSourceEntry.js
@@ -20,10 +20,7 @@ export default function StaticValuesSourceEntry(props) {
 
     const index = values.length + 1;
 
-    const entry = {
-      label: `Value ${index}`,
-      value: `value${index}`
-    };
+    const entry = getIndexedEntry(index);
 
     editField(field, VALUES_SOURCES_PATHS[VALUES_SOURCES.STATIC], arrayAdd(values, values.length, entry));
   };
@@ -73,4 +70,21 @@ export default function StaticValuesSourceEntry(props) {
     add: addEntry,
     shouldSort: false
   };
+}
+
+
+// helper
+
+function getIndexedEntry(index) {
+  const entry = {
+    label: 'Value',
+    value: 'value'
+  };
+
+  if (index > 1) {
+    entry.label += ` ${index}`;
+    entry.value += `${index}`;
+  }
+
+  return entry;
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3220

This aligns the behaviour between the default value added when creating the field, and the one added when using the '+' button.