### PR TITLE
Build and Deploy to Playground Demo (Netlify)

### DIFF
--- a/.github/workflows/ADD_TO_HTO_PROJECT.yml
+++ b/.github/workflows/ADD_TO_HTO_PROJECT.yml
@@ -1,4 +1,4 @@
-name: ADD_TO_HTO_PROJECT
+name: Add to HTO project
 
 on:
   issues:

--- a/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
@@ -1,4 +1,4 @@
-name: DEPLOY_PLAYGROUND_PREVIEW
+name: Deploy playground preview
 on:
   pull_request:
     types: [ labeled, synchronize ]

--- a/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
@@ -1,0 +1,49 @@
+name: DEPLOY_PLAYGROUND_PREVIEW
+on:
+  pull_request:
+    types: [ labeled, synchronize ]
+jobs:
+  deploy-preview:
+    # check whether the labeled event was deploy-preview || check whether on new commit of PR the label deploy-preview exists
+    if: github.event.label.name == 'deploy-preview' || contains( github.event.pull_request.labels.*.name, 'deploy-preview')
+    runs-on: ubuntu-20.04
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }} # head_ref = branch on PR, ref_name if master / stable/**
+      PREVIEW_BRANCH_NAME: demo-${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Check form-playground branch
+        run: echo "BRANCH_EXISTS=$(git ls-remote --heads https://${{ secrets.ADD_TO_HTO_PROJECT_PAT }}@github.com./camunda/form-playground ${{ env.PREVIEW_BRANCH_NAME }} | wc -l)" >> $GITHUB_ENV
+      - name: Create form-playground branch
+        if: env.BRANCH_EXISTS == 0
+        uses: GuillaumeFalourd/create-other-repo-branch-action@706963eca4b230707b1cfecee6760b519e2cbbf3
+        with:
+          repository_owner: camunda
+          repository_name: form-playground
+          new_branch_name: ${{ env.PREVIEW_BRANCH_NAME }}
+          access_token: ${{ secrets.ADD_TO_HTO_PROJECT_PAT }}
+      - name: Create GitHub deployment
+        uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3
+        id: deployment
+        with:
+          step: start
+          env: ${{ env.PREVIEW_BRANCH_NAME }}
+          token: "${{ secrets.ADD_TO_HTO_PROJECT_PAT }}"
+          ref: ${{ env.BRANCH_NAME }}
+      - name: Trigger Netlify branch build
+        run: | 
+          curl --location --request POST '${{ secrets.NETLIFY_CUSTOM_BUILD_HOOK }}?trigger_branch=${{ env.PREVIEW_BRANCH_NAME }}' \
+            --header 'Content-Type: application/x-www-form-urlencoded' \
+            --data-urlencode 'FORM_JS_BRANCH=${{ env.BRANCH_NAME }}'
+      - name: Update branch deployment status
+        # `always()` ensures that the deployment status
+        # is updated regardless of previous steps failing.
+        if: always()
+        uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3
+        with:
+          step: finish
+          token: ${{ secrets.ADD_TO_HTO_PROJECT_PAT }}
+          status: ${{ job.status }}
+          env: ${{ env.PREVIEW_BRANCH_NAME }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: https://${{ env.PREVIEW_BRANCH_NAME }}--camunda-form-playground.netlify.app
+          ref: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
@@ -6,7 +6,7 @@ jobs:
   deploy-preview:
     # check whether the labeled event was deploy-preview || check whether on new commit of PR the label deploy-preview exists
     if: github.event.label.name == 'deploy-preview' || contains( github.event.pull_request.labels.*.name, 'deploy-preview')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }} # head_ref = branch on PR, ref_name if master / stable/**
       PREVIEW_BRANCH_NAME: demo-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           step: start
           env: ${{ env.PREVIEW_BRANCH_NAME }}
-          token: "${{ secrets.ADD_TO_HTO_PROJECT_PAT }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.BRANCH_NAME }}
       - name: Trigger Netlify branch build
         run: | 
@@ -41,7 +41,7 @@ jobs:
         uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3
         with:
           step: finish
-          token: ${{ secrets.ADD_TO_HTO_PROJECT_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
           env: ${{ env.PREVIEW_BRANCH_NAME }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/MERGE_MASTER_TO_DEVELOP.yml
+++ b/.github/workflows/MERGE_MASTER_TO_DEVELOP.yml
@@ -1,4 +1,4 @@
-name: MERGE_MASTER_TO_DEVELOP
+name: Merge master to develop
 on:
   push:
     branches:

--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -1,4 +1,4 @@
-name: POST_RELEASE
+name: Post release
 on:
   push:
     tags:

--- a/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
@@ -1,4 +1,4 @@
-name: TEARDOWN_PLAYGROUND_PREVIEW
+name: Teardown playground preview
 on:
   pull_request:
     types: [ unlabeled, closed ]

--- a/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
@@ -8,7 +8,7 @@ jobs:
     # check whether the unlabel name was deploy-preview || check whether the PR was closed / merged and whether deploy-preview was part of the array
     if: github.event.label.name == 'deploy-preview' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
     name: teardown-${{ github.head_ref || github.event.ref }} # env is not yet available here
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.event.ref }} # head_ref = branch on PR, event.ref stable/**
       PREVIEW_BRANCH_NAME: demo-${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
@@ -1,0 +1,30 @@
+name: TEARDOWN_PLAYGROUND_PREVIEW
+on:
+  pull_request:
+    types: [ unlabeled, closed ]
+
+jobs:
+  teardown:
+    # check whether the unlabel name was deploy-preview || check whether the PR was closed / merged and whether deploy-preview was part of the array
+    if: github.event.label.name == 'deploy-preview' || (github.event.action == 'closed' && contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    name: teardown-${{ github.head_ref || github.event.ref }} # env is not yet available here
+    runs-on: ubuntu-20.04
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.event.ref }} # head_ref = branch on PR, event.ref stable/**
+      PREVIEW_BRANCH_NAME: demo-${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Remove form-playground branch
+        uses: dawidd6/action-delete-branch@145cd9febe29b6d83e19682d4b95849b851f544c
+        with:
+          github_token: ${{ secrets.ADD_TO_HTO_PROJECT_PAT }}
+          owner: camunda
+          repository: form-playground
+          branches: ${{ env.PREVIEW_BRANCH_NAME }}
+      - uses: bobheadxi/deployments@88ce5600046c82542f8246ac287d0a53c461bca3
+        if: always()
+        name: Deactivate GitHub Deployment environment
+        with:
+          step: deactivate-env
+          env: ${{ env.PREVIEW_BRANCH_NAME }}
+          token: "${{ secrets.ADD_TO_HTO_PROJECT_PAT }}"
+          ref: ${{ env.BRANCH_NAME }}

--- a/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           step: deactivate-env
           env: ${{ env.PREVIEW_BRANCH_NAME }}
-          token: "${{ secrets.ADD_TO_HTO_PROJECT_PAT }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ env.BRANCH_NAME }}


### PR DESCRIPTION
Related to https://github.com/camunda/form-playground/issues/16

This one adds two GitHub actions to create and clean up `form-playground` demos with a form-js branch attached. Some things were mirrored from [`infra-global-github-actions`](https://github.com/camunda/infra-global-github-actions/tree/main/preview-env).

<img width="902" alt="image" src="https://user-images.githubusercontent.com/9433996/219665090-768376f3-a12e-4553-8e6b-05c533822098.png">

- Example: [preview creation](https://github.com/bpmn-io/form-js/actions/runs/4204150254/jobs/7294433364)
- Example: [clean up](https://github.com/bpmn-io/form-js/actions/runs/4204142528/jobs/7294415851)
=> [Resulting demo](https://demo-deploy-playground-demo--camunda-form-playground.netlify.app/)

Todo:
* [ ] Update [HTO Handbook](https://github.com/camunda/team-hto)
