### PR TITLE
chore(playground): adjust data panel names

### DIFF
--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -228,10 +228,10 @@ export function PlaygroundRoot(props) {
         <Section name="Form Preview">
           <div ref={ formContainerRef } class="fjs-pgl-form-container"></div>
         </Section>
-        <Section name="Form Data (Input)">
+        <Section name="Form Input">
           <div ref={ dataContainerRef } class="fjs-pgl-text-container"></div>
         </Section>
-        <Section name="Form Data (Submit)">
+        <Section name="Form Output">
           <div ref={ resultContainerRef } class="fjs-pgl-text-container"></div>
         </Section>
       </div>


### PR DESCRIPTION
Rename playground data panels to `Form Input` and `Form Output`:

![image](https://user-images.githubusercontent.com/58601/209655888-ff1d130f-5eeb-4aaf-87c1-a5d877868f4f.png)
