### PR TITLE
fix(viewer): hidden fields do not affect other fields

### DIFF
--- a/packages/form-js-viewer/src/render/hooks/useCondition.js
+++ b/packages/form-js-viewer/src/render/hooks/useCondition.js
@@ -9,11 +9,18 @@ import useService from './useService.js';
  * @returns {boolean} true if condition is met or no condition or condition checker exists
  */
 export function useCondition(condition, data) {
+  const initialData = useService('form')._getState().initialData;
   const conditionChecker = useService('conditionChecker', false);
 
   if (!conditionChecker) {
     return null;
   }
 
-  return conditionChecker.check(condition, data);
+  // make sure we do not use data from hidden fields
+  const filteredData = {
+    ...initialData,
+    ...conditionChecker.applyConditions(data, data)
+  };
+
+  return conditionChecker.check(condition, filteredData);
 }

--- a/packages/form-js-viewer/src/render/hooks/useEvaluation.js
+++ b/packages/form-js-viewer/src/render/hooks/useEvaluation.js
@@ -6,11 +6,18 @@ import useService from './useService.js';
  * @param {import('../../types').Data} data
  */
 export function useEvaluation(expression, data) {
+  const initialData = useService('form')._getState().initialData;
   const conditionChecker = useService('conditionChecker', false);
 
   if (!conditionChecker) {
     return null;
   }
 
-  return conditionChecker.evaluate(expression, data);
+  // make sure we do not use data from hidden fields
+  const filteredData = {
+    ...initialData,
+    ...conditionChecker.applyConditions(data, data)
+  };
+
+  return conditionChecker.evaluate(expression, filteredData);
 }

--- a/packages/form-js-viewer/test/spec/hidden-fields-conditional.json
+++ b/packages/form-js-viewer/test/spec/hidden-fields-conditional.json
@@ -1,0 +1,33 @@
+{
+  "components": [
+    {
+      "label": "a",
+      "type": "checkbox",
+      "key": "a"
+    },
+    {
+      "label": "b",
+      "type": "checkbox",
+      "key": "b"
+    },
+    {
+      "label": "c",
+      "type": "checkbox",
+      "key": "c",
+      "conditional": {
+        "hide": "=a"
+      }
+    },
+    {
+      "text": "# Text",
+      "type": "text",
+      "conditional": {
+        "hide": "=b and c"
+      }
+    }
+  ],
+  "type": "default",
+  "id": "Form_0jn1poe",
+  "exporter": {},
+  "schemaVersion": 6
+}

--- a/packages/form-js-viewer/test/spec/hidden-fields-expression.json
+++ b/packages/form-js-viewer/test/spec/hidden-fields-expression.json
@@ -1,0 +1,31 @@
+{
+  "components": [
+    {
+      "label": "a",
+      "type": "checkbox",
+      "key": "a"
+    },
+    {
+      "label": "b",
+      "type": "textfield",
+      "key": "b"
+    },
+    {
+      "label": "c",
+      "type": "textfield",
+      "key": "c",
+      "conditional": {
+        "hide": "=a"
+      }
+    },
+    {
+      "type": "image",
+      "alt": "=b + c",
+      "source": "https://"
+    }
+  ],
+  "type": "default",
+  "id": "Form_0z44jiv",
+  "exporter": {},
+  "schemaVersion": 6
+}

--- a/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
@@ -320,6 +320,9 @@ function createFormField(options = {}) {
         };
       } else if (type === 'conditionChecker') {
         return checkCondition !== false ? {
+          applyConditions(data) {
+            return data;
+          },
           check(...args) {
             return checkCondition(...args);
           }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/helper/index.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/helper/index.js
@@ -25,6 +25,7 @@ export function WithFormContext(Component, options = {}, formId = 'foo') {
       };
     } else if (type === 'conditionChecker') {
       return {
+        applyConditions() {},
         evaluate(...args) {
           return evaluateExpression(...args);
         }


### PR DESCRIPTION
Closes #431

* makes sure data from conditionally hidden fields do not affect other conditions/expressions
* instead, uses `initialData` as the fallback

[Checkout the demo](https://demo-431-hidden-fields-data--camunda-form-playground.netlify.app/).
