### PR TITLE
Display correct submit data in playground output panel

### DIFF
--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -101,51 +101,29 @@ export default function Playground(options) {
     return state;
   };
 
-  this.getSchema = withRef(function() {
-    return ref.getSchema();
-  });
+  this.getSchema = withRef(() => ref.getSchema());
 
-  this.setSchema = withRef(function(schema) {
-    return ref.setSchema(schema);
-  });
+  this.setSchema = withRef((schema) => ref.setSchema(schema));
 
-  this.saveSchema = withRef(function() {
-    return ref.saveSchema();
-  });
+  this.saveSchema = withRef(() => ref.saveSchema());
 
-  this.get = withRef(function(name, strict) {
-    return ref.get(name, strict);
-  });
+  this.get = withRef((name, strict) => ref.get(name, strict));
 
-  this.getEditor = withRef(function() {
-    return ref.getEditor();
-  });
+  this.getEditor = withRef(() => ref.getEditor());
 
   this.destroy = function() {
     this.emit('destroy');
   };
 
-  this.attachEditorContainer = withRef(function(node) {
-    return ref.attachEditorContainer(node);
-  });
+  this.attachEditorContainer = withRef((node) => ref.attachEditorContainer(node));
 
-  this.attachPreviewContainer = withRef(function(node) {
-    return ref.attachFormContainer(node);
-  });
+  this.attachPreviewContainer = withRef((node) => ref.attachFormContainer(node));
 
-  this.attachDataContainer = withRef(function(node) {
-    return ref.attachDataContainer(node);
-  });
+  this.attachDataContainer = withRef((node) => ref.attachDataContainer(node));
 
-  this.attachResultContainer = withRef(function(node) {
-    return ref.attachResultContainer(node);
-  });
+  this.attachResultContainer = withRef((node) => ref.attachResultContainer(node));
 
-  this.attachPaletteContainer = withRef(function(node) {
-    return ref.attachPaletteContainer(node);
-  });
+  this.attachPaletteContainer = withRef((node) => ref.attachPaletteContainer(node));
 
-  this.attachPropertiesPanelContainer = withRef(function(node) {
-    return ref.attachPropertiesPanelContainer(node);
-  });
+  this.attachPropertiesPanelContainer = withRef((node) => ref.attachPropertiesPanelContainer(node));
 }

--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -109,7 +109,13 @@ export default function Playground(options) {
 
   this.get = withRef((name, strict) => ref.get(name, strict));
 
+  this.getDataEditor = withRef(() => ref.getDataEditor());
+
   this.getEditor = withRef(() => ref.getEditor());
+
+  this.getForm = withRef((name, strict) => ref.getForm(name, strict));
+
+  this.getResultView = withRef(() => ref.getResultView());
 
   this.destroy = function() {
     this.emit('destroy');

--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -192,6 +192,7 @@
 
 .fjs-pgl-text-container > .cm-editor > .cm-scroller {
   font-family: var(--font-family-monospace);
+  overflow: auto !important;
 }
 
 .fjs-pgl-form-container > .fjs-container {

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -60,7 +60,7 @@ export function PlaygroundRoot(props) {
   const [ data, setData ] = useState(props.data || {});
   const [ schema, setSchema ] = useState(props.schema);
 
-  const [ resultData, setResultData ] = useState(props.data || {});
+  const [ resultData, setResultData ] = useState({});
 
   // pipe to playground API
   useEffect(() => {
@@ -72,7 +72,10 @@ export function PlaygroundRoot(props) {
       attachPropertiesPanelContainer: (node) => propertiesPanelRef.current.attachTo(node),
       attachResultContainer: (node) => resultViewRef.current.attachTo(node),
       get: (name, strict) => formEditorRef.current.get(name, strict),
+      getDataEditor: () => dataEditorRef.current,
       getEditor: () => formEditorRef.current,
+      getForm: () => formRef.current,
+      getResultView: () => resultViewRef.current,
       getSchema: () => formEditorRef.current.getSchema(),
       setSchema: setInitialSchema,
       saveSchema: () => formEditorRef.current.saveSchema()
@@ -120,11 +123,12 @@ export function PlaygroundRoot(props) {
       emit('formPlayground.rendered');
     });
 
-    form.on('changed', event => {
-      setResultData(event.data);
+    form.on('changed', () => {
+      setResultData(form._getSubmitData());
     });
 
     dataEditor.on('changed', event => {
+
       try {
         setData(JSON.parse(event.value));
       } catch (err) {

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -348,6 +348,25 @@ describe('playground', function() {
   });
 
 
+  it('#getDataEditor', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    // when
+    const dataEditor = playground.getDataEditor();
+
+    // then
+    expect(dataEditor).to.exist;
+    expect(dataEditor.getValue).to.exist;
+  });
+
+
   it('#getEditor', async function() {
 
     // given
@@ -365,6 +384,115 @@ describe('playground', function() {
     expect(editor).to.exist;
     expect(editor.on).to.exist;
     expect(editor.off).to.exist;
+  });
+
+
+  it('#getForm', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    // when
+    const form = playground.getForm();
+
+    // then
+    expect(form).to.exist;
+    expect(form.submit).to.exist;
+  });
+
+
+  it('#getResultView', async function() {
+
+    // given
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    // when
+    const resultView = playground.getResultView();
+
+    // then
+    expect(resultView).to.exist;
+    expect(resultView.getValue).to.exist;
+  });
+
+
+  describe('form data submit', function() {
+
+    it('should show submit data', async function() {
+
+      // given
+      const data = {
+        creditor: 'foo',
+        invoiceNumber: 'C-123'
+      };
+
+      await act(() => {
+        playground = new Playground({
+          container,
+          data,
+          schema
+        });
+      });
+
+      const form = playground.getForm();
+      const resultView = playground.getResultView();
+
+      const resultViewValue = JSON.parse(resultView.getValue());
+
+      // when
+      const { data: submitData } = form.submit();
+
+      // then
+      expect(resultViewValue).to.eql(submitData);
+    });
+
+
+    it('should update with submit data', async function() {
+
+      // given
+      const data = {
+        creditor: 'foo',
+        invoiceNumber: 'C-123'
+      };
+
+      await act(() => {
+        playground = new Playground({
+          container,
+          data,
+          schema
+        });
+      });
+
+      const form = playground.getForm();
+      const resultView = playground.getResultView();
+
+      const formField = getFormField(form, 'creditor');
+
+      // when
+      await act(() => {
+        form._update({
+          field: formField,
+          value: 'bar'
+        });
+      });
+
+      const resultViewValue = JSON.parse(resultView.getValue());
+
+      const { data: submitData } = form.submit();
+
+      // then
+      expect(resultViewValue).to.eql(submitData);
+    });
+
   });
 
 
@@ -577,3 +705,10 @@ describe('playground', function() {
   });
 
 });
+
+
+// helper //////////////
+
+function getFormField(form, key) {
+  return form.get('formFieldRegistry').getAll().find((formField) => formField.key === key);
+}

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -167,26 +167,7 @@ export default class Form {
       throw new Error('form is read-only');
     }
 
-    const formFieldRegistry = this.get('formFieldRegistry');
-
-    const data = formFieldRegistry.getAll().reduce((data, field) => {
-      const {
-        disabled,
-        _path
-      } = field;
-
-      // do not submit disabled form fields
-      if (disabled || !_path) {
-        return data;
-      }
-
-      const value = get(this._getState().data, _path);
-
-      return {
-        ...data,
-        [ _path[ 0 ] ]: value
-      };
-    }, {});
+    const data = this._getSubmitData();
 
     const errors = this.validate();
 
@@ -396,6 +377,32 @@ export default class Form {
    */
   _onEvent(type, priority, handler) {
     this.get('eventBus').on(type, priority, handler);
+  }
+
+  /**
+   * @internal
+   */
+  _getSubmitData() {
+    const formFieldRegistry = this.get('formFieldRegistry');
+
+    return formFieldRegistry.getAll().reduce((data, field) => {
+      const {
+        disabled,
+        _path
+      } = field;
+
+      // do not submit disabled form fields
+      if (disabled || !_path) {
+        return data;
+      }
+
+      const value = get(this._getState().data, _path);
+
+      return {
+        ...data,
+        [ _path[ 0 ] ]: value
+      };
+    }, {});
   }
 
 }


### PR DESCRIPTION
Closes #273 

[As discussed](https://github.com/bpmn-io/form-js/issues/273#issuecomment-1280814553), we shall always display the submit data in the output panel. We simply do a `form.submit` to rely on the exact same data, instead of using the current form state (as we do beforehand).


Demo to try it out: https://demo-submit-panel--camunda-form-playground.netlify.app/


![Kapture 2022-10-18 at 13 34 42](https://user-images.githubusercontent.com/9433996/196418908-967b4843-d258-4d8d-929e-ce14cd2d5caa.gif)
