### PR TITLE
chore(datepicker): disable dates prior to 1900

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
@@ -55,12 +55,11 @@ export default function Datepicker(props) {
       dateFormat: 'm/d/Y',
       static: true,
       clickOpens: false,
+
+      // TODO: support dates prior to 1900 (https://github.com/bpmn-io/form-js/issues/533)
+      minDate: disallowPassedDates ? 'today' : '01/01/1900',
       errorHandler: () => { /* do nothing, we expect the values to sometimes be erronous and we don't want warnings polluting the console */ }
     };
-
-    if (disallowPassedDates) {
-      config = { ...config, minDate: 'today' };
-    }
 
     const instance = flatpickr(dateInputRef.current, config);
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
@@ -281,13 +281,35 @@ describe('Datetime', function() {
         const dateInput = container.querySelector('input[type="text"]');
         fireEvent.focus(dateInput);
 
-        const nextMonthButton = container.querySelector('.flatpickr-prev-month');
+        const previousMonthButton = container.querySelector('.flatpickr-prev-month');
 
         // then
         expect(dateInput.value).to.be.empty;
-        expect([ ...nextMonthButton.classList ]).to.include('flatpickr-disabled');
+        expect([ ...previousMonthButton.classList ]).to.include('flatpickr-disabled');
       });
 
+    });
+
+
+    it('should disable dates prior to 1900', function() {
+
+      // given
+      const { container } = createDatetime({
+        value: '1900-01-01',
+        field: {
+          ...dateField,
+          disallowPassedDates: false
+        }
+      });
+
+      // when
+      const dateInput = container.querySelector('input[type="text"]');
+      fireEvent.focus(dateInput);
+
+      const previousMonthButton = container.querySelector('.flatpickr-prev-month');
+
+      // then
+      expect([ ...previousMonthButton.classList ]).to.include('flatpickr-disabled');
     });
 
   });


### PR DESCRIPTION
Just going to straight up disable the dates which were causing issues for now, so that we don't have the bug in the next release. We've agreed anyways that the historical use case is not a requirement for this component, fixing this is more effort than I'd like so we can take it as a future item:

Have not provided a test case as it is not really the behavior we want long term. 

Proper fix is tracked [here](https://github.com/bpmn-io/form-js/issues/533).