### PR TITLE
feat: retrieve variables mentioned in conditions

### DIFF
--- a/packages/form-js-viewer/src/util/feel.js
+++ b/packages/form-js-viewer/src/util/feel.js
@@ -1,0 +1,24 @@
+import { parseUnaryTests } from 'feelin';
+
+/**
+ * Retrieve variable names from given FEEL unary test.
+ *
+ * @param {string} unaryTest
+ * @returns {string[]}
+ */
+export function getVariableNames(unaryTest) {
+  const tree = parseUnaryTests(unaryTest);
+  const cursor = tree.cursor();
+
+  const variables = new Set();
+  do {
+    const node = cursor.node;
+
+    if (node.type.name === 'VariableName') {
+      variables.add(unaryTest.slice(node.from, node.to));
+    }
+
+  } while (cursor.next());
+
+  return Array.from(variables);
+}

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -1,3 +1,5 @@
+import { getVariableNames } from './feel';
+
 export * from './injector';
 export * from './form';
 
@@ -69,19 +71,19 @@ export function clone(data, replacer) {
  *
  * @return {string[]}
  */
-
 export function getSchemaVariables(schema) {
 
   if (!schema.components) {
     return [];
   }
 
-  return schema.components.reduce((variables, component) => {
+  const variables = schema.components.reduce((variables, component) => {
 
     const {
       key,
       valuesKey,
-      type
+      type,
+      condition
     } = component;
 
     if ([ 'text', 'button' ].includes(type)) {
@@ -92,11 +94,21 @@ export function getSchemaVariables(schema) {
       variables = [ ...variables, key ];
     }
 
-    if (valuesKey && !variables.includes(valuesKey)) {
+    if (valuesKey) {
       variables = [ ...variables, valuesKey ];
     }
 
-    return variables;
+    if (condition) {
 
+      // cut off initial '='
+      const conditionVariables = getVariableNames(condition.slice(1));
+
+      variables = [ ...variables, ...conditionVariables ];
+    }
+
+    return variables;
   }, []);
+
+  // remove duplicates
+  return Array.from(new Set(variables));
 }

--- a/packages/form-js-viewer/test/spec/condition-external-variable.json
+++ b/packages/form-js-viewer/test/spec/condition-external-variable.json
@@ -1,0 +1,23 @@
+{
+  "components": [
+    {
+      "key": "amount",
+      "label": "Amount",
+      "type": "number",
+      "validate": {
+        "min": 0,
+        "max": 1000
+      },
+      "condition": "=externalVariable"
+    },
+    {
+      "label": "Text Field",
+      "type": "textfield",
+      "id": "Field",
+      "condition": "=amount > 2"
+    }
+  ],
+  "type": "default",
+  "id": "Form",
+  "schemaVersion": 5
+}

--- a/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
+++ b/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
@@ -4,6 +4,7 @@ import {
 
 import schema from '../form.json';
 import dynamicSchema from '../dynamic.json';
+import conditionalSchema from '../condition-external-variable.json';
 
 describe('util/getSchemaVariables', () => {
 
@@ -22,6 +23,14 @@ describe('util/getSchemaVariables', () => {
 
     expect(variables).to.eql([ 'product', 'xyzData', 'mailto', 'language', 'tags' ]);
 
+  });
+
+
+  it('should include variables in the conditions', () => {
+
+    const variables = getSchemaVariables(conditionalSchema);
+
+    expect(variables).to.eql([ 'amount', 'externalVariable' ]);
   });
 
 });


### PR DESCRIPTION
This implements support for `field#condition` in `getSchemaVariables`. Note that it doesn't allow to shadow keywords, i.e. `=external` won't work. Until we know the context, we can't tell that a keyword is a variable, and `getSchemaVariables` is used to **create** the context.

Closes #401

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
