### PR TITLE
chore(CHANGELOG): mention `flatpickr/light.css`

### DIFF
--- a/packages/form-js/CHANGELOG.md
+++ b/packages/form-js/CHANGELOG.md
@@ -92,7 +92,7 @@ ___Note:__ Yet to be released changes appear here._
 ### General
 
 * `FEAT`: support prefix and suffix for `textfield` and `number` ([#420](https://github.com/bpmn-io/form-js/issues/420))
-* `FEAT`: support `datetime` component ([#340](https://github.com/bpmn-io/form-js/issues/340))
+* `FEAT`: support `datetime` component, include `/dist/assets/flatpickr/light.css` to display it ([#340](https://github.com/bpmn-io/form-js/issues/340))
 * `FEAT`: support expressions for `text` content ([#436](https://github.com/bpmn-io/form-js/issues/436)) 
 
 ### Viewer


### PR DESCRIPTION
You can easily forget this. Although it is mentioned in the `README` already, I think we can be a bit more helpful in the change logs in case you need to add new style sheets.

In the future, we can consider bundling everything together (cf. #257); I am anyway currently investigating via https://github.com/camunda/team-hto/issues/133. 