### PR TITLE
fix: allow click through taglist input in editor

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor.css
+++ b/packages/form-js-editor/assets/form-js-editor.css
@@ -112,6 +112,7 @@
 }
 
 .fjs-editor-container .fjs-input:disabled,
+.fjs-editor-container .fjs-taglist-input:disabled,
 .fjs-editor-container .fjs-select:disabled {
   pointer-events: none;
 }


### PR DESCRIPTION
Closes #365

Pretty trivial fix, won't provide tests for this one as it's just not worth it