### PR TITLE
Sprint week: conditional properties (read-only + label)

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/PropertiesPanel.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesPanel.js
@@ -19,6 +19,7 @@ import {
   FormatGroup,
   ConstraintsGroup,
   ImageGroup,
+  InteractionGroup,
   ValidationGroup,
   ValuesGroups
 } from './groups';
@@ -33,6 +34,7 @@ function getGroups(field, editField) {
     GeneralGroup(field, editField),
     ConditionGroup(field, editField),
     DisplayGroup(field, editField),
+    InteractionGroup(field, editField),
     FormatGroup(field, editField),
     ...ValuesGroups(field, editField),
     ConstraintsGroup(field, editField),

--- a/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
@@ -1,43 +1,39 @@
-import { get } from 'min-dash';
-
 import { useRef } from 'preact/hooks';
-
-import { INPUTS } from '../Util';
+import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { get } from 'min-dash';
 
 import { getSchemaVariables } from '@bpmn-io/form-js-viewer';
 
 import { useService } from '../hooks';
 import { usePrevious } from '../../../render/hooks';
 
-import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { INPUTS } from '../Util';
 
 
-export default function LabelEntry(props) {
+
+export default function ReadonlyEntry(props) {
   const {
     editField,
     field
   } = props;
 
-  const {
-    type
-  } = field;
+  if (!INPUTS.includes(field.type)) {
+    return [];
+  }
 
-  const entries = [];
-
-  if (INPUTS.includes(type) || type === 'button') {
-    entries.push({
-      id: 'label',
-      component: Label,
+  return [
+    {
+      id: 'readonly',
+      component: Readonly,
       editField: editField,
       field: field,
       isEdited: isFeelEntryEdited
-    });
-  }
-
-  return entries;
+    }
+  ];
 }
 
-function Label(props) {
+
+function Readonly(props) {
   const {
     editField,
     field,
@@ -48,23 +44,24 @@ function Label(props) {
 
   const variables = useVariables();
 
-  const path = [ 'label' ];
+  const path = [ 'readonly' ];
 
   const getValue = () => {
     return get(field, path, '');
   };
 
   const setValue = (value) => {
-    return editField(field, path, value);
+    return editField(field, { readonly: value });
   };
 
   return FeelEntry({
     debounce,
+    description: 'Condition under which the field is readonly',
     element: field,
-    feel: 'optional',
+    feel: 'required',
     getValue,
     id,
-    label: 'Field label',
+    label: 'Read only',
     setValue,
     variables
   });

--- a/packages/form-js-editor/src/features/properties-panel/entries/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/index.js
@@ -21,3 +21,4 @@ export { default as StaticValuesSourceEntry } from './StaticValuesSourceEntry';
 export { default as NumberConstraintsEntry } from './NumberConstraintsEntry';
 export { default as AdornerEntry } from './AdornerEntry';
 export { ConditionEntry } from './ConditionEntry';
+export { default as ReadonlyEntry } from './ReadonlyEntry';

--- a/packages/form-js-editor/src/features/properties-panel/groups/GeneralGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/GeneralGroup.js
@@ -3,7 +3,6 @@ import {
   ColumnsEntry,
   DescriptionEntry,
   DefaultValueEntry,
-  DisabledEntry,
   IdEntry,
   KeyEntry,
   LabelEntry,
@@ -23,8 +22,7 @@ export default function GeneralGroup(field, editField) {
     ...ActionEntry({ field, editField }),
     ...ColumnsEntry({ field, editField }),
     ...DateTimeEntry({ field, editField }),
-    ...TextEntry({ field, editField }),
-    ...DisabledEntry({ field, editField })
+    ...TextEntry({ field, editField })
   ];
 
   return {

--- a/packages/form-js-editor/src/features/properties-panel/groups/InteractionGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/InteractionGroup.js
@@ -1,0 +1,23 @@
+import {
+  DisabledEntry,
+  ReadonlyEntry
+} from '../entries';
+
+
+export default function InteractionGroup(field, editField) {
+
+  const entries = [
+    ...DisabledEntry({ field, editField }),
+    ...ReadonlyEntry({ field, editField })
+  ];
+
+  if (!entries.length) {
+    return null;
+  }
+
+  return {
+    id: 'interaction',
+    label: 'Interaction',
+    entries
+  };
+}

--- a/packages/form-js-editor/src/features/properties-panel/groups/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/index.js
@@ -7,3 +7,4 @@ export { default as ValidationGroup } from './ValidationGroup';
 export { default as ValuesGroups } from './ValuesGroups';
 export { default as CustomValuesGroup } from './CustomValuesGroup';
 export { ConditionGroup } from './ConditionGroup';
+export { default as InteractionGroup } from './InteractionGroup';

--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -32,12 +32,14 @@
   --color-background: var(--color-white);
   --color-background-disabled: var(--color-grey-225-10-95);
   --color-background-adornment: var(--color-grey-225-10-93);
+  --color-background-readonly: transparent;
   --color-text: var(--color-grey-225-10-15);
   --color-text-light: var(--color-grey-225-10-35);
   --color-text-lighter: var(--color-grey-225-10-55);
   --color-text-inverted: var(--color-white);
   --color-borders: var(--color-grey-225-10-55);
   --color-borders-disabled: var(--color-grey-225-10-75);
+  --color-borders-readonly: transparent;
   --color-borders-adornment: var(--color-grey-225-10-85);
   --color-warning: var(--color-red-360-100-45);
   --color-accent: var(--color-blue-205-100-40);
@@ -46,6 +48,7 @@
 
   --border-definition: 1px solid var(--color-borders);
   --outline-definition: 1px solid var(--color-borders);
+  --outline-definition-readonly: 1px solid var(--color-borders-readonly);
   --border-definition-disabled: 1px solid var(--color-borders-disabled);
 
   height: 100%;
@@ -327,6 +330,36 @@
 .fjs-container .fjs-taglist.disabled {
   background-color: var(--color-background-disabled);
   border-color: var(--color-borders-disabled);
+}
+
+.fjs-container .fjs-input-group.readonly, 
+.fjs-container .fjs-input.readonly,
+.fjs-container .fjs-textarea.readonly,
+.fjs-container .fjs-input-group .fjs-input.read-only {
+  background-color: var(--color-background-readonly);
+  border-color: var(--color-borders-readonly);
+}
+
+.fjs-container .fjs-select.readonly,
+.fjs-container .fjs-taglist.readonly,
+.fjs-container .fjs-form-field-checkbox.readonly,
+.fjs-container .fjs-form-field-checklist.readonly,
+.fjs-container .fjs-form-field-radio.readonly,
+.fjs-container .fjs-form-field-datetime.readonly {
+  pointer-events: none;
+}
+
+.fjs-container .fjs-taglist.readonly .fjs-taglist-tag-remove {
+  pointer-events: none;
+}
+
+.fjs-container .fjs-taglist.readonly:focus-within,
+.fjs-container .fjs-input-group.readonly:focus-within,
+.fjs-container .fjs-input[type='text'].readonly:focus,
+.fjs-container .fjs-input[type='number'].readonly:focus,
+.fjs-container .fjs-textarea.readonly:focus,
+.fjs-container .fjs-select.readonly:focus {
+  outline: var(--outline-definition-readonly);
 }
 
 .fjs-container .fjs-button[type='submit']:disabled,

--- a/packages/form-js-viewer/src/core/ConditionChecker.js
+++ b/packages/form-js-viewer/src/core/ConditionChecker.js
@@ -1,4 +1,4 @@
-import { unaryTest } from 'feelin';
+import { unaryTest, evaluate } from 'feelin';
 import { isString } from 'min-dash';
 
 export class ConditionChecker {
@@ -32,12 +32,13 @@ export class ConditionChecker {
    *
    * @param {string} condition
    * @param {import('../types').Data} [data]
+   * @param {boolean} [defaultValue]
    *
    * @returns {boolean}
    */
-  check(condition, data = {}) {
+  check(condition, data = {}, defaultValue) {
     if (!condition) {
-      return true;
+      return defaultValue;
     }
 
     if (!isString(condition) || !condition.startsWith('=')) {
@@ -46,6 +47,24 @@ export class ConditionChecker {
 
     try {
       const result = unaryTest(condition.slice(1), data);
+
+      return result;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  evaluate(condition, data = {}, defaultValue) {
+    if (!condition) {
+      return defaultValue;
+    }
+
+    if (!isString(condition) || !condition.startsWith('=')) {
+      return false;
+    }
+
+    try {
+      const result = evaluate(condition.slice(1), data);
 
       return result;
     } catch (error) {

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -153,6 +153,25 @@ export default class Importer {
         };
       }
 
+      // get values defined via expression
+      // todo(pinussilvestrus): how to correctly get input variables from expressions
+      // in a general manner
+      [
+        'readonly',
+        'label'
+      ].forEach(property => {
+        if (formField[property]) {
+          Object.keys(data).forEach(key => {
+            if (formField[property].includes(key)) {
+              importedData = {
+                ...importedData,
+                [ key ]: get(data, [ key ])
+              };
+            }
+          });
+        }
+      });
+
       // try to get value from data
       // if unavailable - try to get default value from form field
       // if unavailable - get empty value from form field

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -1,11 +1,11 @@
 import { useContext } from 'preact/hooks';
 
-import { get } from 'min-dash';
+import { get, isString } from 'min-dash';
 
 import { FormRenderContext } from '../context';
 
 import useService from '../hooks/useService';
-import { useCondition } from '../hooks/useCondition';
+import { useCondition, useConditionEvaluation } from '../hooks/useCondition';
 
 import { findErrors } from '../../util';
 
@@ -46,7 +46,14 @@ export default function FormField(props) {
 
   const disabled = properties.readOnly || field.disabled || false;
 
-  const visible = useCondition(field.condition, data);
+  // todo(pinussilvestrus): find a general approach to retrieve conditional expression properties
+  const readonly = useCondition(field.readonly, data, false);
+
+  // todo(pinussilvestrus): only demo purposes, remove me later
+  // eslint-disable-next-line
+  const label = isExpression(field.label) ? useConditionEvaluation(field.label, data, '') : field.label;
+
+  const visible = useCondition(field.condition, data, true);
   if (!visible) {
     return <Empty />;
   }
@@ -58,7 +65,16 @@ export default function FormField(props) {
         disabled={ disabled }
         errors={ fieldErrors }
         onChange={ disabled ? noop : onChange }
+        label={ label }
+        readonly={ readonly }
         value={ value } />
     </Element>
   );
+}
+
+
+// helper ///////////////
+
+function isExpression(value) {
+  return isString(value) && value.startsWith('=');
 }

--- a/packages/form-js-viewer/src/render/components/form-fields/Button.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Button.js
@@ -6,13 +6,14 @@ const type = 'button';
 export default function Button(props) {
   const {
     disabled,
-    field
+    field,
+    label
   } = props;
 
   const { action = 'submit' } = field;
 
   return <div class={ formFieldClasses(type) }>
-    <button class="fjs-button" type={ action } disabled={ disabled }>{ field.label }</button>
+    <button class="fjs-button" type={ action } disabled={ disabled }>{ label }</button>
   </div>;
 }
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -1,5 +1,7 @@
 import { useContext } from 'preact/hooks';
 
+import classNames from 'classnames';
+
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -19,13 +21,14 @@ export default function Checkbox(props) {
     disabled,
     errors = [],
     field,
+    label,
+    readonly,
     value = false
   } = props;
 
   const {
     description,
-    id,
-    label
+    id
   } = field;
 
   const onChange = ({ target }) => {
@@ -35,9 +38,10 @@ export default function Checkbox(props) {
     });
   };
 
+
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ classNames(formFieldClasses(type, errors), { readonly }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }
@@ -45,6 +49,9 @@ export default function Checkbox(props) {
       <input
         checked={ value }
         class="fjs-input"
+
+        // todo(pinussilvestrus): a11y concerns?
+        tabIndex={ readonly ? -1 : 0 }
         disabled={ disabled }
         id={ prefixId(id, formId) }
         type="checkbox"

--- a/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
@@ -1,6 +1,8 @@
 import { useContext } from 'preact/hooks';
 import useValuesAsync, { LOAD_STATES } from '../../hooks/useValuesAsync';
 
+import classNames from 'classnames';
+
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -21,13 +23,14 @@ export default function Checklist(props) {
     disabled,
     errors = [],
     field,
-    value = [],
+    label,
+    readonly,
+    value = []
   } = props;
 
   const {
     description,
-    id,
-    label
+    id
   } = field;
 
   const toggleCheckbox = (v) => {
@@ -53,7 +56,7 @@ export default function Checklist(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ classNames(formFieldClasses(type, errors), { readonly }) }>
     <Label
       label={ label } />
     {
@@ -68,6 +71,9 @@ export default function Checklist(props) {
               checked={ value.includes(v.value) }
               class="fjs-input"
               disabled={ disabled }
+
+              // todo(pinussilvestrus): a11y concerns?
+              tabIndex={ readonly ? -1 : 0 }
               id={ prefixId(`${id}-${index}`, formId) }
               type="checkbox"
               onClick={ () => toggleCheckbox(v.value) } />

--- a/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
@@ -26,6 +26,7 @@ export default function Datetime(props) {
     errors = [],
     field,
     onChange,
+    readonly,
     value = ''
   } = props;
 
@@ -126,6 +127,7 @@ export default function Datetime(props) {
     disabled,
     disallowPassedDates,
     date,
+    readonly,
     setDate
   };
 
@@ -133,13 +135,14 @@ export default function Datetime(props) {
     id,
     formId,
     disabled,
+    readonly,
     use24h,
     timeInterval,
     time,
     setTime
   };
 
-  return <div class={ formFieldClasses(type, allErrors) }>
+  return <div class={ classNames(formFieldClasses(type, allErrors), { readonly }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -1,5 +1,7 @@
 import { useContext, useMemo, useRef, useState } from 'preact/hooks';
 
+import classNames from 'classnames';
+
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -20,15 +22,15 @@ export default function Number(props) {
     disabled,
     errors = [],
     field,
-    value,
+    label,
+    readonly,
     onChange,
-
+    value
   } = props;
 
   const {
     description,
     id,
-    label,
     prefixAdorner,
     suffixAdorner,
     validate = {},
@@ -97,15 +99,16 @@ export default function Number(props) {
       id={ prefixId(id, formId) }
       label={ label }
       required={ required } />
-    <InputAdorner disabled={ disabled } pre={ prefixAdorner } post={ suffixAdorner }>
+    <InputAdorner disabled={ disabled } readonly={ readonly } pre={ prefixAdorner } post={ suffixAdorner }>
       <input
         ref={ numberInputRef }
-        class="fjs-input"
+        class={ classNames('fjs-input', { readonly }) }
         disabled={ disabled }
         id={ prefixId(id, formId) }
 
         // @ts-ignore
         onKeyPress={ onKeyPress }
+        readonly={ readonly }
         onInput={ onInput }
         type="number"
         step={ appliedStep }

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -1,6 +1,8 @@
 import { useContext } from 'preact/hooks';
 import useValuesAsync, { LOAD_STATES } from '../../hooks/useValuesAsync';
 
+import classNames from 'classnames';
+
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -21,13 +23,14 @@ export default function Radio(props) {
     disabled,
     errors = [],
     field,
+    label,
+    readonly,
     value
   } = props;
 
   const {
     description,
     id,
-    label,
     validate = {}
   } = field;
 
@@ -61,9 +64,12 @@ export default function Radio(props) {
             required={ false }>
             <input
               checked={ option.value === value }
-              class="fjs-input"
+              class={ classNames('fjs-input', { readonly }) }
               disabled={ disabled }
               id={ prefixId(`${ id }-${ index }`, formId) }
+
+              // todo(pinussilvestrus): a11y concerns?
+              tabIndex={ readonly ? -1 : 0 }
               type="radio"
               onClick={ () => onChange(option.value) } />
           </Label>

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -1,6 +1,8 @@
 import { useContext } from 'preact/hooks';
 import useOptionsAsync, { LOAD_STATES } from '../../hooks/useValuesAsync';
 
+import classNames from 'classnames';
+
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -20,13 +22,14 @@ export default function Select(props) {
     disabled,
     errors = [],
     field,
-    value
+    label,
+    value,
+    readonly
   } = props;
 
   const {
     description,
     id,
-    label,
     validate = {}
   } = field;
 
@@ -52,10 +55,13 @@ export default function Select(props) {
       label={ label }
       required={ required } />
     <select
-      class="fjs-select"
+      class={ classNames('fjs-select', { readonly }) }
       disabled={ disabled }
       id={ prefixId(id, formId) }
       onChange={ onChange }
+
+      // todo(pinussilvestrus): a11y concerns?
+      tabIndex={ readonly ? -1 : 0 }
       value={ value || '' }>
       <option value=""></option>
       {

--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -24,13 +24,14 @@ export default function Taglist(props) {
     disabled,
     errors = [],
     field,
+    label,
+    readonly,
     value : values = []
   } = props;
 
   const {
     description,
     id,
-    label
   } = field;
 
   const { formId } = useContext(FormContext);
@@ -114,7 +115,7 @@ export default function Taglist(props) {
     <Label
       label={ label }
       id={ prefixId(`${id}-search`, formId) } />
-    <div class={ classNames('fjs-taglist', { 'disabled': disabled }) }>
+    <div class={ classNames('fjs-taglist', { disabled, readonly }) }>
       {!disabled && loadState === LOAD_STATES.LOADED &&
         values.map((v) => {
           return (
@@ -137,13 +138,16 @@ export default function Taglist(props) {
         value={ filter }
         placeholder={ 'Search' }
         autoComplete="off"
+
+        // todo(pinussilvestrus): a11y concerns?
+        tabIndex={ readonly ? -1 : 0 }
         onKeyDown={ (e) => onInputKeyDown(e) }
         onMouseDown={ () => setIsEscapeClose(false) }
         onFocus={ () => setIsDropdownExpanded(true) }
         onBlur={ () => { setIsDropdownExpanded(false); setFilter(''); } } />
     </div>
     <div class="fjs-taglist-anchor">
-      {!disabled && loadState === LOAD_STATES.LOADED && isDropdownExpanded && !isEscapeClosed && <DropdownList
+      {!disabled && !readonly && loadState === LOAD_STATES.LOADED && isDropdownExpanded && !isEscapeClosed && <DropdownList
         values={ filteredOptions }
         getLabel={ (o) => o.label }
         onValueSelected={ (o) => selectValue(o.value) }

--- a/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
@@ -1,6 +1,8 @@
 import { isArray, isObject } from 'min-dash';
 import { useCallback, useContext, useEffect, useRef } from 'preact/hooks';
 
+import classNames from 'classnames';
+
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -20,13 +22,14 @@ export default function Textarea(props) {
     disabled,
     errors = [],
     field,
+    label,
+    readonly,
     value = ''
   } = props;
 
   const {
     description,
     id,
-    label,
     validate = {}
   } = field;
 
@@ -76,11 +79,12 @@ export default function Textarea(props) {
       id={ prefixId(id, formId) }
       label={ label }
       required={ required } />
-    <textarea class="fjs-textarea"
+    <textarea class={ classNames('fjs-textarea', { readonly }) }
       disabled={ disabled }
       id={ prefixId(id, formId) }
       onInput={ onInput }
       value={ value }
+      readonly={ readonly }
       ref={ textareaRef } />
     <Description description={ description } />
     <Errors errors={ errors } />

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -1,4 +1,7 @@
 import { isArray, isObject } from 'min-dash';
+
+import classNames from 'classnames';
+
 import { useContext } from 'preact/hooks';
 
 import { FormContext } from '../../context';
@@ -21,13 +24,14 @@ export default function Textfield(props) {
     disabled,
     errors = [],
     field,
+    label,
+    readonly,
     value = ''
   } = props;
 
   const {
     description,
     id,
-    label,
     prefixAdorner,
     suffixAdorner,
     validate = {}
@@ -49,10 +53,11 @@ export default function Textfield(props) {
       id={ prefixId(id, formId) }
       label={ label }
       required={ required } />
-    <InputAdorner disabled={ disabled } pre={ prefixAdorner } post={ suffixAdorner }>
+    <InputAdorner disabled={ disabled } readonly={ readonly } pre={ prefixAdorner } post={ suffixAdorner }>
       <input
-        class="fjs-input"
+        class={ classNames('fjs-input', { readonly }) }
         disabled={ disabled }
+        readonly={ readonly }
         id={ prefixId(id, formId) }
         onInput={ onChange }
         type="text"

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
@@ -13,6 +13,7 @@ export default function Datepicker(props) {
     disabled,
     disallowPassedDates,
     date,
+    readonly,
     setDate
   } = props;
 
@@ -169,7 +170,10 @@ export default function Datepicker(props) {
       <input ref={ dateInputRef }
         type="text"
         id={ `${prefixId(id, formId)}--date` }
-        class={ 'fjs-input' }
+        class="fjs-input"
+
+        // todo(pinussilvestrus): a11y concerns?
+        tabIndex={ readonly ? -1 : 0 }
         disabled={ disabled }
         placeholder="MM/DD/YYYY"
         autoComplete="false"

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/InputAdorner.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/InputAdorner.js
@@ -9,12 +9,13 @@ export default function InputAdorner(props) {
     inputRef,
     children,
     disabled,
+    readonly,
     hasErrors
   } = props;
 
   const onAdornmentClick = () => inputRef?.current?.focus();
 
-  return <div class={ classNames('fjs-input-group', { 'disabled': disabled }, { 'hasErrors': hasErrors }) } ref={ rootRef }>
+  return <div class={ classNames('fjs-input-group', { 'disabled': disabled, 'readonly': readonly }, { 'hasErrors': hasErrors }) } ref={ rootRef }>
     { pre !== null && <span class="fjs-input-adornment border-right border-radius-left" onClick={ onAdornmentClick }> { pre } </span> }
     { children }
     { post !== null && <span class="fjs-input-adornment border-left border-radius-right" onClick={ onAdornmentClick }> { post } </span> }

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Timepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Timepicker.js
@@ -13,6 +13,7 @@ export default function Timepicker(props) {
     id,
     formId,
     disabled,
+    readonly,
     use24h = false,
     timeInterval,
     time,
@@ -121,6 +122,9 @@ export default function Timepicker(props) {
         type="text"
         id={ `${prefixId(id, formId)}--time` }
         class="fjs-input"
+
+        // todo(pinussilvestrus): a11y concerns?
+        tabIndex={ readonly ? -1 : 0 }
         value={ rawValue }
         disabled={ disabled }
         placeholder={ use24h ? 'HH:MM' : 'HH:MM ?M' }

--- a/packages/form-js-viewer/src/render/hooks/useCondition.js
+++ b/packages/form-js-viewer/src/render/hooks/useCondition.js
@@ -5,12 +5,22 @@ import useService from './useService.js';
  * @param {{ expression?: string } | undefined} condition
  * @param {import('../../types').Data} data
  */
-export function useCondition(condition, data) {
+export function useCondition(condition, data, defaultValue) {
   const conditionChecker = useService('conditionChecker', false);
 
   if (!conditionChecker) {
-    return true;
+    return defaultValue;
   }
 
-  return conditionChecker.check(condition, data);
+  return conditionChecker.check(condition, data, defaultValue);
+}
+
+export function useConditionEvaluation(condition, data, defaultValue) {
+  const conditionChecker = useService('conditionChecker', false);
+
+  if (!conditionChecker) {
+    return defaultValue;
+  }
+
+  return conditionChecker.evaluate(condition, data, defaultValue);
 }

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -102,6 +102,7 @@ export function getSchemaVariables(schema) {
       variables = [ ...variables, source ];
     }
 
+    // todo(pinussilvestrus): extract variables defined in FEEL expressions
     return variables;
 
   }, []);


### PR DESCRIPTION

Related to #396

This includes a demo spike for the conditional properties via FEEL. It also adds the `readonly` property to showcase using FEEL expression for specific properties, and adds the capability for the `label` property as well.

![image](https://user-images.githubusercontent.com/9433996/201034553-a940cd86-82b5-44c1-92ea-c70c8507929c.png)


_Missing for `develop`_
* clarify generic FEEL expression handling together with conditional-rendering
* label is only FEEL for demo purposes (to be removed)
* clarify readonly styling for all components (most are simply not interactible for now)
* help users is adding some validation saying that the expression should evaluate to a boolean (readonly)