### PR TITLE
fix(viewer): use blue with more contrast

### DIFF
--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -12,6 +12,7 @@
   --color-grey-225-10-95: hsl(225, 10%, 95%);
   --color-grey-225-10-97: hsl(225, 10%, 97%);
 
+  --color-blue-205-100-40: hsl(205, 100%, 40%);
   --color-blue-205-100-45: hsl(205, 100%, 45%);
   --color-blue-205-100-50: hsl(205, 100%, 50%);
   --color-blue-205-100-80: hsl(205, 100%, 80%);
@@ -36,8 +37,7 @@
   --color-borders: var(--color-grey-225-10-55);
   --color-borders-disabled: var(--color-grey-225-10-75);
   --color-warning: var(--color-red-360-100-45);
-  --color-accent: var(--color-blue-205-100-45);
-  --color-accent-dark: var(--color-blue-205-100-45);
+  --color-accent: var(--color-blue-205-100-40);
 
   --font-family: 'IBM Plex Sans', sans-serif;
 
@@ -195,7 +195,7 @@
 }
 
 .fjs-container .fjs-button[type='submit']:focus {
-  border-color: var(--color-accent-dark);
+  border-color: var(--color-accent);
 }
 
 .fjs-container .fjs-input:disabled,
@@ -233,7 +233,7 @@
 }
 
 .fjs-container .fjs-form-field-text a {
-  color: var(--color-blue-205-100-45);
+  color: var(--color-accent);
 }
 
 .fjs-container .fjs-taglist-anchor {

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
@@ -103,7 +103,25 @@ describe('Button', function() {
 
   describe('a11y', function() {
 
-    it('should have no violations', async function() {
+    it('should have no violations - submit', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createButton({
+        field: {
+          ...defaultField,
+          action: 'submit',
+          label: 'Submit'
+        }
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
+    it('should have no violations - reset', async function() {
 
       // given
       this.timeout(5000);

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -161,6 +161,23 @@ Some _em_ **strong** [text](#text) \`code\`.
       await expectNoViolations(container);
     });
 
+
+    it('should have no violations - links', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createText({
+        field: {
+          text: '# Text\n* Learn more about [forms](https://bpmn.io).',
+          type: 'text'
+        }
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
   });
 
 });


### PR DESCRIPTION
Discovered while working on https://github.com/camunda/team-hto/issues/28. Links and submit buttons have too less contrast against a white background. I propose to increase that a bit. /cc @RomanKostka @christian-konrad 

It doesn't make a big impact visually, but a big impact a11y wise :+1: 

_Before_

![image](https://user-images.githubusercontent.com/9433996/198305526-bc372150-61df-4b4d-a776-1ca40cbf4134.png)

![image](https://user-images.githubusercontent.com/9433996/198306087-ef5db04c-198a-461d-9537-c85e158a0213.png)

_After_

![image](https://user-images.githubusercontent.com/9433996/198306478-843bade4-7b75-4a7f-b0a4-b5a854e938c8.png)

![image](https://user-images.githubusercontent.com/9433996/198306262-cd8aa191-c49e-414e-9b3d-1280d94e42b0.png)
