### PR TITLE
feat(playground): render properties panel to the right

### DIFF
--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -35,10 +35,6 @@
   grid-template-rows: 70% 30%;
 }
 
-.fjs-pgl-inline-editor-panel .fjs-pgl-main {
-  grid-template-columns: 65% 35%;
-}
-
 /**
  * Palette
  */

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -25,7 +25,6 @@ export function PlaygroundRoot(props) {
 
   const {
     actions: actionsConfig = {},
-    editor: editorConfig = {},
     emit,
     exporter: exporterConfig = {}
   } = props;
@@ -33,10 +32,6 @@ export function PlaygroundRoot(props) {
   const {
     display: displayActions = true
   } = actionsConfig;
-
-  const {
-    inlinePropertiesPanel = true
-  } = editorConfig;
 
   const paletteContainerRef = useRef();
   const editorContainerRef = useRef();
@@ -105,7 +100,7 @@ export function PlaygroundRoot(props) {
         parent: paletteContainerRef.current
       },
       propertiesPanel: {
-        parent: !inlinePropertiesPanel && propertiesPanelContainerRef.current
+        parent: propertiesPanelContainerRef.current
       },
       exporter: exporterConfig
     });
@@ -194,8 +189,8 @@ export function PlaygroundRoot(props) {
   return (
     <div class={ classNames(
       'fjs-container',
-      'fjs-pgl-root',
-      { 'fjs-pgl-inline-editor-panel': inlinePropertiesPanel }) }>
+      'fjs-pgl-root'
+    ) }>
       <div class="fjs-pgl-modals">
         { showEmbed ? <EmbedModal schema={ schema } data={ data } onClose={ hideEmbedModal } /> : null }
       </div>

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -168,7 +168,7 @@ describe('playground', function() {
   });
 
 
-  it('should render properties panel (inline)', async function() {
+  it('should render properties panel', async function() {
 
     // given
     const data = {
@@ -181,32 +181,6 @@ describe('playground', function() {
         container,
         schema,
         data
-      });
-    });
-
-    const editorContainer = domQuery('.fjs-form-editor', container);
-    const propertiesContainer = domQuery('.fjs-pgl-properties-container', container);
-
-    // then
-    expect(domQuery('.fjs-properties-panel', editorContainer)).to.exist;
-    expect(domQuery('.fjs-properties-panel', propertiesContainer)).to.not.exist;
-  });
-
-
-  it('should render own properties panel', async function() {
-
-    // given
-    const data = {
-      creditor: 'foo'
-    };
-
-    // when
-    await act(() => {
-      playground = new Playground({
-        container,
-        schema,
-        data,
-        editor: { inlinePropertiesPanel: false }
       });
     });
 


### PR DESCRIPTION
Ensures a uniform UX across our editing tools (always rendered to the right).

![image](https://user-images.githubusercontent.com/58601/209658393-3c54a730-d9ae-417c-a80e-2197e1a0b944.png)
