### PR TITLE
ci(POST_RELEASE): use Node@16

### DIFF
--- a/.github/workflows/POST_RELEASE.yml
+++ b/.github/workflows/POST_RELEASE.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [ 14 ]
+        node-version: [ 16 ]
 
     runs-on: ${{ matrix.os }}
 
@@ -26,15 +26,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v3
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.OS }}-node-
-          ${{ runner.OS }}-
+        cache: 'npm'
     - name: Check for stable release
       run: |
         if [[ ${{ env.TAG }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]


### PR DESCRIPTION
We'd otherwise [generate old style lock files](https://github.com/bpmn-io/bpmn-io-demo/commit/a4d2a5edec8506498a74608fc947dc00d2f6f1af) when upgrading the demo.