### PR TITLE
fix(editor): use proper empty value for select defaults

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/DefaultValueEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DefaultValueEntry.js
@@ -15,6 +15,8 @@ import { useService } from '../hooks';
 
 import { countDecimals, INPUTS, isValidNumber, VALUES_INPUTS } from '../Util';
 
+export const EMPTY_OPTION = null;
+
 export default function DefaultOptionEntry(props) {
   const {
     editField,
@@ -193,7 +195,7 @@ function DefaultValueSingleSelect(props) {
   } = props;
 
   const {
-    defaultValue,
+    defaultValue = EMPTY_OPTION,
     values = []
   } = field;
 
@@ -202,7 +204,8 @@ function DefaultValueSingleSelect(props) {
   const getOptions = () => {
     return [
       {
-        label: '<none>'
+        label: '<none>',
+        value: EMPTY_OPTION
       },
       ...values
     ];

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -23,6 +23,8 @@ import defaultValues from '../../defaultValues.json';
 
 import { insertStyles, setEditorValue } from '../../../TestHelper';
 
+import { EMPTY_OPTION } from '../../../../src/features/properties-panel/entries/DefaultValueEntry';
+
 insertStyles();
 
 const spy = sinon.spy;
@@ -1470,6 +1472,33 @@ describe('properties panel', function() {
 
 
       describe('default value', function() {
+
+        it('should not add default value', function() {
+
+          // given
+          const editFieldSpy = spy();
+
+          const field = schema.components.find(({ key }) => key === 'language');
+
+          createPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field
+          });
+
+          // assume
+          const input = screen.getByLabelText('Default value');
+
+          expect(input.value).to.equal('');
+
+          // when
+          fireEvent.input(input, { target: { value: EMPTY_OPTION } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(editFieldSpy).to.have.been.calledWith(field, [ 'defaultValue' ], undefined);
+        });
+
 
         it('should add default value', function() {
 

--- a/packages/form-js/CHANGELOG.md
+++ b/packages/form-js/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to [form-js](https://github.com/bpmn-io/form-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.12.2
+
+### General
+
+* `FIX`: use correct height for `datetime` inputs ([#548](https://github.com/bpmn-io/form-js/pull/548))
+
+### Editor
+
+* `FIX`: use correct articles in palette titles ([#545](https://github.com/bpmn-io/form-js/pull/545))
+* `FIX`: use correct empty default value for `select` ([#562](https://github.com/bpmn-io/form-js/pull/562))
+
 ## 0.12.1
 
 ### General


### PR DESCRIPTION
Closes #562

Also preparing the changelog so we can follow up with a patch release.
