### PR TITLE
ci: sanitize branch name

### DIFF
--- a/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/DEPLOY_PLAYGROUND_PREVIEW.yml
@@ -9,8 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }} # head_ref = branch on PR, ref_name if master / stable/**
-      PREVIEW_BRANCH_NAME: demo-${{ github.head_ref || github.ref_name }}
     steps:
+      - id: sanitize
+        name: Sanitize form-playground branch name
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          max_length: '25'
+      - name: Save form-playground branch name
+        run: echo "PREVIEW_BRANCH_NAME=demo-${{ steps.sanitize.outputs.branch_name }}" >> $GITHUB_ENV
       - name: Check form-playground branch
         run: echo "BRANCH_EXISTS=$(git ls-remote --heads https://${{ secrets.ADD_TO_HTO_PROJECT_PAT }}@github.com./camunda/form-playground ${{ env.PREVIEW_BRANCH_NAME }} | wc -l)" >> $GITHUB_ENV
       - name: Create form-playground branch

--- a/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
+++ b/.github/workflows/TEARDOWN_PLAYGROUND_PREVIEW.yml
@@ -11,8 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{ github.head_ref || github.event.ref }} # head_ref = branch on PR, event.ref stable/**
-      PREVIEW_BRANCH_NAME: demo-${{ github.head_ref || github.ref_name }}
     steps:
+      - id: sanitize
+        name: Sanitize form-playground branch name
+        uses: camunda/infra-global-github-actions/sanitize-branch-name@main
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          max_length: '25'
+      - name: Save form-playground branch name
+        run: echo "PREVIEW_BRANCH_NAME=demo-${{ steps.sanitize.outputs.branch_name }}" >> $GITHUB_ENV
       - name: Remove form-playground branch
         uses: dawidd6/action-delete-branch@145cd9febe29b6d83e19682d4b95849b851f544c
         with:


### PR DESCRIPTION
Related to https://github.com/bpmn-io/form-js/pull/543#issuecomment-1438709246

Sanitizes the branch name for the preview [similar to how we do it in Tasklist.](https://github.com/camunda/tasklist/blob/master/.github/workflows/preview-env-teardown.yml#L33)