### PR TITLE
fix: truncate adorner text

### DIFF
--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -175,8 +175,12 @@
 
 .fjs-pgl-form-container {
   height: 100%;
-  height: 100%;
+  width: 100%;
   overflow: hidden;
+}
+
+.fjs-pgl-form-container .fjs-form-editor {
+  width: 100%;
 }
 
 .fjs-pgl-text-container {

--- a/packages/form-js-viewer/assets/form-js.css
+++ b/packages/form-js-viewer/assets/form-js.css
@@ -178,6 +178,8 @@
   width: auto !important;
   min-width: 34px;
   text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .fjs-container .fjs-input-adornment svg {


### PR DESCRIPTION
Related to [modeler#3381](https://github.com/camunda/camunda-modeler/issues/3381)