### PR TITLE
Renovate/bpmn io properties panel 0.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "cross-env": "^7.0.3",
         "del-cli": "^4.0.0",
         "diagram-js": "^10.0.0",
+        "didi": "^9.0.0",
         "eslint": "^8.22.0",
         "eslint-plugin-bpmn-io": "^0.16.0",
         "eslint-plugin-import": "^2.26.0",
@@ -7713,12 +7714,6 @@
         "tiny-svg": "^3.0.0"
       }
     },
-    "node_modules/diagram-js/node_modules/didi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w==",
-      "dev": true
-    },
     "node_modules/diagram-js/node_modules/inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
@@ -7747,6 +7742,11 @@
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.0.tgz",
       "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w==",
       "dev": true
+    },
+    "node_modules/didi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -18914,11 +18914,6 @@
         "preact-markup": "^2.1.1"
       }
     },
-    "packages/form-js-viewer/node_modules/didi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
-    },
     "packages/form-js-viewer/node_modules/min-dash": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
@@ -19779,11 +19774,6 @@
         "preact-markup": "^2.1.1"
       },
       "dependencies": {
-        "didi": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-          "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
-        },
         "min-dash": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
@@ -25018,12 +25008,6 @@
         "tiny-svg": "^3.0.0"
       },
       "dependencies": {
-        "didi": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
-          "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w==",
-          "dev": true
-        },
         "inherits-browser": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
@@ -25054,6 +25038,11 @@
           "dev": true
         }
       }
+    },
+    "didi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-9.0.0.tgz",
+      "integrity": "sha512-bOZ7WAah3t8TxKV81pbIivHjWyABot49YXG1M3QztnUlZDHz3MRNJ1nZO87JbqrkqNI/2GR4ncHfXdGIP9LX+w=="
     },
     "diff": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.18.10",
         "@babel/plugin-transform-react-jsx": "^7.14.5",
         "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-        "@bpmn-io/properties-panel": "^0.21.0",
+        "@bpmn-io/properties-panel": "^0.23.0",
         "@rollup/plugin-alias": "^3.1.2",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^19.0.0",
@@ -982,19 +982,38 @@
       }
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.3.0.tgz",
-      "integrity": "sha512-TPDDc2vCALrMletpBos+jM7d96Qp+RWEa3D95H/4EbbDr3+kyqjUy1Omp/+yQGC4a5ryBRrEwAGHbkoAPwwbIQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.4.1.tgz",
+      "integrity": "sha512-+UGpofI09xGxs1Rr/1V3NLeNSfeKrIGcWvwDY5M3xb4tP6nOQfwqmQA1761Wni9fl3RuLzf6gOx7vGWeQ7afIA==",
       "dev": true,
       "dependencies": {
-        "@codemirror/autocomplete": "^6.0.3",
+        "@codemirror/autocomplete": "^6.1.1",
         "@codemirror/commands": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/lint": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
         "@lezer/highlight": "^1.0.0",
-        "lezer-feel": "^0.4.0"
+        "lang-feel": "^0.0.3",
+        "lezer-feel": "^0.14.1",
+        "min-dom": "^4.0.1"
+      }
+    },
+    "node_modules/@bpmn-io/feel-editor/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
+      "dev": true
+    },
+    "node_modules/@bpmn-io/feel-editor/node_modules/min-dom": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+      "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
+      "dev": true,
+      "dependencies": {
+        "component-event": "^0.1.4",
+        "domify": "^1.4.1",
+        "min-dash": "^4.0.0"
       }
     },
     "node_modules/@bpmn-io/form-js": {
@@ -1018,33 +1037,32 @@
       "link": true
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.21.0.tgz",
-      "integrity": "sha512-y9R6vMBFKNL2de4AAP8ep5X8temJMWHfDMTfMHM63G9oKhwEu15Q3Lidm3JmnobT7vUK3POugZJ/ZNK5Ko8igQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.23.0.tgz",
+      "integrity": "sha512-K/KHAf/XEhTPEeVmMdj9j6Al8XLz0eVdTBfKbyvAgSCbq4GVrEU/ylJVRyZo4KGRhj4O4AUo1zaal8pyhaAxdg==",
       "dev": true,
       "dependencies": {
-        "@bpmn-io/feel-editor": "0.3.0",
+        "@bpmn-io/feel-editor": "0.4.1",
         "classnames": "^2.3.1",
-        "diagram-js": "^8.9.0",
-        "min-dash": "^3.8.1",
-        "min-dom": "^3.2.1"
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.3"
       }
     },
-    "node_modules/@bpmn-io/properties-panel/node_modules/diagram-js": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
-      "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
+    "node_modules/@bpmn-io/properties-panel/node_modules/min-dash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+      "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
+      "dev": true
+    },
+    "node_modules/@bpmn-io/properties-panel/node_modules/min-dom": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+      "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
       "dev": true,
       "dependencies": {
-        "css.escape": "^1.5.1",
-        "didi": "^8.0.1",
-        "hammerjs": "^2.0.1",
-        "inherits-browser": "0.0.1",
-        "min-dash": "^3.5.2",
-        "min-dom": "^3.2.0",
-        "object-refs": "^0.3.0",
-        "path-intersection": "^2.2.1",
-        "tiny-svg": "^2.2.2"
+        "component-event": "^0.1.4",
+        "domify": "^1.4.1",
+        "min-dash": "^4.0.0"
       }
     },
     "node_modules/@bpmn-io/snarkdown": {
@@ -1053,9 +1071,9 @@
       "integrity": "sha512-OWe9YQx3Vtnopz0trJCJVI3y7k2EfeR4QkKHfRhukcB7yxG4PD1FGaB5LAxc1wxp66V1S3LU4bqUpJdVhQhIww=="
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz",
-      "integrity": "sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz",
+      "integrity": "sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -7730,12 +7748,6 @@
       "integrity": "sha512-+u6VomQO7MbI7CQe5q1IwNePpbVKG/HVdUQBmaEpSCdP/QmeyjhrS6WKFsNetXlvf9LWu/f5woRqjMdxBMe/0w==",
       "dev": true
     },
-    "node_modules/didi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.1.tgz",
-      "integrity": "sha512-7oXiXbp8DHE3FfQsVBkc2pwePo3Jy2uyGS9trAeBmfxiZAP4WV23LWokRpMmyl3hlu8OEAsyMxx19i5P6TVaJQ==",
-      "dev": true
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -10731,12 +10743,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "node_modules/inherits-browser": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
-      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw==",
-      "dev": true
-    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -11845,6 +11851,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lang-feel": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-0.0.3.tgz",
+      "integrity": "sha512-YEs49jXQfLetXUr4Sj+pq9kcwHyNFcEYiXvm/bRvQyUwVfUEAHQdeFneqw+5zGeDuKDgIGxawXVs7uysXaLrjQ==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "lezer-feel": "^0.14.1"
+      }
+    },
     "node_modules/lerna": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/lerna/-/lerna-5.5.4.tgz",
@@ -11893,27 +11913,13 @@
       }
     },
     "node_modules/lezer-feel": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.4.0.tgz",
-      "integrity": "sha512-yd+AWsOE4NGVeW4x50HXUA9dKs9MUa7H8PATPNEmBiXKfIijPlC6+FEy8OLjOzb4b9y9pPPpAqnZ2/kvLmvZVw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+      "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
       "dev": true,
       "dependencies": {
-        "@lezer/lr": "^0.16.0"
-      }
-    },
-    "node_modules/lezer-feel/node_modules/@lezer/common": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-      "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-      "dev": true
-    },
-    "node_modules/lezer-feel/node_modules/@lezer/lr": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
-      "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
-      "dev": true,
-      "dependencies": {
-        "@lezer/common": "^0.16.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.2.3"
       }
     },
     "node_modules/libnpmaccess": {
@@ -17755,12 +17761,6 @@
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
       "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
-    "node_modules/tiny-svg": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==",
-      "dev": true
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -19648,19 +19648,40 @@
       }
     },
     "@bpmn-io/feel-editor": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.3.0.tgz",
-      "integrity": "sha512-TPDDc2vCALrMletpBos+jM7d96Qp+RWEa3D95H/4EbbDr3+kyqjUy1Omp/+yQGC4a5ryBRrEwAGHbkoAPwwbIQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.4.1.tgz",
+      "integrity": "sha512-+UGpofI09xGxs1Rr/1V3NLeNSfeKrIGcWvwDY5M3xb4tP6nOQfwqmQA1761Wni9fl3RuLzf6gOx7vGWeQ7afIA==",
       "dev": true,
       "requires": {
-        "@codemirror/autocomplete": "^6.0.3",
+        "@codemirror/autocomplete": "^6.1.1",
         "@codemirror/commands": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/lint": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
         "@lezer/highlight": "^1.0.0",
-        "lezer-feel": "^0.4.0"
+        "lang-feel": "^0.0.3",
+        "lezer-feel": "^0.14.1",
+        "min-dom": "^4.0.1"
+      },
+      "dependencies": {
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
+          "dev": true
+        },
+        "min-dom": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+          "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
+          "dev": true,
+          "requires": {
+            "component-event": "^0.1.4",
+            "domify": "^1.4.1",
+            "min-dash": "^4.0.0"
+          }
+        }
       }
     },
     "@bpmn-io/form-js": {
@@ -19771,33 +19792,32 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.21.0.tgz",
-      "integrity": "sha512-y9R6vMBFKNL2de4AAP8ep5X8temJMWHfDMTfMHM63G9oKhwEu15Q3Lidm3JmnobT7vUK3POugZJ/ZNK5Ko8igQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.23.0.tgz",
+      "integrity": "sha512-K/KHAf/XEhTPEeVmMdj9j6Al8XLz0eVdTBfKbyvAgSCbq4GVrEU/ylJVRyZo4KGRhj4O4AUo1zaal8pyhaAxdg==",
       "dev": true,
       "requires": {
-        "@bpmn-io/feel-editor": "0.3.0",
+        "@bpmn-io/feel-editor": "0.4.1",
         "classnames": "^2.3.1",
-        "diagram-js": "^8.9.0",
-        "min-dash": "^3.8.1",
-        "min-dom": "^3.2.1"
+        "min-dash": "^4.0.0",
+        "min-dom": "^4.0.3"
       },
       "dependencies": {
-        "diagram-js": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-8.9.0.tgz",
-          "integrity": "sha512-577bUEbkwZ7id4SCXcD2qrlKoRPXry2SDSPt5T6tEOjwKrTllKr5d1HZoJzGws4VMQq5fmY51Gce1iFT9S4Dlw==",
+        "min-dash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.0.0.tgz",
+          "integrity": "sha512-piIvVJ/nxuA4+LpnYIzF6oCtRvdtDvQJteSC+H768H2UvPKFKIt5oiJnUVtr0ZdchneXTcvUZ91vIrvWVIN0AA==",
+          "dev": true
+        },
+        "min-dom": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.0.3.tgz",
+          "integrity": "sha512-5zQyCMe8rtGiDIRjfGeqnF2YPJ7OAPFdJQeC7MakHais3dh4VG4PV2a0FacziKTzJjYK5qnPKm2sq1wSXB1wTQ==",
           "dev": true,
           "requires": {
-            "css.escape": "^1.5.1",
-            "didi": "^8.0.1",
-            "hammerjs": "^2.0.1",
-            "inherits-browser": "0.0.1",
-            "min-dash": "^3.5.2",
-            "min-dom": "^3.2.0",
-            "object-refs": "^0.3.0",
-            "path-intersection": "^2.2.1",
-            "tiny-svg": "^2.2.2"
+            "component-event": "^0.1.4",
+            "domify": "^1.4.1",
+            "min-dash": "^4.0.0"
           }
         }
       }
@@ -19808,9 +19828,9 @@
       "integrity": "sha512-OWe9YQx3Vtnopz0trJCJVI3y7k2EfeR4QkKHfRhukcB7yxG4PD1FGaB5LAxc1wxp66V1S3LU4bqUpJdVhQhIww=="
     },
     "@codemirror/autocomplete": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz",
-      "integrity": "sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz",
+      "integrity": "sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -25035,12 +25055,6 @@
         }
       }
     },
-    "didi": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-8.0.1.tgz",
-      "integrity": "sha512-7oXiXbp8DHE3FfQsVBkc2pwePo3Jy2uyGS9trAeBmfxiZAP4WV23LWokRpMmyl3hlu8OEAsyMxx19i5P6TVaJQ==",
-      "dev": true
-    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -27270,12 +27284,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "inherits-browser": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.0.1.tgz",
-      "integrity": "sha512-kaDA3DkCdCpvrKIo/1T/3yVn+qpFUHLjYtSHmTYewb+QfjfaQy6FGQ7LwBu7st0tG9UvYad/XAlqQmdIh6CICw==",
-      "dev": true
-    },
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -28102,6 +28110,20 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "lang-feel": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-0.0.3.tgz",
+      "integrity": "sha512-YEs49jXQfLetXUr4Sj+pq9kcwHyNFcEYiXvm/bRvQyUwVfUEAHQdeFneqw+5zGeDuKDgIGxawXVs7uysXaLrjQ==",
+      "dev": true,
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "lezer-feel": "^0.14.1"
+      }
+    },
     "lerna": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/lerna/-/lerna-5.5.4.tgz",
@@ -28141,29 +28163,13 @@
       }
     },
     "lezer-feel": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.4.0.tgz",
-      "integrity": "sha512-yd+AWsOE4NGVeW4x50HXUA9dKs9MUa7H8PATPNEmBiXKfIijPlC6+FEy8OLjOzb4b9y9pPPpAqnZ2/kvLmvZVw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-0.14.1.tgz",
+      "integrity": "sha512-sfpzZvAtObFon74XiFp1L8pS1FminnfM8JAm4S2Kxk7Wk8qYe7crjJdhHqju/MKl9dV5s44NHDhbq5tCDWMTlw==",
       "dev": true,
       "requires": {
-        "@lezer/lr": "^0.16.0"
-      },
-      "dependencies": {
-        "@lezer/common": {
-          "version": "0.16.1",
-          "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.16.1.tgz",
-          "integrity": "sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==",
-          "dev": true
-        },
-        "@lezer/lr": {
-          "version": "0.16.3",
-          "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.16.3.tgz",
-          "integrity": "sha512-pau7um4eAw94BEuuShUIeQDTf3k4Wt6oIUOYxMmkZgDHdqtIcxWND4LRxi8nI9KuT4I1bXQv67BCapkxt7Ywqw==",
-          "dev": true,
-          "requires": {
-            "@lezer/common": "^0.16.0"
-          }
-        }
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.2.3"
       }
     },
     "libnpmaccess": {
@@ -32528,12 +32534,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
       "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
-    },
-    "tiny-svg": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-2.2.2.tgz",
-      "integrity": "sha512-u6zCuMkDR/3VAh83X7hDRn/pi0XhwG2ycuNS0cTFtQjGdOG2tSvEb8ds65VeGWc3H6PUjJKeunueXqgkZqtMsg==",
-      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@babel/core": "^7.18.10",
     "@babel/plugin-transform-react-jsx": "^7.14.5",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-    "@bpmn-io/properties-panel": "^0.21.0",
+    "@bpmn-io/properties-panel": "^0.23.0",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "chai": "^4.3.5",
     "cross-env": "^7.0.3",
     "del-cli": "^4.0.0",
+    "didi": "^9.0.0",
     "diagram-js": "^10.0.0",
     "eslint": "^8.22.0",
     "eslint-plugin-bpmn-io": "^0.16.0",


### PR DESCRIPTION
Also adds `didi` to the editor. With this properties panel version it starts to report missing types. 

As the `viewer` also has the `didi` dependency, I wonder why the `editor` doesn't have it already. 

![image](https://user-images.githubusercontent.com/9433996/199999623-5dd5d77b-e139-4aa6-9f1e-1866c0911e93.png)

