### PR TITLE
Integrate `@bpmn-io/draggle`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2110,6 +2110,15 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/@bpmn-io/draggle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/draggle/-/draggle-4.0.0.tgz",
+      "integrity": "sha512-tr2ANCOgR9hR6Gc3x1r6JiWSwiFflFHdF0ilN8Pl5P1Q9kzsWuoTnzwVLHLQt0Ly6CiiwHJ9x+LTkJ5Bd3b3qA==",
+      "dependencies": {
+        "contra": "^1.9.4",
+        "crossvent": "^1.5.5"
+      }
+    },
     "node_modules/@bpmn-io/feel-editor": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.8.0.tgz",
@@ -9862,14 +9871,6 @@
       },
       "peerDependencies": {
         "react": ">=0.14.9"
-      }
-    },
-    "node_modules/dragula": {
-      "version": "3.7.3",
-      "license": "MIT",
-      "dependencies": {
-        "contra": "1.9.4",
-        "crossvent": "1.5.5"
       }
     },
     "node_modules/duplexer": {
@@ -20159,11 +20160,11 @@
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@bpmn-io/draggle": "^4.0.0",
         "@bpmn-io/form-js-viewer": "^1.1.0",
         "@bpmn-io/properties-panel": "^3.2.1",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
-        "dragula": "^3.7.3",
         "ids": "^1.0.0",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.0",
@@ -21680,6 +21681,15 @@
         }
       }
     },
+    "@bpmn-io/draggle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/draggle/-/draggle-4.0.0.tgz",
+      "integrity": "sha512-tr2ANCOgR9hR6Gc3x1r6JiWSwiFflFHdF0ilN8Pl5P1Q9kzsWuoTnzwVLHLQt0Ly6CiiwHJ9x+LTkJ5Bd3b3qA==",
+      "requires": {
+        "contra": "^1.9.4",
+        "crossvent": "^1.5.5"
+      }
+    },
     "@bpmn-io/feel-editor": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-0.8.0.tgz",
@@ -21768,11 +21778,11 @@
     "@bpmn-io/form-js-editor": {
       "version": "file:packages/form-js-editor",
       "requires": {
+        "@bpmn-io/draggle": "^4.0.0",
         "@bpmn-io/form-js-viewer": "^1.1.0",
         "@bpmn-io/properties-panel": "^3.2.1",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
-        "dragula": "^3.7.3",
         "ids": "^1.0.0",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.0",
@@ -27153,13 +27163,6 @@
         "compute-scroll-into-view": "^1.0.13",
         "prop-types": "^15.7.2",
         "react-is": "^16.13.1"
-      }
-    },
-    "dragula": {
-      "version": "3.7.3",
-      "requires": {
-        "contra": "1.9.4",
-        "crossvent": "1.5.5"
       }
     },
     "duplexer": {

--- a/packages/form-js-editor/assets/index.scss
+++ b/packages/form-js-editor/assets/index.scss
@@ -1,3 +1,3 @@
 @use 'form-js-editor-base.css';
-@use 'dragula/dist/dragula.css';
+@use '@bpmn-io/draggle/dist/dragula.css';
 @use '@bpmn-io/properties-panel/assets/properties-panel.css';

--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -46,11 +46,11 @@
     "url": "https://github.com/bpmn-io"
   },
   "dependencies": {
+    "@bpmn-io/draggle": "^4.0.0",
     "@bpmn-io/form-js-viewer": "^1.1.0",
     "@bpmn-io/properties-panel": "^3.2.1",
     "array-move": "^3.0.1",
     "big.js": "^6.2.1",
-    "dragula": "^3.7.3",
     "ids": "^1.0.0",
     "min-dash": "^4.0.0",
     "min-dom": "^4.0.0",

--- a/packages/form-js-editor/rollup.config.js
+++ b/packages/form-js-editor/rollup.config.js
@@ -62,14 +62,14 @@ export default [
       'preact/jsx-runtime',
       'preact/hooks',
       'preact/compat',
-      'dragula',
+      '@bpmn-o/draggle',
       '@bpmn-io/form-js-viewer'
     ],
     plugins: pgl([
       copy({
         targets: [
           { src: 'assets/form-js-editor-base.css', dest: 'dist/assets' },
-          { src: '../../node_modules/dragula/dist/dragula.css', dest: 'dist/assets' },
+          { src: '../../node_modules/@bpmn-io/draggle/dist/dragula.css', dest: 'dist/assets' },
           { src: '../../node_modules/@bpmn-io/properties-panel/assets/properties-panel.css', dest: 'dist/assets' }
         ]
       })

--- a/packages/form-js-editor/src/features/dragging/Dragging.js
+++ b/packages/form-js-editor/src/features/dragging/Dragging.js
@@ -1,4 +1,4 @@
-import dragula from 'dragula';
+import dragula from '@bpmn-io/draggle';
 
 import { set as setCursor } from '../../render/util/Cursor';
 
@@ -200,12 +200,17 @@ export default class Dragging {
 
     const {
       container,
-      direction,
       mirrorContainer
     } = options || {};
 
-    const dragulaInstance = dragula({
-      direction,
+    let dragulaOptions = {
+      direction: function(el, target) {
+        if (isRow(target)) {
+          return 'horizontal';
+        }
+
+        return 'vertical';
+      },
       mirrorContainer,
       isContainer(el) {
         return container.some(cls => el.classList.contains(cls));
@@ -245,7 +250,9 @@ export default class Dragging {
       },
       slideFactorX: 10,
       slideFactorY: 5
-    });
+    };
+
+    const dragulaInstance = dragula(dragulaOptions);
 
     // bind life cycle events
     dragulaInstance.on('drag', (element, source) => {

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -322,7 +322,6 @@ export default function FormEditor(props) {
         DROP_CONTAINER_VERTICAL_CLS,
         DROP_CONTAINER_HORIZONTAL_CLS
       ],
-      direction: 'vertical',
       mirrorContainer: formContainerRef.current
     });
 
@@ -345,7 +344,6 @@ export default function FormEditor(props) {
           DROP_CONTAINER_VERTICAL_CLS,
           DROP_CONTAINER_HORIZONTAL_CLS
         ],
-        direction: 'vertical',
         mirrorContainer: formContainerRef.current
       });
       setDrake(dragulaInstance);


### PR DESCRIPTION
This uses an updated `dragula` version to make the `direction` dynamic. It detects whether the drop would happen inside a row or not and change the direction accordingly.

This makes drag & drop quite a bit smoother as it uses the correct axis depending where the cursor is located. Beforehand it would always have used the y-axis. 

Depends on https://github.com/bpmn-io/dragula/pull/1

Demo: https://demo-improve-dragging--camunda-form-playground.netlify.app/

![Kapture 2023-03-30 at 13 59 19](https://user-images.githubusercontent.com/9433996/228829228-00d71884-d6ed-4506-a41a-7355b2f6138a.gif)

