### PR TITLE
542 select components can consume a simple array of strings for options

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/InputKeyValuesSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/InputKeyValuesSourceEntry.js
@@ -15,7 +15,7 @@ export default function InputKeyValuesSourceEntry(props) {
 
   const description = <div>
     Define which input property to populate the values from.
-    <br /><br />The input property must follow this schema:
+    <br /><br />The input property may be an array of simple values or alternatively follow this schema:
     <pre><code>{schema}</code></pre>
   </div>;
 

--- a/packages/form-js-viewer/src/render/components/util/sanitizerUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/sanitizerUtil.js
@@ -19,6 +19,22 @@ export function sanitizeDateTimePickerValue(options) {
   return value;
 }
 
+/**
+ * Retrieves the actual value optimistically of a provided select option/value.
+ * If the provided option is a supported primitive, it returns it directly,
+ * otherwise it looks for the value inside it.
+ * (For future iterations, it might be better to wrap the "value"/"option" object 
+ * into a dedicated class/functional, to make it easier to retrieve label and value
+ * or instantiate them easily and safely from the form context)
+ */
+function _getValueOptimistically(potentialValue) {
+  if (['string', 'number'].includes(typeof potentialValue)) {
+    return potentialValue;
+  }
+
+  return potentialValue?.value || null;
+}
+
 export function sanitizeSingleSelectValue(options) {
   const {
     formField,
@@ -32,7 +48,7 @@ export function sanitizeSingleSelectValue(options) {
   } = formField;
 
   try {
-    const validValues = (valuesKey ? get(data, [ valuesKey ]) : values).map(v => v.value) || [];
+    const validValues = (valuesKey ? get(data, [ valuesKey ]) : values).map(v => _getValueOptimistically(v)) || [];
     return validValues.includes(value) ? value : null;
   } catch (error) {
 
@@ -55,7 +71,7 @@ export function sanitizeMultiSelectValue(options) {
   } = formField;
 
   try {
-    const validValues = (valuesKey ? get(data, [ valuesKey ]) : values).map(v => v.value) || [];
+    const validValues = (valuesKey ? get(data, [ valuesKey ]) : values).map(v => _getValueOptimistically(v)) || [];
     return value.filter(v => validValues.includes(v));
   } catch (error) {
 

--- a/packages/form-js-viewer/src/render/components/util/sanitizerUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/sanitizerUtil.js
@@ -1,6 +1,6 @@
-import { get } from 'min-dash';
 import { DATETIME_SUBTYPES } from '../../../util/constants/DatetimeConstants';
 import { isDateInputInformationMatching, isDateTimeInputInformationSufficient, isInvalidDateString, parseIsoTime } from './dateTimeUtil';
+import { getValuesData, normalizeValuesData } from './valuesUtil';
 
 export function sanitizeDateTimePickerValue(options) {
   const {
@@ -19,22 +19,6 @@ export function sanitizeDateTimePickerValue(options) {
   return value;
 }
 
-/**
- * Retrieves the actual value optimistically of a provided select option/value.
- * If the provided option is a supported primitive, it returns it directly,
- * otherwise it looks for the value inside it.
- * (For future iterations, it might be better to wrap the "value"/"option" object 
- * into a dedicated class/functional, to make it easier to retrieve label and value
- * or instantiate them easily and safely from the form context)
- */
-function _getValueOptimistically(potentialValue) {
-  if (['string', 'number'].includes(typeof potentialValue)) {
-    return potentialValue;
-  }
-
-  return potentialValue?.value || null;
-}
-
 export function sanitizeSingleSelectValue(options) {
   const {
     formField,
@@ -42,13 +26,8 @@ export function sanitizeSingleSelectValue(options) {
     value
   } = options;
 
-  const {
-    valuesKey,
-    values
-  } = formField;
-
   try {
-    const validValues = (valuesKey ? get(data, [ valuesKey ]) : values).map(v => _getValueOptimistically(v)) || [];
+    const validValues = normalizeValuesData(getValuesData(formField, data)).map(v => v.value);
     return validValues.includes(value) ? value : null;
   } catch (error) {
 
@@ -65,13 +44,8 @@ export function sanitizeMultiSelectValue(options) {
     value
   } = options;
 
-  const {
-    valuesKey,
-    values
-  } = formField;
-
   try {
-    const validValues = (valuesKey ? get(data, [ valuesKey ]) : values).map(v => _getValueOptimistically(v)) || [];
+    const validValues = normalizeValuesData(getValuesData(formField, data)).map(v => v.value);
     return value.filter(v => validValues.includes(v));
   } catch (error) {
 

--- a/packages/form-js-viewer/src/render/components/util/valuesUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/valuesUtil.js
@@ -1,0 +1,49 @@
+import { get } from 'min-dash';
+
+// parses the options data from the provided form field and form data
+export function getValuesData(formField, formData) {
+  const { valuesKey, values } = formField;
+  return valuesKey ? get(formData, [ valuesKey ]) : values;
+}
+
+// transforms the provided options into a normalized format, trimming invalid options
+export function normalizeValuesData(valuesData) {
+  return valuesData.filter(_isValueSomething).map(v => _normalizeValueData(v)).filter(v => v);
+}
+
+function _normalizeValueData(valueData) {
+
+  if (_isAllowedValue(valueData)) {
+
+    // if a primitive is provided, use it as label and value
+    return { value: valueData, label: valueData };
+  }
+
+  if (typeof (valueData) === 'object') {
+    if (!valueData.label && _isAllowedValue(valueData.value)) {
+
+      // if no label is provided, use the value as label
+      return { value: valueData.value, label: valueData.value };
+    }
+
+    if (_isValueSomething(valueData.value) && _isAllowedValue(valueData.label)) {
+
+      // if both value and label are provided, use them as is
+      return valueData;
+    }
+  }
+
+  return null;
+}
+
+function _isAllowedValue(value) {
+  return _isAllowedValueType(value) && _isValueSomething(value);
+}
+
+function _isAllowedValueType(value) {
+  return [ 'number', 'string' ].includes(typeof(value));
+}
+
+function _isValueSomething(value) {
+  return value || value === 0;
+}

--- a/packages/form-js-viewer/src/render/components/util/valuesUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/valuesUtil.js
@@ -16,19 +16,19 @@ function _normalizeValueData(valueData) {
   if (_isAllowedValue(valueData)) {
 
     // if a primitive is provided, use it as label and value
-    return { value: valueData, label: valueData };
+    return { value: valueData, label: `${ valueData }` };
   }
 
   if (typeof (valueData) === 'object') {
     if (!valueData.label && _isAllowedValue(valueData.value)) {
 
       // if no label is provided, use the value as label
-      return { value: valueData.value, label: valueData.value };
+      return { value: valueData.value, label: `${ valueData.value }` };
     }
 
     if (_isValueSomething(valueData.value) && _isAllowedValue(valueData.label)) {
 
-      // if both value and label are provided, use them as is
+      // if both value and label are provided, use them as is, in this scenario, the value may also be an object
       return valueData;
     }
   }
@@ -37,13 +37,13 @@ function _normalizeValueData(valueData) {
 }
 
 function _isAllowedValue(value) {
-  return _isAllowedValueType(value) && _isValueSomething(value);
+  return _isReadableType(value) && _isValueSomething(value);
 }
 
-function _isAllowedValueType(value) {
-  return [ 'number', 'string' ].includes(typeof(value));
+function _isReadableType(value) {
+  return [ 'number', 'string', 'boolean' ].includes(typeof(value));
 }
 
 function _isValueSomething(value) {
-  return value || value === 0;
+  return value || value === 0 || value === false;
 }

--- a/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
+++ b/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
@@ -57,13 +57,13 @@ export default function(field) {
       if (['string', 'number'].includes(typeof option)) {
         return {
           value: option,
-          label: option
+          label: `${option}`
         };
       }
 
       if (!option?.value) return null;
 
-      if (!option?.label) option.label = option.value;
+      if (!option?.label) option.label = `${option.value}`;
 
       return option;
     })

--- a/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
+++ b/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
@@ -35,14 +35,15 @@ export default function(field) {
 
     let values = [];
 
+    // dynamic values
     if (valuesKey !== undefined) {
-
       const keyedValues = (initialData || {})[ valuesKey ];
 
       if (keyedValues && Array.isArray(keyedValues)) {
         values = keyedValues;
       }
     }
+    // static values
     else if (staticValues !== undefined) {
       values = Array.isArray(staticValues) ? staticValues : [];
     }
@@ -50,6 +51,24 @@ export default function(field) {
       setValuesGetter(getErrorState('No values source defined in the form definition'));
       return;
     }
+
+    // map values in case they are provided as primitives
+    values = values.map(option => {
+      if (['string', 'number'].includes(typeof option)) {
+        return {
+          value: option,
+          label: option
+        };
+      }
+
+      if (!option?.value) return null;
+
+      if (!option?.label) option.label = option.value;
+
+      return option;
+    })
+    // remove option from list if not valid
+    .filter(value => !!value);
 
     setValuesGetter(buildLoadedState(values));
 

--- a/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
+++ b/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'preact/hooks';
+import { normalizeValuesData } from '../components/util/valuesUtil';
 import useService from './useService';
 
 /**
@@ -43,32 +44,18 @@ export default function(field) {
         values = keyedValues;
       }
     }
+
     // static values
     else if (staticValues !== undefined) {
       values = Array.isArray(staticValues) ? staticValues : [];
     }
     else {
-      setValuesGetter(getErrorState('No values source defined in the form definition'));
+      setValuesGetter(buildErrorState('No values source defined in the form definition'));
       return;
     }
 
-    // map values in case they are provided as primitives
-    values = values.map(option => {
-      if (['string', 'number'].includes(typeof option)) {
-        return {
-          value: option,
-          label: `${option}`
-        };
-      }
-
-      if (!option?.value) return null;
-
-      if (!option?.label) option.label = `${option.value}`;
-
-      return option;
-    })
-    // remove option from list if not valid
-    .filter(value => !!value);
+    // normalize data to support primitives and partially defined objects
+    values = normalizeValuesData(values);
 
     setValuesGetter(buildLoadedState(values));
 
@@ -77,6 +64,6 @@ export default function(field) {
   return valuesGetter;
 }
 
-const getErrorState = (error) => ({ values: [], error, state: LOAD_STATES.ERROR });
+const buildErrorState = (error) => ({ values: [], error, state: LOAD_STATES.ERROR });
 
 const buildLoadedState = (values) => ({ values, error: undefined, state: LOAD_STATES.LOADED });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -386,7 +386,7 @@ describe('Taglist', function() {
           initialData: {
             dynamicValues: [
               {
-                value: 'dynamicValue1'
+                value: { foo: 'bar' }
               },
               {
                 label: 'Dynamic Value 2',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/util/valuesUtil.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/util/valuesUtil.spec.js
@@ -82,7 +82,7 @@ describe('valuesUtil', function() {
     });
 
 
-    it('should filter out random objects', function() {
+    it('should filter out invalid objects', function() {
 
       // given
       const valuesData = [ { foo: 'bar' }, { value: 'john', label: 'John' } ];

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/util/valuesUtil.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/util/valuesUtil.spec.js
@@ -82,7 +82,7 @@ describe('valuesUtil', function() {
     });
 
 
-    it('should filter out invalid objects', function() {
+    it('should filter out incorrectly structured objects', function() {
 
       // given
       const valuesData = [ { foo: 'bar' }, { value: 'john', label: 'John' } ];
@@ -96,7 +96,7 @@ describe('valuesUtil', function() {
     });
 
 
-    it('should allow random objects as values if a proper label is defined', function() {
+    it('should allow any structured objects as values if a proper label is defined', function() {
 
       // given
       const valuesData = [ { value: { foo: 'bar', bar: 'foo' }, label: 'myObject' }, { value: 'john', label: 'John' } ];
@@ -110,7 +110,7 @@ describe('valuesUtil', function() {
     });
 
 
-    it('should filter out random objects as values if no label is defined', function() {
+    it('should filter out any structured objects as values if no label is defined', function() {
 
       // given
       const valuesData = [ { value: { foo: 'bar', bar: 'foo' } }, { value: 'john', label: 'John' } ];
@@ -133,7 +133,7 @@ describe('valuesUtil', function() {
       const result = normalizeValuesData(valuesData);
 
       // then
-      expect(result).to.eql([ { value: 1, label: 1 }, { value: 2, label: 2 } ]);
+      expect(result).to.eql([ { value: 1, label: '1' }, { value: 2, label: '2' } ]);
     });
 
 
@@ -146,7 +146,7 @@ describe('valuesUtil', function() {
       const result = normalizeValuesData(valuesData);
 
       // then
-      expect(result).to.eql([ { value: 0, label: 0 } ]);
+      expect(result).to.eql([ { value: 0, label: '0' } ]);
     });
 
 
@@ -159,7 +159,7 @@ describe('valuesUtil', function() {
       const result = normalizeValuesData(valuesData);
 
       // then
-      expect(result).to.eql([]);
+      expect(result).to.eql([ { value: true, label: 'true' }, { value: false, label: 'false' } ]);
     });
 
 
@@ -172,7 +172,7 @@ describe('valuesUtil', function() {
       const result = normalizeValuesData(valuesData);
 
       // then
-      expect(result).to.eql([ { value: 'john', label: 'John' }, { value: 'jessica', label: 'jessica' }, { value: 1, label: 1 } ]);
+      expect(result).to.eql([ { value: 'john', label: 'John' }, { value: 'jessica', label: 'jessica' }, { value: 1, label: '1' }, { value: true, label: 'true' }, { value: false, label: 'false' } ]);
     });
 
   });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/util/valuesUtil.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/util/valuesUtil.spec.js
@@ -1,0 +1,180 @@
+import { normalizeValuesData } from '../../../../../../src/render/components/util/valuesUtil.js';
+
+describe('valuesUtil', function() {
+
+  describe('#normalizeValuesData', function() {
+
+    it('should not alter fully defined value', function() {
+
+      // given
+      const values = [ { value: 'john', label: 'John' }, { value: 'jessica', label: 'Jessica' } ];
+
+      // when
+      const result = normalizeValuesData(values);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'John' }, { value: 'jessica', label: 'Jessica' } ]);
+    });
+
+
+    it('should filter out null', function() {
+
+      // given
+      const values = [ { value: 'john', label: 'John' }, { value: 'jessica', label: 'Jessica' }, null ];
+
+      // when
+      const result = normalizeValuesData(values);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'John' }, { value: 'jessica', label: 'Jessica' } ]);
+    });
+
+
+    it('should filter out undefined', function() {
+
+      // given
+      const values = [ { value: 'john', label: 'John' }, { value: 'jessica', label: 'Jessica' }, undefined ];
+
+      // when
+      const result = normalizeValuesData(values);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'John' }, { value: 'jessica', label: 'Jessica' } ]);
+    });
+
+
+    it('should add label if not provided', function() {
+
+      // given
+      const values = [ { value: 'john' }, { value: 'jessica' } ];
+
+      // when
+      const result = normalizeValuesData(values);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'john' }, { value: 'jessica', label: 'jessica' } ]);
+    });
+
+
+    it('should ignore valuesData without value', function() {
+
+      // given
+      const valuesData = [ { label: 'John' }, { label: 'Jessica' } ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([]);
+    });
+
+
+    it('should convert string definitions to value/label objects', function() {
+
+      // given
+      const valuesData = [ 'john', 'jessica' ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'john' }, { value: 'jessica', label: 'jessica' } ]);
+    });
+
+
+    it('should filter out random objects', function() {
+
+      // given
+      const valuesData = [ { foo: 'bar' }, { value: 'john', label: 'John' } ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'John' } ]);
+
+    });
+
+
+    it('should allow random objects as values if a proper label is defined', function() {
+
+      // given
+      const valuesData = [ { value: { foo: 'bar', bar: 'foo' }, label: 'myObject' }, { value: 'john', label: 'John' } ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: { foo: 'bar', bar: 'foo' }, label: 'myObject' }, { value: 'john', label: 'John' } ]);
+
+    });
+
+
+    it('should filter out random objects as values if no label is defined', function() {
+
+      // given
+      const valuesData = [ { value: { foo: 'bar', bar: 'foo' } }, { value: 'john', label: 'John' } ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'John' } ]);
+
+    });
+
+
+    it('should convert number definitions to value/label objects', function() {
+
+      // given
+      const valuesData = [ 1, 2 ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: 1, label: 1 }, { value: 2, label: 2 } ]);
+    });
+
+
+    it('should handle zero as value', function() {
+
+      // given
+      const valuesData = [ 0 ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: 0, label: 0 } ]);
+    });
+
+
+    it('should ignore boolean definitions', function() {
+
+      // given
+      const valuesData = [ true, false ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([]);
+    });
+
+
+    it('should handle mixed definitions individually', function() {
+
+      // given
+      const valuesData = [ { value: 'john', label: 'John' }, 'jessica', 1, true, false, null, undefined ];
+
+      // when
+      const result = normalizeValuesData(valuesData);
+
+      // then
+      expect(result).to.eql([ { value: 'john', label: 'John' }, { value: 'jessica', label: 'jessica' }, { value: 1, label: 1 } ]);
+    });
+
+  });
+
+});


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

Closes #542 

You can now provide any mixture of input options, and without breaking the select components and output.

![image](https://user-images.githubusercontent.com/56470362/218580671-19d2a48f-369b-49f2-b9ca-1567088bc4b6.png)

This is a draft PR, lacking any tests.