### PR TITLE
removed dependency on initialData

### DIFF
--- a/packages/form-js-viewer/src/core/ConditionChecker.js
+++ b/packages/form-js-viewer/src/core/ConditionChecker.js
@@ -13,9 +13,11 @@ export class ConditionChecker {
    * @param {Object<string, any>} data
    */
   applyConditions(properties, data = {}) {
+
     const conditions = this._getConditions();
 
     const newProperties = { ...properties };
+
     for (const { key, condition } of conditions) {
       const shouldRemove = !this.check(condition, data);
 
@@ -56,21 +58,16 @@ export class ConditionChecker {
   _getConditions() {
     const formFields = this._formFieldRegistry.getAll();
 
-    const conditions = [];
-    for (const field of formFields) {
-      const { key, condition } = field;
+    return formFields.reduce((conditions, formField) => {
+      const { key, condition } = formField;
 
-      if (!condition || !key) {
-        continue;
+      if (key && condition) {
+        return [ ...conditions, { key, condition } ];
       }
 
-      conditions.push({
-        key,
-        condition
-      });
-    }
+      return conditions;
 
-    return conditions;
+    }, []);
   }
 }
 

--- a/packages/form-js-viewer/src/import/Importer.js
+++ b/packages/form-js-viewer/src/import/Importer.js
@@ -38,12 +38,12 @@ export default class Importer {
 
     try {
       const importedSchema = this.importFormField(clone(schema)),
-            importedData = this.importData(clone(data));
+            initializedData = this.initializeFieldValues(clone(data));
 
       return {
         warnings,
         schema: importedSchema,
-        data: importedData
+        data: initializedData
       };
     } catch (err) {
       err.warnings = warnings;
@@ -124,25 +124,16 @@ export default class Importer {
   /**
    * @param {Object} data
    *
-   * @return {Object} importedData
+   * @return {Object} initializedData
    */
-  importData(data) {
-    return this._formFieldRegistry.getAll().reduce((importedData, formField) => {
+  initializeFieldValues(data) {
+    return this._formFieldRegistry.getAll().reduce((initializedData, formField) => {
       const {
         defaultValue,
         _path,
-        type,
-        valuesKey
+        type
       } = formField;
 
-      // get values defined via valuesKey
-
-      if (valuesKey) {
-        importedData = {
-          ...importedData,
-          [ valuesKey ]: get(data, [ valuesKey ])
-        };
-      }
 
       // try to get value from data
       // if unavailable - try to get default value from form field
@@ -157,17 +148,17 @@ export default class Importer {
           valueData = fieldImplementation.sanitizeValue({ formField, data, value: valueData });
         }
 
-        const initialFieldValue = !isUndefined(valueData) ? valueData : (!isUndefined(defaultValue) ? defaultValue : fieldImplementation.emptyValue);
+        const initializedFieldValue = !isUndefined(valueData) ? valueData : (!isUndefined(defaultValue) ? defaultValue : fieldImplementation.emptyValue);
 
-        importedData = {
-          ...importedData,
-          [_path[0]]: initialFieldValue,
+        initializedData = {
+          ...initializedData,
+          [_path[0]]: initializedFieldValue,
         };
       }
 
-      return importedData;
+      return initializedData;
 
-    }, {});
+    }, data);
   }
 }
 

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -26,7 +26,6 @@ export default function FormField(props) {
   const {
     data,
     errors,
-    initialData,
     properties
   } = form._getState();
 
@@ -47,7 +46,7 @@ export default function FormField(props) {
 
   const disabled = properties.readOnly || field.disabled || false;
 
-  const visible = useCondition(field.condition, { ...initialData, ...data });
+  const visible = useCondition(field.condition, data);
   if (!visible) {
     return <Empty />;
   }

--- a/packages/form-js-viewer/test/spec/import/Importer.spec.js
+++ b/packages/form-js-viewer/test/spec/import/Importer.spec.js
@@ -315,6 +315,32 @@ describe('Importer', function() {
     }));
 
 
+    it('should import data not defined on the form', inject(async function(form) {
+
+      // given
+      const data = { randomExternalDataBool: true, randomExternalDataInt: 9 };
+
+      // when
+      await form.importSchema(defaultValues, data);
+
+      // then
+      expect(form._getState().data).to.eql({
+        randomExternalDataBool: true,
+        randomExternalDataInt: 9 ,
+        creditor: 'Max Mustermann GmbH',
+        invoiceNumber: '',
+        amount: 0,
+        approved: true,
+        approvedBy: '',
+        approverComments: 'Sample comment provided by the approver',
+        mailto: [ 'regional-manager', 'approver' ],
+        product: 'camunda-platform',
+        tags: [ 'tag1', 'tag2', 'tag3' ],
+        language: 'english'
+      });
+    }));
+
+
     it('should sanitize data (static)', inject(async function(form) {
 
       // given

--- a/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
@@ -246,23 +246,6 @@ describe('FormField', function() {
     });
 
 
-    it('should use initial data to check condition', function() {
-
-      // when
-      const { container } = createFormField({
-        checkCondition: (_, data) => data.shouldShow || false,
-        initialData: {
-          shouldShow: true
-        }
-      });
-
-      // then
-      const formField = container.querySelector('.fjs-form-field');
-
-      expect(formField).to.exist;
-    });
-
-
     it('should use form data to check condition', function() {
 
       // when
@@ -279,25 +262,6 @@ describe('FormField', function() {
       expect(formField).to.exist;
     });
 
-
-    it('should use give precedence to form data to check condition', function() {
-
-      // when
-      const { container } = createFormField({
-        checkCondition: (_, data) => data.shouldShow || false,
-        data: {
-          shouldShow: true
-        },
-        initialData: {
-          shouldShow: false
-        }
-      });
-
-      // then
-      const formField = container.querySelector('.fjs-form-field');
-
-      expect(formField).to.exist;
-    });
   });
 
 });


### PR DESCRIPTION
The main change is that we no longer have an import step for the data. We do however still have to pass it through an initialization step to apply stuff like form field value defaults and input sanitation. 

But now instead of having to specify all the values that get passed, we just pass all the values by default, and then for form fields we overwrite with defaults when it makes sense. 