### PR TITLE
fix(editor): use constant value for custom validation type

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/groups/ValidationGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/ValidationGroup.js
@@ -19,7 +19,7 @@ import { INPUTS } from '../Util';
 
 const VALIDATION_TYPE_OPTIONS = {
   custom: {
-    value: undefined,
+    value: '',
     label: 'Custom',
   },
   email: {
@@ -35,7 +35,7 @@ const VALIDATION_TYPE_OPTIONS = {
 export default function ValidationGroup(field, editField) {
   const { type } = field;
   const validate = get(field, [ 'validate' ], {});
-  const isCustomValidation = [ undefined, VALIDATION_TYPE_OPTIONS.custom.value ].includes(validate && validate.validationType);
+  const isCustomValidation = [ undefined, VALIDATION_TYPE_OPTIONS.custom.value ].includes(validate.validationType);
 
   if (!(INPUTS.includes(type) && type !== 'checkbox' && type !== 'checklist' && type !== 'taglist')) {
     return null;

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/ValidationGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/ValidationGroup.spec.js
@@ -154,6 +154,31 @@ describe('ValidationGroup', function() {
       expect(field.validate.validationType).to.equal('phone');
     });
 
+
+    it('should write - empty', function() {
+
+      // given
+      const field = {
+        type: 'textfield',
+        validate: {
+          validationType: 'email'
+        }
+      };
+
+      const editFieldSpy = sinon.spy();
+
+      const { container } = renderValidationGroup({ field, editField: editFieldSpy });
+
+      const requiredSelect = findSelect('validationType', container);
+
+      // when
+      fireEvent.input(requiredSelect, { target: { value: '' } });
+
+      // then
+      expect(editFieldSpy).to.have.been.calledWith(field, [ 'validate' ], {});
+      expect(field.validate.validationType).to.not.exist;
+    });
+
   });
 
 


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3379#issuecomment-1413802106

Seems like some browsers do not work properly with `undefined` as option type. I think we should avoid this anyway.
