### PR TITLE
style: properly align rows in viewer

### DIFF
--- a/packages/form-js-playground/src/components/PlaygroundRoot.css
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.css
@@ -160,6 +160,11 @@
   overflow: hidden;
 }
 
+.fjs-pgl-form-container .fjs-container .cds--grid .cds--row {
+  margin-left: -1rem;
+  margin-right: -1rem;
+}
+
 .fjs-pgl-form-container .fjs-form-editor {
   width: 100%;
 }

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -113,6 +113,8 @@
 
 .fjs-container .cds--grid .cds--row {
   align-items: start;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 @media (max-width: 66rem) {


### PR DESCRIPTION
We do not use the Wide grid mode (https://carbondesignsystem.com/guidelines/2x-grid/implementation#the-wide-grid), so a slight negative margin is added to both sides. We want to prevent that when embedding the viewer inside applications.

We still apply the margin to the playground to save space. 

Related to https://github.com/camunda/tasklist/pull/2746
