### PR TITLE
feat: add `key` validation to `input values key`

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/InputKeyValuesSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/InputKeyValuesSourceEntry.js
@@ -1,5 +1,5 @@
 import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
-import { get } from 'min-dash';
+import { get, isUndefined } from 'min-dash';
 import { useService } from '../hooks';
 import { VALUES_SOURCES, VALUES_SOURCES_PATHS } from './ValuesSourceUtil';
 
@@ -40,6 +40,18 @@ function InputValuesKey(props) {
 
   const setValue = (value) => editField(field, path, value || '');
 
+  const validate = (value) => {
+    if (isUndefined(value) || !value.length) {
+      return 'Must not be empty.';
+    }
+
+    if (/\s/.test(value)) {
+      return 'Must not contain spaces.';
+    }
+
+    return null;
+  };
+
   return TextFieldEntry({
     debounce,
     description,
@@ -47,6 +59,7 @@ function InputValuesKey(props) {
     getValue,
     id,
     label,
-    setValue
+    setValue,
+    validate
   });
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -694,6 +694,68 @@ describe('properties panel', function() {
         });
 
 
+        it('should not be empty', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          let field = schema.components.find(({ key }) => key === 'product');
+          field = { ...field, values: undefined, valuesKey: '' };
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Input values key');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: '' } });
+
+          // then
+          expect(editFieldSpy).not.to.have.been.called;
+
+          const error = screen.getByText('Must not be empty.');
+
+          expect(error).to.exist;
+        });
+
+
+        it('should not contain spaces', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          let field = schema.components.find(({ key }) => key === 'product');
+          field = { ...field, values: undefined, valuesKey: '' };
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Input values key');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: 'credi tor' } });
+
+          // then
+          expect(editFieldSpy).not.to.have.been.called;
+
+          const error = screen.getByText('Must not contain spaces.');
+
+          expect(error).to.exist;
+        });
+
+
         it('entries should change', function() {
 
           // given


### PR DESCRIPTION
Closes #428

@RomanKostka 

![firefox_zn2fH4YaeX](https://user-images.githubusercontent.com/17801113/204007213-3baba7a7-c9a0-4700-a686-e765a02f5d70.gif)

Is this okay behavior? This property is required to be set always, and while I understand that preemptively erroring things in a form might be a UX problem, I think the clarity is more important to a form designer. This is a pattern we've applied for the bpmn editor as well. 