### PR TITLE
fix: clear custom validation when using presets

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/groups/ValidationGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/ValidationGroup.js
@@ -19,7 +19,7 @@ import { INPUTS } from '../Util';
 
 const VALIDATION_TYPE_OPTIONS = {
   custom: {
-    value: 'custom',
+    value: undefined,
     label: 'Custom',
   },
   email: {
@@ -272,15 +272,27 @@ function ValidationType(props) {
 
   const debounce = useService('debounce');
 
+  const clearCustomValidation = () => {
+    onChange('minLength')(undefined);
+    onChange('maxLength')(undefined);
+    onChange('pattern')(undefined);
+  };
+
+  const setValue = (validationType) => {
+    if (validationType) {
+      clearCustomValidation();
+    }
+
+    onChange('validationType')(validationType || undefined);
+  };
+
   return SelectEntry({
     debounce,
     element: field,
     getValue: getValue('validationType'),
     id,
     label: 'Regular expression validation',
-    setValue: onChange('validationType'),
-    getOptions() {
-      return Object.values(VALIDATION_TYPE_OPTIONS);
-    }
+    setValue,
+    getOptions: () => Object.values(VALIDATION_TYPE_OPTIONS)
   });
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/ValidationGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/ValidationGroup.spec.js
@@ -150,8 +150,37 @@ describe('ValidationGroup', function() {
       fireEvent.input(requiredSelect, { target: { value: 'phone' } });
 
       // then
-      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(editFieldSpy).to.have.been.calledWith(field, [ 'validate' ], { validationType: 'phone' });
       expect(field.validate.validationType).to.equal('phone');
+    });
+
+
+    it('should clear custom', function() {
+
+      // given
+      const field = {
+        type: 'textfield',
+        validate: {
+          minLength: 5,
+          maxLength: 10,
+          pattern: 'abc'
+        }
+      };
+
+      const editFieldSpy = sinon.spy();
+
+      const { container } = renderValidationGroup({ field, editField: editFieldSpy });
+
+      const requiredSelect = findSelect('validationType', container);
+
+      // when
+      fireEvent.input(requiredSelect, { target: { value: 'phone' } });
+
+      // then
+      expect(field.validate.validationType).to.equal('phone');
+      expect(field.validate.minLength).to.not.exist;
+      expect(field.validate.maxLength).to.not.exist;
+      expect(field.validate.pattern).to.not.exist;
     });
 
   });


### PR DESCRIPTION
Related to [camunda-modeler#3379](https://github.com/camunda/camunda-modeler/issues/3379)

I removed the 'custom' definition in the schema because it diverged from the previous schema versions and wasn't really required for the behavior to work. Now when you select custom the validationType property just gets cleared. 

Aside from that we switching to a non-custom schema, we now clear minLength, maxLenght, and pattern. Since we're hiding those three properties panel properties. @vsgoulart let me know if there's anything wrong you see in my approach.