### PR TITLE
fix(playground): props panel no longer squashes

### DIFF
--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -29,7 +29,7 @@
 }
 
 .fjs-pgl-main {
-  width: calc(100% - 111px);
+  width: calc(100% - 361px);
   height: 100%;
 
   display: grid;
@@ -79,9 +79,13 @@
   position: relative;
   display: flex;
   height: 100%;
+  width: 250px;
   overflow-y: auto;
   background-color: var(--color-properties-container-background);
-  --properties-panel-width: 200px;
+}
+
+.fjs-pgl-properties-container .fjs-properties-container {
+  --properties-panel-width: 250px;
 }
 
 .fjs-pgl-properties-container .bio-properties-panel {


### PR DESCRIPTION
Closes #487

![image](https://user-images.githubusercontent.com/17801113/211312389-0d623e04-32a1-4161-9159-3627f323f8af.png)
