### PR TITLE
fix(taglist): make tag remove accessible via keyboard

### DIFF
--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -267,6 +267,12 @@
   background-color: var(--color-grey-225-10-90);
 }
 
+.fjs-container .fjs-taglist .fjs-taglist-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
 .fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-label {
   padding: 2px 6px 2px 8px;
 }
@@ -278,18 +284,26 @@
   text-align: center;
   line-height: 28px;
   background-color: var(--color-grey-225-10-80);
+  border: none;
+  padding: 1px 0;
 }
 
 .fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove svg {
   opacity: 0.6;
 }
 
-.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:hover {
+.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:hover,
+.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:focus-visible {
   background-color: var(--color-grey-225-10-75);
 }
 
-.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:hover > svg {
+.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:hover > svg,
+.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:focus-visible > svg {
   opacity: 1;
+}
+
+.fjs-container .fjs-taglist .fjs-taglist-tag .fjs-taglist-tag-remove:focus-visible {
+  outline: none;
 }
 
 .fjs-container .fjs-taglist .fjs-taglist-input {
@@ -311,7 +325,8 @@
 .fjs-container .fjs-dropdownlist {
   position: absolute;
   user-select: none;
-  overflow-y: auto;
+  overflow-y: scroll;
+  max-height: 120px;
   scroll-behavior: smooth;
   width: 100%;
   border-radius: 3px;

--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+
 import useValuesAsync, { LOAD_STATES } from '../../hooks/useValuesAsync';
 
 import { FormContext } from '../../context';
@@ -113,22 +114,44 @@ export default function Taglist(props) {
     }
   };
 
+  const onTagRemoveClick = (event, value) => {
+    const { target } = event;
+
+    deselectValue(value);
+
+    // restore focus if there is no next sibling to focus
+    const nextTag = target.closest('.fjs-taglist-tag').nextSibling;
+    if (!nextTag) {
+      searchbarRef.current.focus();
+    }
+  };
+
   return <div class={ formFieldClasses(type, errors) }>
     <Label
       label={ label }
       id={ prefixId(`${id}-search`, formId) } />
     <div class={ classNames('fjs-taglist', { 'disabled': disabled }) }>
       {!disabled && loadState === LOAD_STATES.LOADED &&
-        values.map((v) => {
-          return (
-            <div class="fjs-taglist-tag" onMouseDown={ (e) => e.preventDefault() }>
-              <span class="fjs-taglist-tag-label">
-                {valueToOptionMap[v] ? valueToOptionMap[v].label : `unexpected value{${v}}`}
-              </span>
-              <span class="fjs-taglist-tag-remove" onMouseDown={ () => deselectValue(v) }><CloseIcon /></span>
-            </div>
-          );
-        })
+        <div class="fjs-taglist-tags">
+          {
+            values.map((v) => {
+              return (
+                <div class="fjs-taglist-tag" onMouseDown={ (e) => e.preventDefault() }>
+                  <span class="fjs-taglist-tag-label">
+                    {valueToOptionMap[v] ? valueToOptionMap[v].label : `unexpected value{${v}}`}
+                  </span>
+                  <button
+                    type="button"
+                    title="Remove tag"
+                    class="fjs-taglist-tag-remove"
+                    onClick={ (event) => onTagRemoveClick(event, v) }>
+                    <CloseIcon />
+                  </button>
+                </div>
+              );
+            })
+          }
+        </div>
       }
       <input
         disabled={ disabled }

--- a/packages/form-js-viewer/test/helper/index.js
+++ b/packages/form-js-viewer/test/helper/index.js
@@ -178,12 +178,12 @@ export function insertCSS(name, css) {
 
 export async function expectNoViolations(node, options = {}) {
   const {
-    rules,
+    runOnly,
     ...rest
   } = options;
 
   const results = await axe.run(node, {
-    runOnly: rules || DEFAULT_AXE_RULES,
+    runOnly: runOnly || DEFAULT_AXE_RULES,
     ...rest
   });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -1,6 +1,7 @@
 import {
   fireEvent,
-  render
+  render,
+  screen
 } from '@testing-library/preact/pure';
 
 import Taglist from '../../../../../src/render/components/form-fields/Taglist';
@@ -224,7 +225,7 @@ describe('Taglist', function() {
         // when
         const removeButton = container.querySelectorAll('.fjs-taglist-tag-remove')[ 1 ];
 
-        fireEvent.mouseDown(removeButton);
+        fireEvent.click(removeButton);
 
         // then
         expect(onChangeSpy).to.have.been.calledWith({
@@ -234,7 +235,7 @@ describe('Taglist', function() {
       });
 
 
-      it('should work via keyboard', function() {
+      it('should work via backspace keyboard', function() {
 
         // given
         const onChangeSpy = spy();
@@ -278,6 +279,27 @@ describe('Taglist', function() {
           value: [ 'dynamicValue1' ]
         });
       });
+
+
+      it('restore focus if last tag got removed', function() {
+
+        // given
+        const onChangeSpy = spy();
+
+        const { container } = createTaglist({
+          onChange: onChangeSpy,
+          value: [ 'tag1', 'tag2', 'tag3' ]
+        });
+
+        // when
+        const removeButton = container.querySelectorAll('.fjs-taglist-tag-remove')[ 2 ];
+
+        fireEvent.click(removeButton);
+
+        // then
+        expect(document.activeElement).to.equal(container.querySelector('.fjs-taglist-input'));
+      });
+
     });
 
     describe('filtering', function() {
@@ -633,6 +655,32 @@ describe('Taglist', function() {
 
       // then
       await expectNoViolations(container);
+    });
+
+
+    it('should have no violations - focus on', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createTaglist({
+        value: [ 'tag1', 'tag2', 'tag3' ]
+      });
+
+
+      const input = screen.getByLabelText('Taglist');
+      fireEvent.focus(input);
+
+      // then
+      // @Note: we ignore the dropdownlist is not focussable,
+      // as it is keyboard navigatible via up/down keys
+      await expectNoViolations(container, {
+        rules: {
+          'scrollable-region-focusable': {
+            enabled: false
+          }
+        }
+      });
     });
 
   });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/parts/DropdownList.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/parts/DropdownList.spec.js
@@ -44,6 +44,7 @@ describe('DropdownList', function() {
 
   });
 
+
   it('should render custom label mappings', function() {
 
     // given


### PR DESCRIPTION
Closes #413

This makes the tag remove pills actual buttons. I also added another a11y test to verify the focus state (dropdown list open).

![Kapture 2022-11-22 at 14 18 34](https://user-images.githubusercontent.com/9433996/203323829-6f2356df-7228-4b20-8ce8-d4fc8856ecc5.gif)
