### PR TITLE
chore: Add extra classes so it's easier to customize components

### DIFF
--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -281,6 +281,7 @@
   text-align: center;
   line-height: 28px;
   background-color: var(--color-grey-225-10-80);
+  color: var(--color-black);
 }
 
 .fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove svg {

--- a/packages/form-js-viewer/src/render/components/Label.js
+++ b/packages/form-js-viewer/src/render/components/Label.js
@@ -1,3 +1,5 @@
+import classNames from 'classnames';
+
 export default function Label(props) {
   const {
     id,
@@ -6,7 +8,7 @@ export default function Label(props) {
   } = props;
 
   return (
-    <label for={ id } class="fjs-form-field-label">
+    <label for={ id } class={ classNames('fjs-form-field-label', props['class']) }>
       { props.children }
       { label || '' }
       {

--- a/packages/form-js-viewer/src/render/components/Util.js
+++ b/packages/form-js-viewer/src/render/components/Util.js
@@ -1,24 +1,20 @@
 import snarkdown from '@bpmn-io/snarkdown';
 import { get } from 'min-dash';
+import classNames from 'classnames';
 
 import { sanitizeHTML } from './Sanitizer';
 
-export function formFieldClasses(type, errors = []) {
+export function formFieldClasses(type, { errors = [], disabled = false } = {}) {
   if (!type) {
     throw new Error('type required');
   }
 
-  const classes = [
-    'fjs-form-field',
-    `fjs-form-field-${ type }`
-  ];
-
-  if (errors.length) {
-    classes.push('fjs-has-errors');
-  }
-
-  return classes.join(' ');
+  return classNames('fjs-form-field', `fjs-form-field-${type}`, {
+    'fjs-has-errors': errors.length > 0,
+    'fjs-disabled': disabled,
+  });
 }
+
 
 export function prefixId(id, formId) {
   if (formId) {

--- a/packages/form-js-viewer/src/render/components/Util.js
+++ b/packages/form-js-viewer/src/render/components/Util.js
@@ -11,7 +11,7 @@ export function formFieldClasses(type, { errors = [], disabled = false } = {}) {
 
   return classNames('fjs-form-field', `fjs-form-field-${type}`, {
     'fjs-has-errors': errors.length > 0,
-    'fjs-disabled': disabled,
+    'fjs-disabled': disabled
   });
 }
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -10,6 +10,7 @@ import {
   formFieldClasses,
   prefixId
 } from '../Util';
+import classNames from 'classnames';
 
 const type = 'checkbox';
 
@@ -37,22 +38,26 @@ export default function Checkbox(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
-    <Label
-      id={ prefixId(id, formId) }
-      label={ label }
-      required={ false }>
-      <input
-        checked={ value }
-        class="fjs-input"
-        disabled={ disabled }
-        id={ prefixId(id, formId) }
-        type="checkbox"
-        onChange={ onChange } />
-    </Label>
-    <Description description={ description } />
-    <Errors errors={ errors } />
-  </div>;
+  return (
+    <div
+      class={ classNames(formFieldClasses(type, { errors, disabled }), {
+        'fjs-checked': value,
+      }) }
+    >
+      <Label id={ prefixId(id, formId) } label={ label } required={ false }>
+        <input
+          checked={ value }
+          class="fjs-input"
+          disabled={ disabled }
+          id={ prefixId(id, formId) }
+          type="checkbox"
+          onChange={ onChange }
+        />
+      </Label>
+      <Description description={ description } />
+      <Errors errors={ errors } />
+    </div>
+  );
 }
 
 Checkbox.create = function(options = {}) {

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -38,26 +38,22 @@ export default function Checkbox(props) {
 
   const { formId } = useContext(FormContext);
 
-  return (
-    <div
-      class={ classNames(formFieldClasses(type, { errors, disabled }), {
-        'fjs-checked': value,
-      }) }
-    >
-      <Label id={ prefixId(id, formId) } label={ label } required={ false }>
-        <input
-          checked={ value }
-          class="fjs-input"
-          disabled={ disabled }
-          id={ prefixId(id, formId) }
-          type="checkbox"
-          onChange={ onChange }
-        />
-      </Label>
-      <Description description={ description } />
-      <Errors errors={ errors } />
-    </div>
-  );
+  return <div class={ classNames(formFieldClasses(type, { errors, disabled }), { 'fjs-checked': value }) }>
+    <Label
+      id={ prefixId(id, formId) }
+      label={ label }
+      required={ false }>
+      <input
+        checked={ value }
+        class="fjs-input"
+        disabled={ disabled }
+        id={ prefixId(id, formId) }
+        type="checkbox"
+        onChange={ onChange } />
+    </Label>
+    <Description description={ description } />
+    <Errors errors={ errors } />
+  </div>;
 }
 
 Checkbox.create = function(options = {}) {

--- a/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
@@ -1,6 +1,6 @@
 import { useContext } from 'preact/hooks';
 import useValuesAsync, { LOAD_STATES } from '../../hooks/useValuesAsync';
-
+import classNames from 'classnames';
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -12,7 +12,6 @@ import {
   prefixId,
   sanitizeMultiSelectValue
 } from '../Util';
-import classNames from 'classnames';
 
 const type = 'checklist';
 
@@ -54,38 +53,34 @@ export default function Checklist(props) {
 
   const { formId } = useContext(FormContext);
 
-  return (
-    <div
-      class={ classNames(formFieldClasses(type, { errors, disabled })) }
-    >
-      <Label label={ label } />
-      {loadState == LOAD_STATES.LOADED &&
-        options.map((v, index) => {
-          return (
-            <Label
+  return <div class={ classNames(formFieldClasses(type, { errors, disabled })) }>
+    <Label
+      label={ label } />
+    {
+      loadState == LOAD_STATES.LOADED && options.map((v, index) => {
+        return (
+          <Label
+            id={ prefixId(`${id}-${index}`, formId) }
+            key={ `${id}-${index}` }
+            label={ v.label }
+            class={ classNames({
+              'fjs-checked': value.includes(v.value)
+            }) }
+            required={ false }>
+            <input
+              checked={ value.includes(v.value) }
+              class="fjs-input"
+              disabled={ disabled }
               id={ prefixId(`${id}-${index}`, formId) }
-              key={ `${id}-${index}` }
-              label={ v.label }
-              required={ false }
-              class={ classNames({
-                'fjs-checked': value.includes(v.value),
-              }) }
-            >
-              <input
-                checked={ value.includes(v.value) }
-                class="fjs-input"
-                disabled={ disabled }
-                id={ prefixId(`${id}-${index}`, formId) }
-                type="checkbox"
-                onClick={ () => toggleCheckbox(v.value) }
-              />
-            </Label>
-          );
-        })}
-      <Description description={ description } />
-      <Errors errors={ errors } />
-    </div>
-  );
+              type="checkbox"
+              onClick={ () => toggleCheckbox(v.value) } />
+          </Label>
+        );
+      })
+    }
+    <Description description={ description } />
+    <Errors errors={ errors } />
+  </div>;
 }
 
 Checklist.create = function(options = {}) {

--- a/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
@@ -12,6 +12,7 @@ import {
   prefixId,
   sanitizeMultiSelectValue
 } from '../Util';
+import classNames from 'classnames';
 
 const type = 'checklist';
 
@@ -53,31 +54,38 @@ export default function Checklist(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
-    <Label
-      label={ label } />
-    {
-      loadState == LOAD_STATES.LOADED && options.map((v, index) => {
-        return (
-          <Label
-            id={ prefixId(`${id}-${index}`, formId) }
-            key={ `${id}-${index}` }
-            label={ v.label }
-            required={ false }>
-            <input
-              checked={ value.includes(v.value) }
-              class="fjs-input"
-              disabled={ disabled }
+  return (
+    <div
+      class={ classNames(formFieldClasses(type, { errors, disabled })) }
+    >
+      <Label label={ label } />
+      {loadState == LOAD_STATES.LOADED &&
+        options.map((v, index) => {
+          return (
+            <Label
               id={ prefixId(`${id}-${index}`, formId) }
-              type="checkbox"
-              onClick={ () => toggleCheckbox(v.value) } />
-          </Label>
-        );
-      })
-    }
-    <Description description={ description } />
-    <Errors errors={ errors } />
-  </div>;
+              key={ `${id}-${index}` }
+              label={ v.label }
+              required={ false }
+              class={ classNames({
+                'fjs-checked': value.includes(v.value),
+              }) }
+            >
+              <input
+                checked={ value.includes(v.value) }
+                class="fjs-input"
+                disabled={ disabled }
+                id={ prefixId(`${id}-${index}`, formId) }
+                type="checkbox"
+                onClick={ () => toggleCheckbox(v.value) }
+              />
+            </Label>
+          );
+        })}
+      <Description description={ description } />
+      <Errors errors={ errors } />
+    </div>
+  );
 }
 
 Checklist.create = function(options = {}) {

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -40,7 +40,7 @@ export default function Number(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ formFieldClasses(type, { errors, disabled }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -1,6 +1,6 @@
 import { useContext } from 'preact/hooks';
 import useValuesAsync, { LOAD_STATES } from '../../hooks/useValuesAsync';
-
+import classNames from 'classnames';
 import { FormContext } from '../../context';
 
 import Description from '../Description';
@@ -47,7 +47,7 @@ export default function Radio(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ formFieldClasses(type, { errors, disabled }) }>
     <Label
       label={ label }
       required={ required } />
@@ -58,7 +58,8 @@ export default function Radio(props) {
             id={ prefixId(`${ id }-${ index }`, formId) }
             key={ `${ id }-${ index }` }
             label={ option.label }
-            required={ false }>
+            required={ false }
+            class={ classNames({ 'fjs-checked': option.value === value }) }>
             <input
               checked={ option.value === value }
               class="fjs-input"

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -58,8 +58,8 @@ export default function Radio(props) {
             id={ prefixId(`${ id }-${ index }`, formId) }
             key={ `${ id }-${ index }` }
             label={ option.label }
-            required={ false }
-            class={ classNames({ 'fjs-checked': option.value === value }) }>
+            class={ classNames({ 'fjs-checked': option.value === value }) }
+            required={ false }>
             <input
               checked={ option.value === value }
               class="fjs-input"

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -46,7 +46,7 @@ export default function Select(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ formFieldClasses(type, { errors, disabled }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }

--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -113,7 +113,7 @@ export default function Taglist(props) {
     }
   };
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ formFieldClasses(type, { errors, disabled }) }>
     <Label
       label={ label }
       id={ prefixId(`${id}-search`, formId) } />

--- a/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
@@ -71,7 +71,7 @@ export default function Textarea(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ formFieldClasses(type, { errors, disabled }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -41,7 +41,7 @@ export default function Textfield(props) {
 
   const { formId } = useContext(FormContext);
 
-  return <div class={ formFieldClasses(type, errors) }>
+  return <div class={ formFieldClasses(type, { errors, disabled }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }

--- a/packages/form-js-viewer/src/render/components/form-fields/icons/Close.svg
+++ b/packages/form-js-viewer/src/render/components/form-fields/icons/Close.svg
@@ -1,1 +1,1 @@
-<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m12 4.7-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8 12 4.7Z" fill="#000"/></svg>
+<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m12 4.7-.7-.7L8 7.3 4.7 4l-.7.7L7.3 8 4 11.3l.7.7L8 8.7l3.3 3.3.7-.7L8.7 8 12 4.7Z" fill="currentColor"/></svg>

--- a/packages/form-js-viewer/test/spec/render/components/Util.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Util.spec.js
@@ -22,7 +22,7 @@ describe('Util', function() {
     it('should contain errors class', function() {
 
       // when
-      const classes = formFieldClasses('button', [ 'foo' ]);
+      const classes = formFieldClasses('button', { errors:[ 'foo' ] });
 
       // then
       expect(classes).to.equal('fjs-form-field fjs-form-field-button fjs-has-errors');

--- a/packages/form-js-viewer/test/spec/render/components/Util.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Util.spec.js
@@ -28,6 +28,7 @@ describe('Util', function() {
       expect(classes).to.equal('fjs-form-field fjs-form-field-button fjs-has-errors');
     });
 
+
     it('should contain disabled class', function() {
 
       // when

--- a/packages/form-js-viewer/test/spec/render/components/Util.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Util.spec.js
@@ -28,6 +28,15 @@ describe('Util', function() {
       expect(classes).to.equal('fjs-form-field fjs-form-field-button fjs-has-errors');
     });
 
+    it('should contain disabled class', function() {
+
+      // when
+      const classes = formFieldClasses('button', { disabled: true });
+
+      // then
+      expect(classes).to.equal('fjs-form-field fjs-form-field-button fjs-disabled');
+    });
+
   });
 
 


### PR DESCRIPTION
In order to make `form-js` more customizable we need to add these new classes. Most of this could be replaced by the [`:has()` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/:has), but it still is behind a flag on Firefox