### PR TITLE
feat(editor): allow uneven columns

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -184,6 +184,11 @@
   background: var(--color-resize-handle-background);
 }
 
+.fjs-editor-container .fjs-element-resizing-right .fjs-context-pad,
+.fjs-editor-container .fjs-element-resizing-left .fjs-context-pad {
+  display: none;
+}
+
 .fjs-editor-container .fjs-children .fjs-editor-selected .fjs-field-resize-handle {
   visibility: visible;
 }

--- a/packages/form-js-editor/src/core/FormLayoutValidator.js
+++ b/packages/form-js-editor/src/core/FormLayoutValidator.js
@@ -1,7 +1,7 @@
-const MAX_COLUMNS_PER_ROW = 16;
-const MAX_COLUMNS = 16;
-const MIN_COLUMNS = 1;
-const MAX_FIELDS_PER_ROW = 4;
+export const MAX_COLUMNS_PER_ROW = 16;
+export const MAX_COLUMNS = 16;
+export const MIN_COLUMNS = 2;
+export const MAX_FIELDS_PER_ROW = 4;
 
 export default class FormLayoutValidator {
 

--- a/packages/form-js-editor/src/core/FormLayoutValidator.js
+++ b/packages/form-js-editor/src/core/FormLayoutValidator.js
@@ -1,3 +1,8 @@
+const MAX_COLUMNS_PER_ROW = 16;
+const MAX_COLUMNS = 16;
+const MIN_COLUMNS = 1;
+const MAX_FIELDS_PER_ROW = 4;
+
 export default class FormLayoutValidator {
 
   /**
@@ -16,18 +21,14 @@ export default class FormLayoutValidator {
     // allow empty (auto columns)
     if (Number.isInteger(columns)) {
 
-      // allow minimum 2 cols
-      if (columns < 2) {
-        return 'Minimum 2 columns are allowed';
+      // allow minimum cols
+      if (columns < MIN_COLUMNS) {
+        return `Minimum ${MIN_COLUMNS} columns are allowed`;
       }
 
-      // allow maximum 16 cols
-      if (columns > 16) {
-        return 'Maximum 16 columns are allowed';
-      }
-
-      if (columns % 2 !== 0) {
-        return 'Columns must be even';
+      // allow maximum cols
+      if (columns > MAX_COLUMNS) {
+        return `Maximum ${MAX_COLUMNS} columns are allowed`;
       }
     }
 
@@ -59,14 +60,14 @@ export default class FormLayoutValidator {
 
     // do not allow overflows
     if (
-      sumColumns > 16 ||
-      (sumColumns === 16 && sumAutoCols > 0) ||
-      (columns === 16 && sumFields > 1)) {
-      return 'New value exceeds the maximum of 16 columns per row';
+      sumColumns > MAX_COLUMNS_PER_ROW ||
+      (sumAutoCols > 0 && sumColumns > calculateMaxColumnsWithAuto(sumAutoCols)) ||
+      (columns === MAX_COLUMNS_PER_ROW && sumFields > 1)) {
+      return `New value exceeds the maximum of ${MAX_COLUMNS_PER_ROW} columns per row`;
     }
 
-    if (sumFields > 4) {
-      return 'Maximum 4 fields per row are allowed';
+    if (sumFields > MAX_FIELDS_PER_ROW) {
+      return `Maximum ${MAX_FIELDS_PER_ROW} fields per row are allowed`;
     }
 
     return null;
@@ -74,3 +75,11 @@ export default class FormLayoutValidator {
 }
 
 FormLayoutValidator.$inject = [ 'formLayouter', 'formFieldRegistry' ];
+
+
+// helper //////////////////////
+
+// on normal screen sizes, auto columns take minimum 2 columns
+function calculateMaxColumnsWithAuto(autoCols) {
+  return MAX_COLUMNS_PER_ROW - (autoCols * 2);
+}

--- a/packages/form-js-editor/src/features/properties-panel/entries/ColumnsEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ColumnsEntry.js
@@ -7,6 +7,8 @@ import {
   SelectEntry
 } from '@bpmn-io/properties-panel';
 
+import { MIN_COLUMNS } from '../../../core/FormLayoutValidator';
+
 
 export const AUTO_OPTION_VALUE = '';
 
@@ -64,7 +66,7 @@ function Columns(props) {
 
       // todo(pinussilvestrus): make options dependant on field type
       // cf. https://github.com/bpmn-io/form-js/issues/575
-      ...asArray(16).map(asOption)
+      ...asArray(16).filter(i => i >= MIN_COLUMNS).map(asOption)
     ];
   };
 

--- a/packages/form-js-editor/src/features/properties-panel/entries/ColumnsEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ColumnsEntry.js
@@ -64,7 +64,7 @@ function Columns(props) {
 
       // todo(pinussilvestrus): make options dependant on field type
       // cf. https://github.com/bpmn-io/form-js/issues/575
-      ...[ 2, 4, 6, 8, 10, 12, 14, 16 ].map(asOption)
+      ...asArray(16).map(asOption)
     ];
   };
 
@@ -88,4 +88,8 @@ function asOption(number) {
     value: number,
     label: number.toString()
   };
+}
+
+function asArray(length) {
+  return Array.from({ length }).map((_, i) => i + 1);
 }

--- a/packages/form-js-editor/test/spec/core/FormLayoutValidator.form.json
+++ b/packages/form-js-editor/test/spec/core/FormLayoutValidator.form.json
@@ -68,6 +68,33 @@
         "row": "Row_1",
         "columns": 2
       }
+    },
+    {
+      "id": "AutoTextfield_1",
+      "key": "auto_1",
+      "label": "Auto Textfield 1",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_4"
+      }
+    },
+    {
+      "id": "AutoTextfield_2",
+      "key": "auto_2",
+      "label": "Auto Textfield 2",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_4"
+      }
+    },
+    {
+      "id": "AutoTextfield_3",
+      "key": "auto_3",
+      "label": "Auto Textfield 3",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_4"
+      }
     }
   ],
   "type": "default"

--- a/packages/form-js-editor/test/spec/core/FormLayoutValidator.spec.js
+++ b/packages/form-js-editor/test/spec/core/FormLayoutValidator.spec.js
@@ -19,10 +19,10 @@ describe('core/FormLayoutValidator', function() {
       const field = formFieldRegistry.get('Textfield_1');
 
       // when
-      const error = formLayoutValidator.validateField(field, 1);
+      const error = formLayoutValidator.validateField(field, 0);
 
       // then
-      expect(error).to.eql('Minimum 2 columns are allowed');
+      expect(error).to.eql('Minimum 1 columns are allowed');
     }));
 
 
@@ -39,7 +39,7 @@ describe('core/FormLayoutValidator', function() {
     }));
 
 
-    it('should disallow - uneven', inject(function(formLayoutValidator, formFieldRegistry) {
+    it('should allow - uneven', inject(function(formLayoutValidator, formFieldRegistry) {
 
       // given
       const field = formFieldRegistry.get('Textfield_1');
@@ -48,7 +48,7 @@ describe('core/FormLayoutValidator', function() {
       const error = formLayoutValidator.validateField(field, 3);
 
       // then
-      expect(error).to.eql('Columns must be even');
+      expect(error).to.not.exist;
     }));
 
 
@@ -97,6 +97,24 @@ describe('core/FormLayoutValidator', function() {
 
         // then
         expect(error).to.eql('Maximum 4 fields per row are allowed');
+      }
+    ));
+
+
+    it('should disallow - auto columns', inject(
+      function(formLayoutValidator, formFieldRegistry, formLayouter) {
+
+        // given
+        const field = formFieldRegistry.get('AutoTextfield_1');
+
+        const row = formLayouter.getRow('Row_4');
+
+        // when
+        // explanation: two fields with auto columns, 12 columns left
+        const error = formLayoutValidator.validateField(field, 13, row);
+
+        // then
+        expect(error).to.eql('New value exceeds the maximum of 16 columns per row');
       }
     ));
 

--- a/packages/form-js-editor/test/spec/core/FormLayoutValidator.spec.js
+++ b/packages/form-js-editor/test/spec/core/FormLayoutValidator.spec.js
@@ -19,10 +19,10 @@ describe('core/FormLayoutValidator', function() {
       const field = formFieldRegistry.get('Textfield_1');
 
       // when
-      const error = formLayoutValidator.validateField(field, 0);
+      const error = formLayoutValidator.validateField(field, 1);
 
       // then
-      expect(error).to.eql('Minimum 1 columns are allowed');
+      expect(error).to.eql('Minimum 2 columns are allowed');
     }));
 
 


### PR DESCRIPTION
Allows for uneven columns. Improves the validation to properly account for `auto` columns. It does not prevent row wrapping in every case, as we discovered via #605. I have the feeling it's rather a form-playground problem, as I can't reproduce these cases in form-js. 

Closes #605

Try it out via https://demo-605-odd-columns--camunda-form-playground.netlify.app/