### PR TITLE
chore(ci): pin ubuntu version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-20.04, windows-latest ]
         node-version: [ 16 ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Firefox is currently not included: https://github.com/actions/runner-images/issues/6399.

Let's pin this for the while being.
