### PR TITLE
chore(lerna): do not use nx

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,6 @@
 {
   "version": "0.10.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "useWorkspaces": true
+  "useWorkspaces": true,
+  "useNx": false
 }


### PR DESCRIPTION
By [bumping to `lerna@6`](https://github.com/bpmn-io/form-js/pull/471), we now enable the new `nx` task scheduler per default (cf. https://github.com/lerna/lerna/blob/main/CHANGELOG.md#600-2022-10-12).

Although it seems not to have a negative impact, I'd like to make this an actual decision and take a bit of time to understand the consequences. This one disables `nx` until we make this decision.

Also, pinging @bpmn-io/modeling-dev to make them aware. I think we should roll this out across a couple of more bpmn-io projects in case we decide to do so. 