### PR TITLE
chore: add `ADD_TO_HTO_PROJECT` action

### DIFF
--- a/.github/workflows/ADD_TO_HTO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_HTO_PROJECT.yml
@@ -1,0 +1,20 @@
+name: ADD_TO_HTO_PROJECT
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  Exec:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@d3b6ae9953cfef24c2e92848b832e7c91d6dba67
+        with:
+          project-url: ${{ secrets.HTO_PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_HTO_PROJECT_PAT }}


### PR DESCRIPTION
This adds a `add-to-project` action to add new `form-js` issues + prs to the [HTO project board](https://github.com/orgs/camunda/projects/41).
