### PR TITLE
chore: bump to `schemaVersion@6`

### DIFF
--- a/packages/form-js-viewer/src/index.js
+++ b/packages/form-js-viewer/src/index.js
@@ -4,7 +4,7 @@ export { FormFieldRegistry } from './core';
 export * from './render';
 export * from './util';
 
-const schemaVersion = 5;
+const schemaVersion = 6;
 
 export {
   Form,

--- a/packages/form-js/test/spec/Form.spec.js
+++ b/packages/form-js/test/spec/Form.spec.js
@@ -128,7 +128,7 @@ describe('viewer exports', function() {
   it('should expose schemaVersion', function() {
     expect(typeof schemaVersion).to.eql('number');
 
-    expect(schemaVersion).to.eql(5);
+    expect(schemaVersion).to.eql(6);
   });
 
 


### PR DESCRIPTION
Just to make sure we already did that. There will be a bunch of schema changes in the upcoming days.

Related to https://github.com/camunda/team-hto/issues/44