### PR TITLE
feat(editor): make elements keyboard accessible

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -417,6 +417,11 @@
   color: var(--color-context-pad-item-hover-fill);
 }
 
+.fjs-editor-container .fjs-context-pad-item:focus-visible {
+  outline: 2px solid var(--color-children-selected-border);
+  border-radius: 2px;
+}
+
 /**
  * Palette
  */

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -247,8 +247,10 @@
   background-color: var(--color-children-selected-background);
 }
 
-.fjs-editor-container .fjs-children .fjs-element:hover {
+.fjs-editor-container .fjs-children .fjs-element:hover,
+.fjs-editor-container .fjs-children .fjs-element:focus-within {
   border-color: var(--color-children-hover-border);
+  outline: none;
 }
 
 .fjs-editor-container .fjs-input:disabled,

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState
 } from 'preact/hooks';
@@ -98,10 +99,19 @@ function Element(props) {
     return () => eventBus.off('selection.changed', scrollIntoView);
   }, [ id ]);
 
+  useLayoutEffect(() => {
+    if (selection.isSelected(field)) {
+      ref.current.focus();
+    }
+  }, [ selection, field ]);
+
   function onClick(event) {
     event.stopPropagation();
 
     selection.toggle(field);
+
+    // properly focus on field
+    ref.current.focus();
   }
 
   const classes = [];

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -124,12 +124,21 @@ function Element(props) {
     modeling.removeFormField(field, parentField, index);
   };
 
+  const onKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      event.stopPropagation();
+      selection.toggle(field);
+    }
+  };
+
   return (
     <div
       class={ classes.join(' ') }
       data-id={ id }
       data-field-type={ type }
+      tabIndex={ type === 'default' ? -1 : 0 }
       onClick={ onClick }
+      onKeyPress={ onKeyPress }
       ref={ ref }>
       <DebugColumns field={ field } />
       <ContextPad>

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -18,7 +18,8 @@ import {
 import {
   insertStyles,
   insertTheme,
-  isSingleStart
+  isSingleStart,
+  expectNoViolations
 } from '../TestHelper';
 
 import schema from './form.json';
@@ -1412,6 +1413,25 @@ describe('FormEditor', function() {
       8, 2, 10,
       true
     );
+
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      await createFormEditor({
+        schema,
+        container
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
 
   });
 


### PR DESCRIPTION
Related to #173

* Make editor form fields accessible via keyboard
* Add `Enter` key handler to select focussed elements


![Kapture 2023-04-28 at 13 26 36](https://user-images.githubusercontent.com/9433996/235137470-4b917e81-3c8c-4175-aac4-9da896f99c8c.gif)
