### PR TITLE
docs(viewer): document event listener priorities

### DIFF
--- a/packages/form-js-viewer/README.md
+++ b/packages/form-js-viewer/README.md
@@ -38,8 +38,14 @@ const form = new Form({
 
 await form.importSchema(schema, data);
 
+// add event listeners
 form.on('submit', event => {
   console.log('Form <submit>', event);
+});
+
+// provide a priority to event listeners
+form.on('changed', 500, event => {
+  console.log('Form <changed>', event);
 });
 ```
 


### PR DESCRIPTION
Discovered while working with @marcellobarile (cf. https://github.com/camunda/web-modeler/pull/2750). Adds a bit of documentation to the viewer docs to make it clearer how to add a priority to an event listener.