### PR TITLE
Datetime: correct `autocomplete` attribute

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
@@ -176,7 +176,7 @@ export default function Datepicker(props) {
           class={ 'fjs-input' }
           disabled={ disabled }
           placeholder="mm/dd/yyyy"
-          autoComplete="false"
+          autoComplete="off"
           onFocus={ onInputFocus }
           onKeyDown={ onInputKeyDown }
           onMouseDown={ (e) => !flatpickrInstance.isOpen && flatpickrInstance.open() }

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Timepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Timepicker.js
@@ -150,7 +150,7 @@ export default function Timepicker(props) {
           value={ rawValue }
           disabled={ disabled }
           placeholder={ use24h ? 'hh:mm' : 'hh:mm ?m' }
-          autoComplete="false"
+          autoComplete="off"
           onFocus={ () => useDropdown && setDropdownIsOpen(true) }
           onClick={ () => useDropdown && setDropdownIsOpen(true) }
 

--- a/packages/form-js-viewer/test/TestHelper.js
+++ b/packages/form-js-viewer/test/TestHelper.js
@@ -6,6 +6,9 @@ import { insertCSS } from './helper';
 import formCSS from '../dist/assets/form-js.css';
 
 // @ts-ignore-next-line
+import flatpickrCSS from '@bpmn-io/form-js-viewer/dist/assets/flatpickr/light.css';
+
+// @ts-ignore-next-line
 import testCSS from './test.css';
 
 export function isSingleStart(topic) {
@@ -16,6 +19,7 @@ export function isSingleStart(topic) {
 
 function insertStyles() {
   insertCSS('form-js.css', formCSS);
+  insertCSS('flatpickr.css', flatpickrCSS);
   insertCSS('test.css', testCSS);
 }
 

--- a/packages/form-js-viewer/test/helper/index.js
+++ b/packages/form-js-viewer/test/helper/index.js
@@ -27,7 +27,8 @@ const DEFAULT_AXE_RULES = [
   'best-practice',
   'wcag2a',
   'wcag2aa',
-  'cat.semantics'
+  'cat.semantics',
+  'cat.forms'
 ];
 
 /**


### PR DESCRIPTION
Closes #522 

Apparently, we didn't test against the [`autocomplete-valid`](https://dequeuniversity.com/rules/axe/4.6/autocomplete-valid?application=RuleDescription) rule beforehand, as it was not part of the used test definitions. 

I added `cat.forms` to cover this; it makes anyway sense to use these best practices.
