### PR TITLE
fix(get-schema-variables): add variables in text expressions

### DIFF
--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -94,7 +94,7 @@ export function getSchemaVariables(schema) {
       conditional
     } = component;
 
-    if ([ 'text', 'button' ].includes(type)) {
+    if ([ 'button' ].includes(type)) {
       return variables;
     }
 

--- a/packages/form-js-viewer/test/spec/expression-external-variable.json
+++ b/packages/form-js-viewer/test/spec/expression-external-variable.json
@@ -14,6 +14,10 @@
       "label": "Another image",
       "alt": "This is just an image",
       "type": "image"
+    },
+    {
+      "text": "=myText",
+      "type": "text"
     }
   ],
   "type": "default",

--- a/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
+++ b/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
@@ -39,7 +39,7 @@ describe('util/getSchemaVariables', () => {
 
     const variables = getSchemaVariables(expressionSchema);
 
-    expect(variables).to.eql([ 'logo', 'alt' ]);
+    expect(variables).to.eql([ 'logo', 'alt', 'myText' ]);
   });
 
 


### PR DESCRIPTION
Follow-up of #436 