### PR TITLE
Add `readonly` property

### DIFF
--- a/docs/FORM_SCHEMA.md
+++ b/docs/FORM_SCHEMA.md
@@ -168,6 +168,20 @@ Find a complete component reference in the [Camunda Platform documentation](http
       "type": "image"
     },
     {
+      "key": "disabled",
+      "label": "A disabled field",
+      "type": "textfield",
+      "defaultValue": "some value",
+      "disabled": true
+    },
+    {
+      "key": "readonly",
+      "label": "A readonly field",
+      "type": "textfield",
+      "defaultValue": "some value",
+      "readonly": true
+    },
+    {
       "key": "submit",
       "label": "Submit",
       "type": "button"

--- a/packages/form-js-carbon-styles/src/carbon-styles.js
+++ b/packages/form-js-carbon-styles/src/carbon-styles.js
@@ -57,110 +57,108 @@ const getSelectArrowStyles = ({
 `;
 
 const MARKDOWN_STYLES = css`
-  ${({ theme }) => css`
-    .fjs-container .fjs-form-field.fjs-form-field-text .markup {
-      & {
-        font-size: var(--cds-body-long-01-font-size);
-        font-weight: var(--cds-body-long-01-font-weight);
-        line-height: var(--cds-body-long-01-line-height);
-        letter-spacing: var(--cds-body-long-01-letter-spacing);
-      }
+  .fjs-container .fjs-form-field.fjs-form-field-text .markup {
+    & {
+      font-size: var(--cds-body-long-01-font-size);
+      font-weight: var(--cds-body-long-01-font-weight);
+      line-height: var(--cds-body-long-01-line-height);
+      letter-spacing: var(--cds-body-long-01-letter-spacing);
+    }
 
-      & h1 {
-        font-size: var(--cds-productive-heading-06-font-size);
-        font-weight: var(--cds-productive-heading-06-font-weight);
-        line-height: var(--cds-productive-heading-06-line-height);
-        letter-spacing: var(--cds-productive-heading-06-letter-spacing);
-      }
+    & h1 {
+      font-size: var(--cds-productive-heading-06-font-size);
+      font-weight: var(--cds-productive-heading-06-font-weight);
+      line-height: var(--cds-productive-heading-06-line-height);
+      letter-spacing: var(--cds-productive-heading-06-letter-spacing);
+    }
 
-      & h2 {
-        font-size: var(--cds-productive-heading-05-font-size);
-        font-weight: var(--cds-productive-heading-05-font-weight);
-        line-height: var(--cds-productive-heading-05-line-height);
-        letter-spacing: var(--cds-productive-heading-05-letter-spacing);
-      }
+    & h2 {
+      font-size: var(--cds-productive-heading-05-font-size);
+      font-weight: var(--cds-productive-heading-05-font-weight);
+      line-height: var(--cds-productive-heading-05-line-height);
+      letter-spacing: var(--cds-productive-heading-05-letter-spacing);
+    }
 
-      & h3 {
-        font-size: var(--cds-productive-heading-04-font-size);
-        font-weight: var(--cds-productive-heading-04-font-weight);
-        line-height: var(--cds-productive-heading-04-line-height);
-        letter-spacing: var(--cds-productive-heading-04-letter-spacing);
-      }
-      & h4 {
-        font-size: var(--cds-productive-heading-03-font-size);
-        font-weight: var(--cds-productive-heading-03-font-weight);
-        line-height: var(--cds-productive-heading-03-line-height);
-        letter-spacing: var(--cds-productive-heading-03-letter-spacing);
-      }
-      & h5 {
-        font-size: var(--cds-productive-heading-02-font-size);
-        font-weight: var(--cds-productive-heading-02-font-weight);
-        line-height: var(--cds-productive-heading-02-line-height);
-        letter-spacing: var(--cds-productive-heading-02-letter-spacing);
-      }
-      & h6 {
-        font-size: var(--cds-productive-heading-01-font-size);
-        font-weight: var(--cds-productive-heading-01-font-weight);
-        line-height: var(--cds-productive-heading-01-line-height);
-        letter-spacing: var(--cds-productive-heading-01-letter-spacing);
-      }
+    & h3 {
+      font-size: var(--cds-productive-heading-04-font-size);
+      font-weight: var(--cds-productive-heading-04-font-weight);
+      line-height: var(--cds-productive-heading-04-line-height);
+      letter-spacing: var(--cds-productive-heading-04-letter-spacing);
+    }
+    & h4 {
+      font-size: var(--cds-productive-heading-03-font-size);
+      font-weight: var(--cds-productive-heading-03-font-weight);
+      line-height: var(--cds-productive-heading-03-line-height);
+      letter-spacing: var(--cds-productive-heading-03-letter-spacing);
+    }
+    & h5 {
+      font-size: var(--cds-productive-heading-02-font-size);
+      font-weight: var(--cds-productive-heading-02-font-weight);
+      line-height: var(--cds-productive-heading-02-line-height);
+      letter-spacing: var(--cds-productive-heading-02-letter-spacing);
+    }
+    & h6 {
+      font-size: var(--cds-productive-heading-01-font-size);
+      font-weight: var(--cds-productive-heading-01-font-weight);
+      line-height: var(--cds-productive-heading-01-line-height);
+      letter-spacing: var(--cds-productive-heading-01-letter-spacing);
+    }
 
-      & code {
-        font-family: var(--cds-code-02-font-family);
-        font-size: var(--cds-code-02-font-size);
-        font-weight: var(--cds-code-02-font-weight);
-        line-height: var(--cds-code-02-line-height);
-        letter-spacing: var(--cds-code-02-letter-spacing);
-        white-space: pre-wrap;
-      }
+    & code {
+      font-family: var(--cds-code-02-font-family);
+      font-size: var(--cds-code-02-font-size);
+      font-weight: var(--cds-code-02-font-weight);
+      line-height: var(--cds-code-02-line-height);
+      letter-spacing: var(--cds-code-02-letter-spacing);
+      white-space: pre-wrap;
+    }
 
-      & blockquote {
-        font-family: var(--cds-quotation-02-font-family);
-        font-size: var(--cds-quotation-02-font-size);
-        font-weight: var(--cds-quotation-02-font-weight);
-        line-height: var(--cds-quotation-02-line-height);
-        letter-spacing: var(--cds-quotation-02-letter-spacing);
-      }
+    & blockquote {
+      font-family: var(--cds-quotation-02-font-family);
+      font-size: var(--cds-quotation-02-font-size);
+      font-weight: var(--cds-quotation-02-font-weight);
+      line-height: var(--cds-quotation-02-line-height);
+      letter-spacing: var(--cds-quotation-02-letter-spacing);
+    }
 
-      & ul,
-      & ol {
-        box-sizing: border-box;
-        padding: 0;
-        border: 0;
-        margin: 0;
-        list-style: none;
-      }
+    & ul,
+    & ol {
+      box-sizing: border-box;
+      padding: 0;
+      border: 0;
+      margin: 0;
+      list-style: none;
+    }
 
-      & ul {
-        margin-left: var(--cds-spacing-05);
-      }
+    & ul {
+      margin-left: var(--cds-spacing-05);
+    }
 
-      & ol {
-        margin-left: var(--cds-spacing-05);
-      }
+    & ol {
+      margin-left: var(--cds-spacing-05);
+    }
 
-      & ul li {
-        position: relative;
+    & ul li {
+      position: relative;
 
-        &:before {
-          position: absolute;
-          left: calc(-1 * var(--cds-spacing-05));
-          content: '–';
-        }
-      }
-
-      & ol li {
-        position: relative;
-        counter-increment: item;
-
-        &:before {
-          position: absolute;
-          left: calc(-1 * var(--cds-spacing-05));
-          content: counter(item) '.';
-        }
+      &:before {
+        position: absolute;
+        left: calc(-1 * var(--cds-spacing-05));
+        content: '–';
       }
     }
-  `}
+
+    & ol li {
+      position: relative;
+      counter-increment: item;
+
+      &:before {
+        position: absolute;
+        left: calc(-1 * var(--cds-spacing-05));
+        content: counter(item) '.';
+      }
+    }
+  }
 `;
 
 const ANCHOR_STYLES = css`
@@ -197,6 +195,108 @@ const ANCHOR_STYLES = css`
       color: var(--cds-link-primary-hover);
     }
   }
+`;
+
+const READONLY_STYLES = css`
+  ${({ theme }) => css`
+    .fjs-container {
+      .fjs-readonly {
+
+        .fjs-input:read-only:not(:disabled), 
+        .fjs-textarea:read-only:not(:disabled),
+        .fjs-select:read-only:not(:disabled),
+        &.fjs-taglist,
+        .fjs-input-group {
+          background-color: transparent;
+        }
+
+        &.fjs-form-field-number {
+          .fjs-input-group .fjs-number-arrow-container {
+            background-color: transparent;
+
+            .fjs-number-arrow-up, 
+            .fjs-number-arrow-down {
+              background-color: transparent;
+              pointer-events: none;
+            }
+          }
+        }
+
+        &.fjs-form-field:not(.fjs-form-field-datetime) {
+          .fjs-input-group .fjs-input-adornment {
+            background: transparent;
+          }
+        }
+
+        &.fjs-form-field-select {
+          .fjs-input-group {
+            cursor: unset;
+            background-image: ${getSelectArrowSvg(theme.iconDisabled)};
+            background-color: transparent;
+            border-bottom: 1px solid var(--cds-border-strong);
+
+            .fjs-input:read-only:not(:disabled) {
+              border-color: transparent;
+            }
+
+            .fjs-select-display {
+              color: var(--cds-text-primary);
+            }
+          }
+        }
+
+        &.fjs-form-field-datetime {
+          .fjs-input-group {
+            cursor: unset;
+
+            .fjs-input-adornment {
+              background-color: transparent;
+            }
+
+            .flatpickr-input {
+              cursor: unset;
+            }
+
+            .fjs-input-adornment svg {
+              cursor: unset;
+            }
+          }
+        }
+
+        &.fjs-form-field-checkbox,
+        &.fjs-form-field-radio,
+        &.fjs-form-field-checklist {
+          .fjs-input:read-only {
+            opacity: 1;
+            background-color: transparent;
+
+            &:before {
+              border-color: var(--cds-icon-disabled);
+            }
+          }
+
+          &.fjs-checked .fjs-input[type='checkbox'],
+          .fjs-form-field-label.fjs-checked .fjs-input[type='checkbox'] {
+            &:before {
+              border: 1px solid  var(--cds-icon-disabled);
+              background: transparent;
+            }
+
+            &:after {
+              border-bottom: 2px solid var(--cds-icon-primary);
+              border-left: 2px solid var(--cds-icon-primary);
+            }
+          }
+        }
+
+        &.fjs-taglist .fjs-taglist-tag {
+          .fjs-taglist-tag-label {
+            padding: 2px 0px;
+          }
+        }
+      }
+    }
+  `}
 `;
 
 const DISABLED_STYLES = css`
@@ -271,11 +371,11 @@ const DISABLED_STYLES = css`
     }
 
     .fjs-taglist.fjs-disabled .fjs-taglist-tag {
-      background-color: var(--cds-field-02);
-      opacity: 0.7;
+      background-color: var(--cds-layer-01);
 
       .fjs-taglist-tag-label {
         padding: 2px 0px;
+        opacity: 0.7;
         color: var(--cds-text-on-color-disabled);
       }
     }
@@ -283,57 +383,55 @@ const DISABLED_STYLES = css`
 `;
 
 const LABEL_DESCRIPTION_ERROR_STYLES = css`
-  ${({ theme }) => css`
-    .fjs-container {
-      .fjs-form-field-label {
-        font-size: var(--cds-label-01-font-size);
-        font-weight: var(--cds-label-01-font-weight);
-        line-height: var(--cds-label-01-line-height);
-        letter-spacing: var(--cds-label-01-letter-spacing);
-      }
-
-      .fjs-form-field:not(.fjs-form-field-checkbox)
-        .fjs-form-field-label:first-child {
-        margin: 0;
-        margin-bottom: var(--cds-spacing-03);
-      }
-
-      .fjs-form-field.fjs-form-field-radio
-        .fjs-form-field-label:not(:first-of-type),
-      .fjs-form-field.fjs-form-field-checklist
-        .fjs-form-field-label:not(:first-of-type) {
-        margin: 0;
-        margin-bottom: 0.1875rem;
-      }
-
-      .fjs-form-field.fjs-form-field-radio
-        .fjs-form-field-label:not(:first-of-type) {
-        min-height: ${rem(27)};
-      }
-
-      .fjs-form-field-description {
-        margin: 0;
-        margin-top: var(--cds-spacing-02);
-        font-size: var(--cds-helper-text-01-font-size);
-        font-weight: var(--cds-helper-text-01-font-weight);
-        line-height: var(--cds-helper-text-01-line-height);
-        letter-spacing: var(--cds-helper-text-01-letter-spacing);
-      }
-
-      .fjs-form-field-error {
-        margin: 0;
-        margin-top: var(--cds-spacing-02);
-        font-size: var(--cds-label-01-font-size);
-        font-weight: var(--cds-label-01-font-weight);
-        line-height: var(--cds-label-01-line-height);
-        letter-spacing: var(--cds-label-01-letter-spacing);
-      }
-
-      .fjs-has-errors .fjs-form-field-description {
-        display: none;
-      }
+  .fjs-container {
+    .fjs-form-field-label {
+      font-size: var(--cds-label-01-font-size);
+      font-weight: var(--cds-label-01-font-weight);
+      line-height: var(--cds-label-01-line-height);
+      letter-spacing: var(--cds-label-01-letter-spacing);
     }
-  `}
+
+    .fjs-form-field:not(.fjs-form-field-checkbox)
+      .fjs-form-field-label:first-child {
+      margin: 0;
+      margin-bottom: var(--cds-spacing-03);
+    }
+
+    .fjs-form-field.fjs-form-field-radio
+      .fjs-form-field-label:not(:first-of-type),
+    .fjs-form-field.fjs-form-field-checklist
+      .fjs-form-field-label:not(:first-of-type) {
+      margin: 0;
+      margin-bottom: 0.1875rem;
+    }
+
+    .fjs-form-field.fjs-form-field-radio
+      .fjs-form-field-label:not(:first-of-type) {
+      min-height: ${rem(27)};
+    }
+
+    .fjs-form-field-description {
+      margin: 0;
+      margin-top: var(--cds-spacing-02);
+      font-size: var(--cds-helper-text-01-font-size);
+      font-weight: var(--cds-helper-text-01-font-weight);
+      line-height: var(--cds-helper-text-01-line-height);
+      letter-spacing: var(--cds-helper-text-01-letter-spacing);
+    }
+
+    .fjs-form-field-error {
+      margin: 0;
+      margin-top: var(--cds-spacing-02);
+      font-size: var(--cds-label-01-font-size);
+      font-weight: var(--cds-label-01-font-weight);
+      line-height: var(--cds-label-01-line-height);
+      letter-spacing: var(--cds-label-01-letter-spacing);
+    }
+
+    .fjs-has-errors .fjs-form-field-description {
+      display: none;
+    }
+  }
 `;
 
 const CHECKBOX_STYLES = css`
@@ -1033,6 +1131,7 @@ const ADORNMENTS_STYLES = css`
 const CARBON_STYLES = css`
   ${MARKDOWN_STYLES}
   ${ANCHOR_STYLES}
+  ${READONLY_STYLES}
   ${DISABLED_STYLES}
   ${LABEL_DESCRIPTION_ERROR_STYLES}
   ${CHECKBOX_STYLES}

--- a/packages/form-js-carbon-styles/test/spec/carbon-styles.spec.js
+++ b/packages/form-js-carbon-styles/test/spec/carbon-styles.spec.js
@@ -107,6 +107,9 @@ describe('FormCustomStyling', function() {
         }
       ],
       tags: [ 'tag1', 'tag2', 'tag3' ],
+      readonly_tags: [ 'tag1', 'tag2', 'tag3' ],
+      readonly_checklist: [ 'option_1' ],
+      readonly_radio: 'option_1',
       language: 'english'
     };
 
@@ -202,7 +205,7 @@ function FormContainer(props) {
     return () => { form.destroy(); };
   }, [ ref, props ]);
 
-  return <div ref={ ref } class="form-container"></div>;
+  return <div ref={ ref } class="form-container cds--layer-two"></div>;
 }
 
 

--- a/packages/form-js-carbon-styles/test/spec/complex.json
+++ b/packages/form-js-carbon-styles/test/spec/complex.json
@@ -6,23 +6,32 @@
       "id": "Field_1bbbwwg"
     },
     {
-      "label": "I am a texfield",
+      "label": "I am a textfield",
       "type": "textfield",
       "id": "Field_1l0t1m5",
       "key": "textfield",
-      "description": "I am a texfield description",
+      "description": "I am a textfield description",
       "validate": {
         "required": true
       },
       "defaultValue": "value"
     },
     {
-      "label": "I am a disabled texfield",
+      "label": "I am a disabled textfield",
       "type": "textfield",
       "id": "Field_1r9b6p2",
       "key": "disabled_textfield",
-      "description": "I am a disabled texfield description",
+      "description": "I am a disabled textfield description",
       "disabled": true,
+      "defaultValue": "value"
+    },
+    {
+      "label": "I am a read only textfield",
+      "type": "textfield",
+      "id": "Field_1r9b6p3",
+      "key": "readonly-textfield",
+      "description": "I am a read only textfield description",
+      "readonly": true,
       "defaultValue": "value"
     },
     {
@@ -37,12 +46,21 @@
       "defaultValue": 1
     },
     {
-      "label": "I am a number field",
+      "label": "I am a disabled number field",
       "type": "number",
       "id": "Field_1t8wtoa",
       "key": "disabled_number_field",
       "description": "I am a disabled number field description",
       "disabled": true,
+      "defaultValue": 1
+    },
+    {
+      "label": "I am a read only number field",
+      "type": "number",
+      "id": "Field_1t8wtob",
+      "key": "readonly_number_field",
+      "description": "I am a read only number field description",
+      "readonly": true,
       "defaultValue": 1
     },
     {
@@ -63,12 +81,29 @@
       "description": "I am disabled checked checkbox description"
     },
     {
+      "label": "I am read only checked checkbox",
+      "type": "checkbox",
+      "id": "Field_1klmaha",
+      "key": "readonly_checked_checkbox",
+      "readonly": true,
+      "defaultValue": true,
+      "description": "I am read only checked checkbox description"
+    },
+    {
       "label": "I am disabled checkbox",
       "type": "checkbox",
       "id": "Field_01h0ngn",
       "key": "disabled_checkbox",
       "description": "I am disabled checkbox description",
       "disabled": true
+    },
+    {
+      "label": "I am read only checkbox",
+      "type": "checkbox",
+      "id": "Field_01h0ngm",
+      "key": "readonly_checkbox",
+      "description": "I am read only checkbox description",
+      "readonly": true
     },
     {
       "values": [
@@ -116,6 +151,24 @@
           "value": "option_2"
         }
       ],
+      "label": "I am read only checklist",
+      "type": "checklist",
+      "id": "Field_0l0y6cg",
+      "key": "readonly_checklist",
+      "description": "I am read only checklist description",
+      "readonly": true
+    },
+    {
+      "values": [
+        {
+          "label": "Option 1",
+          "value": "option_1"
+        },
+        {
+          "label": "Option 2",
+          "value": "option_2"
+        }
+      ],
       "label": "I am a taglist",
       "type": "taglist",
       "id": "Field_07zrh4q",
@@ -143,6 +196,28 @@
       "key": "tags",
       "description": "I am a disabled taglist description",
       "disabled": true
+    },
+    {
+      "values": [
+        {
+          "label": "Tag 1",
+          "value": "tag1"
+        },
+        {
+          "label": "Tag 2",
+          "value": "tag2"
+        },
+        {
+          "label": "Tag 3",
+          "value": "tag3"
+        }
+      ],
+      "label": "I am a read only taglist",
+      "type": "taglist",
+      "id": "Field_0hm9hgi",
+      "key": "readonly_tags",
+      "description": "I am a read only taglist description",
+      "readonly": true
     },
     {
       "values": [
@@ -196,6 +271,27 @@
           "value": "option_2"
         }
       ],
+      "label": "I am a read only radio",
+      "type": "radio",
+      "id": "Field_110t1zz",
+      "key": "readonly_radio",
+      "description": "I am a read only radio description",
+      "validate": {
+        "required": false
+      },
+      "readonly": true
+    },
+    {
+      "values": [
+        {
+          "label": "Option 1",
+          "value": "option_1"
+        },
+        {
+          "label": "Option 2",
+          "value": "option_2"
+        }
+      ],
       "label": "I am a select",
       "type": "select",
       "id": "Field_1iw4ekg",
@@ -223,6 +319,25 @@
       "key": "disabled_select",
       "description": "I am a select description",
       "disabled": true,
+      "defaultValue": "option_2"
+    },
+    {
+      "values": [
+        {
+          "label": "Option 1",
+          "value": "option_1"
+        },
+        {
+          "label": "Option 2",
+          "value": "option_2"
+        }
+      ],
+      "label": "I am a read only select",
+      "type": "select",
+      "id": "Field_06g19xm",
+      "key": "readonly_select",
+      "description": "I am a read only select description",
+      "readonly": true,
       "defaultValue": "option_2"
     },
     {
@@ -268,6 +383,26 @@
       "defaultValue": "option_2"
     },
     {
+      "values": [
+        {
+          "label": "Option 1",
+          "value": "option_1"
+        },
+        {
+          "label": "Option 2",
+          "value": "option_2"
+        }
+      ],
+      "label": "I am a read only searchable select",
+      "searchable": true,
+      "type": "select",
+      "id": "Field_06g19xx",
+      "key": "readonly_searchable_select",
+      "description": "I am a read only select description",
+      "readonly": true,
+      "defaultValue": "option_2"
+    },
+    {
       "type": "image",
       "alt": "An image",
       "id": "Field_1mv8qs4",
@@ -292,6 +427,14 @@
       "disabled": true
     },
     {
+      "label": "I am a read only text area",
+      "type": "textarea",
+      "id": "Field_1ae1pqo",
+      "key": "readonly_textarea",
+      "description": "I am a read only text area description",
+      "readonly": true
+    },
+    {
       "subtype": "date",
       "dateLabel": "I am a date field",
       "type": "datetime",
@@ -310,6 +453,15 @@
       "key": "disabled_date_field",
       "description": "I am a disabled date field description",
       "disabled": true
+    },
+    {
+      "subtype": "date",
+      "dateLabel": "I am a read only date field",
+      "type": "datetime",
+      "id": "Field_09ff8mw",
+      "key": "readonly_date_field",
+      "description": "I am a read only date field description",
+      "readonly": true
     },
     {
       "subtype": "time",
@@ -334,6 +486,21 @@
       "timeInterval": 15,
       "description": "I am a disabled time field description",
       "disabled": true,
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "subtype": "time",
+      "dateLabel": "Date",
+      "type": "datetime",
+      "id": "Field_16am9zw",
+      "key": "readonly_time",
+      "timeLabel": "I am a read only time field",
+      "timeSerializingFormat": "utc_offset",
+      "timeInterval": 15,
+      "description": "I am a read only time field description",
+      "readonly": true,
       "validate": {
         "required": true
       }
@@ -365,11 +532,38 @@
       }
     },
     {
+      "subtype": "datetime",
+      "dateLabel": "I am a read only datetime field date label",
+      "type": "datetime",
+      "id": "Field_0qupylm",
+      "key": "readonly_datetime",
+      "timeLabel": "I am a read only datetime field time label",
+      "timeSerializingFormat": "utc_offset",
+      "timeInterval": 15,
+      "readonly": true,
+      "description": "I am a read only datetime description",
+      "validate": {
+        "required": true
+      }
+    },
+    {
       "label": "I am an adorned field",
       "type": "textfield",
       "id": "Field_0k58wk0",
       "key": "adorned_field",
       "description": "I am an adorned field description",
+      "appearance": {
+        "prefixAdorner": "prefix",
+        "suffixAdorner": "suffix"
+      }
+    },
+    {
+      "label": "I am an adorned read only field",
+      "type": "textfield",
+      "id": "Field_0k58wk1",
+      "key": "adorned_readonly_field",
+      "description": "I am an adorned read only field description",
+      "readonly": true,
       "appearance": {
         "prefixAdorner": "prefix",
         "suffixAdorner": "suffix"
@@ -398,5 +592,5 @@
     "name": "Camunda Modeler",
     "version": "5.7.0-nightly.20230103"
   },
-  "schemaVersion": 6
+  "schemaVersion": 9
 }

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -261,6 +261,10 @@
   pointer-events: none;
 }
 
+.fjs-editor-container .fjs-readonly {
+  pointer-events: none;
+}
+
 .fjs-editor-container .fjs-drag-container,
 .fjs-editor-container .fjs-drop-container-vertical {
   user-select: none;

--- a/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
@@ -1,0 +1,57 @@
+import { get } from 'min-dash';
+
+import { INPUTS } from '../Util';
+
+import { ToggleSwitchEntry, isToggleSwitchEntryEdited } from '@bpmn-io/properties-panel';
+
+
+export default function ReadonlyEntry(props) {
+  const {
+    editField,
+    field
+  } = props;
+
+  const {
+    type
+  } = field;
+
+  const entries = [];
+
+  if (INPUTS.includes(type)) {
+    entries.push({
+      id: 'readonly',
+      component: Readonly,
+      editField: editField,
+      field: field,
+      isEdited: isToggleSwitchEntryEdited
+    });
+  }
+
+  return entries;
+}
+
+function Readonly(props) {
+  const {
+    editField,
+    field,
+    id
+  } = props;
+
+  const path = [ 'readonly' ];
+
+  const getValue = () => {
+    return get(field, path, '');
+  };
+
+  const setValue = (value) => {
+    return editField(field, path, value);
+  };
+
+  return ToggleSwitchEntry({
+    element: field,
+    getValue,
+    id,
+    label: 'Read only',
+    setValue
+  });
+}

--- a/packages/form-js-editor/src/features/properties-panel/entries/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/index.js
@@ -21,4 +21,5 @@ export { default as ValuesSourceSelectEntry } from './ValuesSourceSelectEntry';
 export { default as InputKeyValuesSourceEntry } from './InputKeyValuesSourceEntry';
 export { default as StaticValuesSourceEntry } from './StaticValuesSourceEntry';
 export { default as AdornerEntry } from './AdornerEntry';
+export { default as ReadonlyEntry } from './ReadonlyEntry';
 export { ConditionEntry } from './ConditionEntry';

--- a/packages/form-js-editor/src/features/properties-panel/groups/GeneralGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/GeneralGroup.js
@@ -8,6 +8,7 @@ import {
   ImageSourceEntry,
   KeyEntry,
   LabelEntry,
+  ReadonlyEntry,
   SelectEntries,
   TextEntry,
   NumberEntries,
@@ -30,7 +31,8 @@ export default function GeneralGroup(field, editField, getService) {
     ...ImageSourceEntry({ field, editField }),
     ...AltTextEntry({ field, editField }),
     ...SelectEntries({ field, editField }),
-    ...DisabledEntry({ field, editField })
+    ...DisabledEntry({ field, editField }),
+    ...ReadonlyEntry({ field, editField })
   ];
 
   return {

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -394,7 +394,7 @@ export default function FormEditor(props) {
               errors: {},
               properties: {
                 ariaLabel,
-                readOnly: true
+                disabled: true
               },
               schema
             };

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/GeneralGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/GeneralGroup.spec.js
@@ -826,6 +826,85 @@ describe('GeneralGroup', function() {
   });
 
 
+  describe('readonly', function() {
+
+    it('should NOT render for default', function() {
+
+      // given
+      const field = { type: 'default' };
+
+      // when
+      const { container } = renderGeneralGroup({ field });
+
+      // then
+      const readonlyInput = findInput('readonly', container);
+
+      expect(readonlyInput).to.not.exist;
+    });
+
+
+    it('should render for INPUTS', function() {
+
+      // given
+      for (const type of INPUTS) {
+
+        const field = { type };
+
+        // when
+        const { container } = renderGeneralGroup({ field });
+
+        // then
+        const readonlyInput = findInput('readonly', container);
+
+        expect(readonlyInput).to.exist;
+      }
+    });
+
+
+    it('should read', function() {
+
+      // given
+      const field = {
+        type: 'number',
+        readonly: true
+      };
+
+      // when
+      const { container } = renderGeneralGroup({ field });
+
+      const readonlyInput = findInput('readonly', container);
+
+      // then
+      expect(readonlyInput).to.exist;
+      expect(readonlyInput.checked).to.equal(true);
+    });
+
+
+    it('should write', function() {
+
+      // given
+      const field = {
+        type: 'number',
+        readonly: true
+      };
+
+      const editFieldSpy = sinon.spy((field, path, value) => set(field, path, value));
+
+      const { container } = renderGeneralGroup({ field, editField: editFieldSpy });
+
+      const readonlyInput = findInput('readonly', container);
+
+      // when
+      fireEvent.click(readonlyInput);
+
+      // then
+      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(field.readonly).to.equal(false);
+    });
+
+  });
+
+
   describe('subtype', function() {
 
     it('should render for datetime', function() {

--- a/packages/form-js-editor/test/spec/render/components/form-fields/helper/index.js
+++ b/packages/form-js-editor/test/spec/render/components/form-fields/helper/index.js
@@ -32,7 +32,7 @@ export function WithEditorFormContext(Component, options = {}, formId = 'foo') {
             data: {},
             errors: {},
             properties: {
-              readOnly: true
+              disabled: true
             }
           };
         }

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -44,6 +44,7 @@
     var(--cds-field-01, var(--color-white))
   );
   --color-background-disabled: var(--cds-background, var(--color-grey-225-10-95));
+  --color-background-readonly: var(--cds-background, var(--color-grey-225-10-95));
   --color-background-adornment: var(
     --cds-field, 
     var(--cds-field-01, var(--color-grey-225-10-95))
@@ -74,11 +75,16 @@
     --cds-border-subtle, 
     var(--cds-border-subtle-01, var(--color-grey-225-10-85))
   );
+  --color-borders-readonly: var(--cds-border-disabled, var(--color-grey-225-10-75));
   --color-borders-inverted: var(--cds-border-inverse, var(--color-grey-225-10-90));
 
   --color-warning: var(--cds-text-error, var(--color-red-360-100-45));
   --color-warning-light: var(--cds-text-error, var(--color-red-360-100-92));
   --color-accent: var(--cds-link-primary, var(--color-blue-205-100-40));
+  --color-accent-readonly: var(
+    --cds-border-strong, 
+    var(--cds-border-strong-01, var(--color-grey-225-10-55))
+  );
   --color-datepicker-focused-day: var(--cds-button-primary, var(--color-grey-225-10-55));
   --color-shadow: var(--cds-shadow, var(--color-grey-225-10-85));
 
@@ -102,6 +108,7 @@
   --border-definition-adornment: 1px solid var(--color-borders-adornment);
   --outline-definition: 1px solid var(--cds-focus, var(--color-borders));
   --border-definition-disabled: 1px solid var(--color-borders-disabled);
+  --border-definition-readonly: 1px solid var(--color-borders-readonly);
 
   height: 100%;
 }
@@ -230,7 +237,9 @@
 .fjs-container .fjs-taglist-input::placeholder,
 .fjs-container .fjs-textarea::placeholder,
 .fjs-container .fjs-select > option:disabled,
-.fjs-container .fjs-select [disabled] {
+.fjs-container .fjs-select [disabled],
+.fjs-container .fjs-select > option:read-only,
+.fjs-container .fjs-select [read-only] {
   color: var(--color-text-lightest);
   font-size: var(--font-size-input);
   line-height: var(--line-height-input);
@@ -408,7 +417,8 @@
 }
 
 .fjs-container .fjs-input-group .fjs-select-display.fjs-select-placeholder,
-.fjs-container .fjs-disabled .fjs-input-group .fjs-select-display {
+.fjs-container .fjs-disabled .fjs-input-group .fjs-select-display,
+.fjs-container .fjs-readonly .fjs-input-group .fjs-select-display {
   color: var(--color-text-lighter);
   line-height: var(--line-height-input);
 }
@@ -563,12 +573,43 @@
   background-color: var(--cds-toggle-off, var(--color-background-disabled));
 }
 
+.fjs-container .fjs-input:read-only,
+.fjs-container .fjs-textarea:read-only,
+.fjs-container .fjs-select:read-only,
+.fjs-container .fjs-number-arrow-container.fjs-readonly button,
+.fjs-container .fjs-taglist.fjs-readonly,
+.fjs-container .fjs-readonly .fjs-input-group {
+  background-color: var(--color-background-readonly);
+  border-color: var(--color-borders-readonly);
+}
+
+.fjs-container .fjs-form-field-checkbox.fjs-readonly,
+.fjs-container .fjs-form-field-checklist.fjs-readonly,
+.fjs-container .fjs-form-field-radio.fjs-readonly {
+  pointer-events: none;
+}
+
+.fjs-container .fjs-form-field-checkbox.fjs-readonly .fjs-input:not(:disabled),
+.fjs-container .fjs-form-field-checklist.fjs-readonly .fjs-input:not(:disabled),
+.fjs-container .fjs-form-field-radio.fjs-readonly .fjs-input:not(:disabled) {
+  opacity: 0.4;
+  accent-color: var(--color-accent-readonly);
+}
+
 .fjs-container .fjs-button[type='submit']:disabled,
 .fjs-container .fjs-button[type='reset']:disabled {
   color: var(--cds-text-on-color-disabled, var(--color-text-light));
   background-color: var(--color-background-disabled);
   border-color: var(--color-borders-disabled);
 }
+
+.fjs-container .fjs-button[type='submit']:read-only,
+.fjs-container .fjs-button[type='reset']:read-only {
+  color: var(--text-light);
+  background-color: var(--color-background-readonly);
+  border-color: var(--color-borders-readonly);
+}
+
 .fjs-container .fjs-disabled .fjs-input-group .fjs-input-adornment,
 .fjs-container .fjs-disabled .fjs-input-group .fjs-number-arrow-container,
 .fjs-container .fjs-disabled .fjs-input-group .fjs-number-arrow-separator {
@@ -578,6 +619,12 @@
 .fjs-container .fjs-disabled .fjs-input-group .fjs-number-arrow-container .fjs-number-arrow-up,
 .fjs-container .fjs-disabled .fjs-input-group .fjs-number-arrow-container .fjs-number-arrow-down {
   pointer-events: none;
+}
+
+.fjs-container .fjs-readonly .fjs-input-group .fjs-input-adornment,
+.fjs-container .fjs-readonly .fjs-input-group .fjs-number-arrow-container,
+.fjs-container .fjs-readonly .fjs-input-group .fjs-number-arrow-separator {
+  border-color: var(--color-borders-readonly);
 }
 
 .fjs-container .fjs-form-field.fjs-has-errors .fjs-input,
@@ -677,7 +724,8 @@
   border-radius: 2px;
 }
 
-.fjs-container .fjs-taglist.fjs-disabled .fjs-taglist-tag { 
+.fjs-container .fjs-taglist.fjs-disabled .fjs-taglist-tag,
+.fjs-container .fjs-taglist.fjs-readonly .fjs-taglist-tag { 
   background-color: var(--color-background-inverted);
 }
 
@@ -691,7 +739,8 @@
   padding: 2px 6px 2px 8px;
 }
 
-.fjs-container .fjs-taglist.fjs-disabled .fjs-taglist-tag .fjs-taglist-tag-label {
+.fjs-container .fjs-taglist.fjs-disabled .fjs-taglist-tag .fjs-taglist-tag-label,
+.fjs-container .fjs-taglist.fjs-readonly .fjs-taglist-tag .fjs-taglist-tag-label {
   padding: 2px 8px;
 }
 

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -573,9 +573,9 @@
   background-color: var(--cds-toggle-off, var(--color-background-disabled));
 }
 
-.fjs-container .fjs-input:read-only,
-.fjs-container .fjs-textarea:read-only,
-.fjs-container .fjs-select:read-only,
+.fjs-container .fjs-readonly .fjs-input:read-only:not(:disabled),
+.fjs-container .fjs-readonly .fjs-textarea:read-only:not(:disabled),
+.fjs-container .fjs-readonly .fjs-select:read-only:not(:disabled),
 .fjs-container .fjs-number-arrow-container.fjs-readonly button,
 .fjs-container .fjs-taglist.fjs-readonly,
 .fjs-container .fjs-readonly .fjs-input-group {

--- a/packages/form-js-viewer/src/Form.js
+++ b/packages/form-js-viewer/src/Form.js
@@ -166,7 +166,7 @@ export default class Form {
       properties
     } = this._getState();
 
-    if (properties.readOnly) {
+    if (properties.readOnly || properties.disabled) {
       throw new Error('form is read-only');
     }
 

--- a/packages/form-js-viewer/src/index.js
+++ b/packages/form-js-viewer/src/index.js
@@ -5,7 +5,7 @@ export * from './render';
 export * from './util';
 export * from './features';
 
-const schemaVersion = 8;
+const schemaVersion = 9;
 
 export {
   Form,

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -45,7 +45,9 @@ export default function FormField(props) {
 
   const fieldErrors = findErrors(errors, field._path);
 
-  const disabled = properties.readOnly || field.disabled || false;
+  const disabled = properties.disabled || field.disabled || false;
+
+  const readonly = properties.readOnly || field.readonly || false;
 
   const hidden = useCondition(field.conditional && field.conditional.hide || null);
 
@@ -60,7 +62,8 @@ export default function FormField(props) {
           { ...props }
           disabled={ disabled }
           errors={ fieldErrors }
-          onChange={ disabled ? noop : onChange }
+          onChange={ disabled || readonly ? noop : onChange }
+          readonly={ readonly }
           value={ value } />
       </Element>
     </Column>

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -45,9 +45,12 @@ export default function FormField(props) {
 
   const fieldErrors = findErrors(errors, field._path);
 
-  const disabled = properties.disabled || field.disabled || false;
-
   const readonly = properties.readOnly || field.readonly || false;
+
+  // add precedence: global readonly > form field disabled
+  const disabled = !properties.readOnly && (
+    properties.disabled || field.disabled || false
+  );
 
   const hidden = useCondition(field.conditional && field.conditional.hide || null);
 

--- a/packages/form-js-viewer/src/render/components/Util.js
+++ b/packages/form-js-viewer/src/render/components/Util.js
@@ -1,13 +1,14 @@
 import classNames from 'classnames';
 
-export function formFieldClasses(type, { errors = [], disabled = false } = {}) {
+export function formFieldClasses(type, { errors = [], disabled = false, readonly = false } = {}) {
   if (!type) {
     throw new Error('type required');
   }
 
   return classNames('fjs-form-field', `fjs-form-field-${type}`, {
     'fjs-has-errors': errors.length > 0,
-    'fjs-disabled': disabled
+    'fjs-disabled': disabled,
+    'fjs-readonly': readonly
   });
 }
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -20,6 +20,7 @@ export default function Checkbox(props) {
     disabled,
     errors = [],
     field,
+    readonly,
     value = false
   } = props;
 
@@ -42,7 +43,7 @@ export default function Checkbox(props) {
   const { formId } = useContext(FormContext);
   const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
 
-  return <div class={ classNames(formFieldClasses(type, { errors, disabled }), { 'fjs-checked': value }) }>
+  return <div class={ classNames(formFieldClasses(type, { errors, disabled, readonly }), { 'fjs-checked': value }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }
@@ -51,6 +52,7 @@ export default function Checkbox(props) {
         checked={ value }
         class="fjs-input"
         disabled={ disabled }
+        readOnly={ readonly }
         id={ prefixId(id, formId) }
         type="checkbox"
         onChange={ onChange }

--- a/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
@@ -21,6 +21,7 @@ export default function Checklist(props) {
     disabled,
     errors = [],
     field,
+    readonly,
     value = [],
   } = props;
 
@@ -57,7 +58,7 @@ export default function Checklist(props) {
   const { formId } = useContext(FormContext);
   const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
 
-  return <div class={ classNames(formFieldClasses(type, { errors, disabled })) }>
+  return <div class={ classNames(formFieldClasses(type, { errors, disabled, readonly })) }>
     <Label
       label={ label }
       required={ required } />
@@ -76,6 +77,7 @@ export default function Checklist(props) {
               checked={ value.includes(v.value) }
               class="fjs-input"
               disabled={ disabled }
+              readOnly={ readonly }
               id={ prefixId(`${id}-${index}`, formId) }
               type="checkbox"
               onClick={ () => toggleCheckbox(v.value) }

--- a/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
@@ -25,6 +25,7 @@ export default function Datetime(props) {
     errors = [],
     field,
     onChange,
+    readonly,
     value = ''
   } = props;
 
@@ -139,6 +140,7 @@ export default function Datetime(props) {
     disabled,
     disallowPassedDates,
     date: dateTime.date,
+    readonly,
     setDate,
     'aria-describedby': errorMessageId
   };
@@ -149,6 +151,7 @@ export default function Datetime(props) {
     formId,
     required,
     disabled,
+    readonly,
     use24h,
     timeInterval,
     time: dateTime.time,
@@ -156,7 +159,7 @@ export default function Datetime(props) {
     'aria-describedby': errorMessageId
   };
 
-  return <div class={ formFieldClasses(type, { errors: allErrors, disabled }) }>
+  return <div class={ formFieldClasses(type, { errors: allErrors, disabled, readonly }) }>
     <div class={ classNames('fjs-vertical-group') }>
       { useDatePicker && <Datepicker { ...datePickerProps } /> }
       { useTimePicker && useDatePicker && <div class="fjs-datetime-separator" /> }

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -32,6 +32,7 @@ export default function Numberfield(props) {
     errors = [],
     field,
     value,
+    readonly,
     onChange
   } = props;
 
@@ -106,6 +107,10 @@ export default function Numberfield(props) {
   }, [ field, onChange, serializeToString ]);
 
   const increment = () => {
+    if (readonly) {
+      return;
+    }
+
     const base = isValidNumber(value) ? Big(value) : Big(0);
     const stepFlooredValue = base.minus(base.mod(arrowIncrementValue));
 
@@ -114,6 +119,10 @@ export default function Numberfield(props) {
   };
 
   const decrement = () => {
+    if (readonly) {
+      return;
+    }
+
     const base = isValidNumber(value) ? Big(value) : Big(0);
     const offset = base.mod(arrowIncrementValue);
 
@@ -167,17 +176,18 @@ export default function Numberfield(props) {
   const { formId } = useContext(FormContext);
   const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
 
-  return <div class={ formFieldClasses(type, { errors, disabled }) }>
+  return <div class={ formFieldClasses(type, { errors, disabled, readonly }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }
       required={ required } />
-    <InputAdorner disabled={ disabled } pre={ prefixAdorner } post={ suffixAdorner }>
-      <div class={ classNames('fjs-vertical-group', { 'fjs-disabled': disabled }, { 'hasErrors': errors.length }) }>
+    <InputAdorner disabled={ disabled } readonly={ readonly } pre={ prefixAdorner } post={ suffixAdorner }>
+      <div class={ classNames('fjs-vertical-group', { 'fjs-disabled': disabled, 'fjs-readonly': readonly }, { 'hasErrors': errors.length }) }>
         <input
           ref={ inputRef }
           class="fjs-input"
           disabled={ disabled }
+          readOnly={ readonly }
           id={ prefixId(id, formId) }
           onKeyDown={ onKeyDown }
           onKeyPress={ onKeyPress }
@@ -189,7 +199,7 @@ export default function Numberfield(props) {
           step={ arrowIncrementValue }
           value={ displayValue }
           aria-describedby={ errorMessageId } />
-        <div class={ classNames('fjs-number-arrow-container', { 'fjs-disabled': disabled }) }>
+        <div class={ classNames('fjs-number-arrow-container', { 'fjs-disabled': disabled, 'fjs-readonly': readonly }) }>
           { /* we're disabling tab navigation on both buttons to imitate the native browser behavior of input[type='number'] increment arrows */ }
           <button
             class="fjs-number-arrow-up"

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -21,6 +21,7 @@ export default function Radio(props) {
     disabled,
     errors = [],
     field,
+    readonly,
     value
   } = props;
 
@@ -48,7 +49,7 @@ export default function Radio(props) {
   const { formId } = useContext(FormContext);
   const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
 
-  return <div class={ formFieldClasses(type, { errors, disabled }) }>
+  return <div class={ formFieldClasses(type, { errors, disabled, readonly }) }>
     <Label
       label={ label }
       required={ required } />
@@ -65,6 +66,7 @@ export default function Radio(props) {
               checked={ option.value === value }
               class="fjs-input"
               disabled={ disabled }
+              readOnly={ readonly }
               id={ prefixId(`${ id }-${ index }`, formId) }
               type="radio"
               onClick={ () => onChange(option.value) }

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -22,6 +22,7 @@ export default function Select(props) {
     errors = [],
     field,
     onChange,
+    readonly,
     value
   } = props;
 
@@ -45,11 +46,12 @@ export default function Select(props) {
     field,
     value,
     onChange,
+    readonly,
     'aria-describedby': errorMessageId,
-  }), [ disabled, errors, field, id, value, onChange, errorMessageId ]);
+  }), [ disabled, errors, field, id, value, onChange, readonly, errorMessageId ]);
 
   return <div
-    class={ formFieldClasses(type, { errors, disabled }) }
+    class={ formFieldClasses(type, { errors, disabled, readonly }) }
     onKeyDown={
       (event) => {
         if (event.key === 'Enter') {

--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -25,6 +25,7 @@ export default function Taglist(props) {
     disabled,
     errors = [],
     field,
+    readonly,
     value : values = []
   } = props;
 
@@ -115,6 +116,11 @@ export default function Taglist(props) {
     }
   };
 
+  const onBlur = () => {
+    setIsDropdownExpanded(false);
+    setFilter('');
+  };
+
   const onTagRemoveClick = (event, value) => {
     const { target } = event;
 
@@ -130,7 +136,7 @@ export default function Taglist(props) {
   const shouldDisplayDropdown = useMemo(() => !disabled && loadState === LOAD_STATES.LOADED && isDropdownExpanded && !isEscapeClosed, [ disabled, isDropdownExpanded, isEscapeClosed, loadState ]);
 
   return <div
-    class={ formFieldClasses(type, { errors, disabled }) }
+    class={ formFieldClasses(type, { errors, disabled, readonly }) }
     onKeyDown={
       (event) => {
         if (event.key === 'Enter') {
@@ -144,17 +150,17 @@ export default function Taglist(props) {
       label={ label }
       required={ required }
       id={ prefixId(`${id}-search`, formId) } />
-    <div class={ classNames('fjs-taglist', { 'fjs-disabled': disabled }) }>
+    <div class={ classNames('fjs-taglist', { 'fjs-disabled': disabled, 'fjs-readonly': readonly }) }>
       { loadState === LOAD_STATES.LOADED &&
         <div class="fjs-taglist-tags">
           {
             values.map((v) => {
               return (
-                <div class={ classNames('fjs-taglist-tag', { 'fjs-disabled': disabled }) } onMouseDown={ (e) => e.preventDefault() }>
+                <div class={ classNames('fjs-taglist-tag', { 'fjs-disabled': disabled, 'fjs-readonly': readonly }) } onMouseDown={ (e) => e.preventDefault() }>
                   <span class="fjs-taglist-tag-label">
                     {valueToOptionMap[v] ? valueToOptionMap[v].label : `unexpected value{${v}}`}
                   </span>
-                  { !disabled && <button
+                  { (!disabled && !readonly) && <button
                     type="button"
                     title="Remove tag"
                     class="fjs-taglist-tag-remove"
@@ -170,18 +176,19 @@ export default function Taglist(props) {
       }
       <input
         disabled={ disabled }
+        readOnly={ readonly }
         class="fjs-taglist-input"
         ref={ searchbarRef }
         id={ prefixId(`${id}-search`, formId) }
         onChange={ onFilterChange }
         type="text"
         value={ filter }
-        placeholder={ disabled ? undefined : 'Search' }
+        placeholder={ (disabled || readonly) ? undefined : 'Search' }
         autoComplete="off"
         onKeyDown={ onInputKeyDown }
         onMouseDown={ () => setIsEscapeClose(false) }
-        onFocus={ () => setIsDropdownExpanded(true) }
-        onBlur={ () => { setIsDropdownExpanded(false); setFilter(''); } }
+        onFocus={ () => !readonly && setIsDropdownExpanded(true) }
+        onBlur={ () => { !readonly && onBlur(); } }
         aria-describedby={ errorMessageId } />
     </div>
     <div class="fjs-taglist-anchor">

--- a/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
@@ -20,6 +20,7 @@ export default function Textarea(props) {
     disabled,
     errors = [],
     field,
+    readonly,
     value = ''
   } = props;
 
@@ -72,13 +73,14 @@ export default function Textarea(props) {
   const { formId } = useContext(FormContext);
   const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
 
-  return <div class={ formFieldClasses(type, { errors, disabled }) }>
+  return <div class={ formFieldClasses(type, { errors, disabled, readonly }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }
       required={ required } />
     <textarea class="fjs-textarea"
       disabled={ disabled }
+      readonly={ readonly }
       id={ prefixId(id, formId) }
       onInput={ onInput }
       value={ value }

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -21,6 +21,7 @@ export default function Textfield(props) {
     disabled,
     errors = [],
     field,
+    readonly,
     value = ''
   } = props;
 
@@ -49,15 +50,16 @@ export default function Textfield(props) {
   const { formId } = useContext(FormContext);
   const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
 
-  return <div class={ formFieldClasses(type, { errors, disabled }) }>
+  return <div class={ formFieldClasses(type, { errors, disabled, readonly }) }>
     <Label
       id={ prefixId(id, formId) }
       label={ label }
       required={ required } />
-    <InputAdorner disabled={ disabled } pre={ prefixAdorner } post={ suffixAdorner }>
+    <InputAdorner disabled={ disabled } readonly={ readonly } pre={ prefixAdorner } post={ suffixAdorner }>
       <input
         class="fjs-input"
         disabled={ disabled }
+        readOnly={ readonly }
         id={ prefixId(id, formId) }
         onInput={ onChange }
         type="text"

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
@@ -18,6 +18,7 @@ export default function Datepicker(props) {
     disabled,
     disallowPassedDates,
     date,
+    readonly,
     setDate
   } = props;
 
@@ -138,10 +139,10 @@ export default function Datepicker(props) {
   const onInputFocus = useCallback(
     (e) => {
 
-      if (!flatpickrInstance || focusScopeRef.current.contains(e.relatedTarget)) return;
+      if (!flatpickrInstance || focusScopeRef.current.contains(e.relatedTarget) || readonly) return;
 
       flatpickrInstance.open();
-    }, [ flatpickrInstance ]
+    }, [ flatpickrInstance, readonly ]
   );
 
   // simulate an enter press on blur to make sure the date value is submitted in all scenarios
@@ -166,6 +167,7 @@ export default function Datepicker(props) {
     <InputAdorner
       pre={ <CalendarIcon /> }
       disabled={ disabled }
+      readonly={ readonly }
       rootRef={ focusScopeRef }
       inputRef={ dateInputRef }>
       <div class="fjs-datepicker" style={ { width: '100%' } }>
@@ -174,11 +176,12 @@ export default function Datepicker(props) {
           id={ fullId }
           class="fjs-input"
           disabled={ disabled }
+          readOnly={ readonly }
           placeholder="mm/dd/yyyy"
           autoComplete="off"
           onFocus={ onInputFocus }
           onKeyDown={ onInputKeyDown }
-          onMouseDown={ () => !flatpickrInstance.isOpen && flatpickrInstance.open() }
+          onMouseDown={ () => !flatpickrInstance.isOpen && !readonly && flatpickrInstance.open() }
           onBlur={ onInputBlur }
           onInput={ () => setIsInputDirty(true) }
           data-input

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/InputAdorner.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/InputAdorner.js
@@ -10,12 +10,13 @@ export default function InputAdorner(props) {
     inputRef,
     children,
     disabled,
+    readonly,
     hasErrors
   } = props;
 
   const onAdornmentClick = () => inputRef && inputRef.current && inputRef.current.focus();
 
-  return <div class={ classNames('fjs-input-group', { 'fjs-disabled': disabled }, { 'hasErrors': hasErrors }) } ref={ rootRef }>
+  return <div class={ classNames('fjs-input-group', { 'fjs-disabled': disabled, 'fjs-readonly': readonly }, { 'hasErrors': hasErrors }) } ref={ rootRef }>
     { pre !== null && <span class="fjs-input-adornment border-right border-radius-left" onClick={ onAdornmentClick }> { isString(pre) ? <span class="fjs-input-adornment-text">{ pre }</span> : pre } </span> }
     { children }
     { post !== null && <span class="fjs-input-adornment border-left border-radius-right" onClick={ onAdornmentClick }> { isString(post) ? <span class="fjs-input-adornment-text">{ post }</span> : post } </span> }

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/SearchableSelect.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/SearchableSelect.js
@@ -21,6 +21,7 @@ export default function SearchableSelect(props) {
     disabled,
     errors,
     field,
+    readonly,
     value
   } = props;
 
@@ -94,11 +95,11 @@ export default function SearchableSelect(props) {
 
   const displayState = useMemo(() => {
     const ds = {};
-    ds.componentReady = !disabled && loadState === LOAD_STATES.LOADED;
+    ds.componentReady = !disabled && !readonly && loadState === LOAD_STATES.LOADED;
     ds.displayCross = ds.componentReady && value !== null && value !== undefined;
-    ds.displayDropdown = !disabled && isDropdownExpanded && !isEscapeClosed;
+    ds.displayDropdown = !disabled && !readonly && isDropdownExpanded && !isEscapeClosed;
     return ds;
-  }, [ disabled, isDropdownExpanded, isEscapeClosed, loadState, value ]);
+  }, [ disabled, isDropdownExpanded, isEscapeClosed, loadState, readonly, value ]);
 
   const onAngelMouseDown = useCallback((e) => {
     setIsEscapeClose(false);
@@ -113,9 +114,10 @@ export default function SearchableSelect(props) {
 
   return <>
     <div id={ prefixId(`${id}`, formId) }
-      class={ classNames('fjs-input-group', { 'disabled': disabled }, { 'hasErrors': errors.length }) }>
+      class={ classNames('fjs-input-group', { 'disabled': disabled, 'readonly': readonly }, { 'hasErrors': errors.length }) }>
       <input
         disabled={ disabled }
+        readOnly={ readonly }
         class="fjs-input"
         ref={ searchbarRef }
         id={ prefixId(`${id}-search`, formId) }

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/SimpleSelect.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/SimpleSelect.js
@@ -22,6 +22,7 @@ export default function SimpleSelect(props) {
     disabled,
     errors,
     field,
+    readonly,
     value
   } = props;
 
@@ -45,9 +46,9 @@ export default function SimpleSelect(props) {
 
   const displayState = useMemo(() => {
     const ds = {};
-    ds.componentReady = !disabled && loadState === LOAD_STATES.LOADED;
+    ds.componentReady = !disabled && !readonly && loadState === LOAD_STATES.LOADED;
     ds.displayCross = ds.componentReady && value !== null && value !== undefined;
-    ds.displayDropdown = !disabled && isDropdownExpanded;
+    ds.displayDropdown = !disabled && !readonly && isDropdownExpanded;
     return ds;
   }, [ disabled, isDropdownExpanded, loadState, value ]);
 
@@ -70,7 +71,7 @@ export default function SimpleSelect(props) {
   return <>
     <div ref={ selectRef }
       id={ prefixId(`${id}`, formId) }
-      class={ classNames('fjs-input-group', { 'disabled': disabled }, { 'hasErrors': errors.length }) }
+      class={ classNames('fjs-input-group', { disabled, readonly }, { 'hasErrors': errors.length }) }
       onFocus={ () => setIsDropdownExpanded(true) }
       onBlur={ () => setIsDropdownExpanded(false) }
       onMouseDown={ onMouseDown }>
@@ -79,8 +80,8 @@ export default function SimpleSelect(props) {
         id={ prefixId(`${id}-search`, formId) }
         class="fjs-select-hidden-input"
         value={ valueLabel }
-        onFocus={ () => setIsDropdownExpanded(true) }
-        onBlur={ () => setIsDropdownExpanded(false) }
+        onFocus={ () => !readonly && setIsDropdownExpanded(true) }
+        onBlur={ () => !readonly && setIsDropdownExpanded(false) }
         aria-describedby={ props['aria-describedby'] } />
       }
       { displayState.displayCross && <span class="fjs-select-cross" onMouseDown={ (e) => { setValue(null); e.stopPropagation(); } }><XMarkIcon /></span> }

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Timepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Timepicker.js
@@ -17,6 +17,7 @@ export default function Timepicker(props) {
     formId,
     required,
     disabled,
+    readonly,
     use24h = false,
     timeInterval,
     time,
@@ -141,7 +142,8 @@ export default function Timepicker(props) {
     <InputAdorner
       pre={ <ClockIcon /> }
       inputRef={ timeInputRef }
-      disabled={ disabled }>
+      disabled={ disabled }
+      readonly={ readonly }>
       <div class="fjs-timepicker fjs-timepicker-anchor">
         <input ref={ timeInputRef }
           type="text"
@@ -149,10 +151,11 @@ export default function Timepicker(props) {
           class="fjs-input"
           value={ rawValue }
           disabled={ disabled }
+          readOnly={ readonly }
           placeholder={ use24h ? 'hh:mm' : 'hh:mm ?m' }
           autoComplete="off"
-          onFocus={ () => useDropdown && setDropdownIsOpen(true) }
-          onClick={ () => useDropdown && setDropdownIsOpen(true) }
+          onFocus={ () => !readonly && useDropdown && setDropdownIsOpen(true) }
+          onClick={ () => !readonly && useDropdown && setDropdownIsOpen(true) }
 
           // @ts-ignore
           onInput={ (e) => { setRawValue(e.target.value); useDropdown && setDropdownIsOpen(false); } }

--- a/packages/form-js-viewer/src/types.d.ts
+++ b/packages/form-js-viewer/src/types.d.ts
@@ -11,7 +11,7 @@ export interface Errors {
   [x: string]: string[];
 }
 
-export type FormProperty = ('readOnly' | string);
+export type FormProperty = ('readOnly' | 'disabled' | string);
 export type FormEvent = ('submit' | 'changed' | string);
 
 export interface FormProperties {

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -614,6 +614,42 @@ describe('Form', function() {
       data,
       schema,
       properties: {
+        disabled: true
+      }
+    });
+
+    // when
+    let error;
+
+    try {
+      form.submit();
+    } catch (_error) {
+      error = _error;
+    }
+
+    // then
+    expect(error).to.exist;
+    expect(error.message).to.eql('form is read-only');
+  });
+
+
+  it('should throw error on submit if readonly', async function() {
+
+    // given
+    const data = {
+      creditor: 'John Doe Company',
+      amount: 456,
+      invoiceNumber: 'C-123',
+      approved: true,
+      approvedBy: 'John Doe'
+    };
+
+    // when
+    const form = await createForm({
+      container,
+      data,
+      schema,
+      properties: {
         readOnly: true
       }
     });

--- a/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
@@ -130,7 +130,7 @@ describe('FormField', function() {
       createFormField({
         FormFieldComponent: componentSpy,
         properties: {
-          readOnly: true
+          disabled: true
         }
       });
 
@@ -139,6 +139,58 @@ describe('FormField', function() {
 
       expect(props).to.include({
         disabled: true
+      });
+    });
+
+
+    it('should not handle change', function() {
+
+      // given
+      const componentSpy = sinon.spy(Textfield);
+
+      const onChangeSpy = sinon.spy();
+
+      // when
+      const { container } = createFormField({
+        FormFieldComponent: componentSpy,
+        onChange: onChangeSpy,
+        properties: {
+          disabled: true
+        }
+      });
+
+      // when
+      const input = container.querySelector('input[type="text"]');
+
+      fireEvent.input(input, { target: { value: 'Jane Doe Company' } });
+
+      // then
+      expect(onChangeSpy).not.to.have.been.called;
+    });
+
+  });
+
+
+  describe('readonly form', function() {
+
+    it('should pass readonly', function() {
+
+      // given
+      const componentSpy = sinon.spy(Textfield);
+
+      // when
+      createFormField({
+        FormFieldComponent: componentSpy,
+        properties: {
+          readOnly: true
+        }
+      });
+
+      // then
+      const props = componentSpy.firstCall.firstArg;
+
+      expect(props).to.include({
+        readonly: true
       });
     });
 
@@ -208,6 +260,60 @@ describe('FormField', function() {
         field: {
           ...defaultField,
           disabled: true
+        },
+        FormFieldComponent: componentSpy,
+        onChange: onChangeSpy
+      });
+
+      // when
+      const input = container.querySelector('input[type="text"]');
+
+      fireEvent.input(input, { target: { value: 'Jane Doe Company' } });
+
+      // then
+      expect(onChangeSpy).not.to.have.been.called;
+    });
+
+  });
+
+
+  describe('readonly form field', function() {
+
+    it('should pass readonly', function() {
+
+      // given
+      const componentSpy = sinon.spy(Textfield);
+
+      // when
+      createFormField({
+        field: {
+          ...defaultField,
+          readonly: true
+        },
+        FormFieldComponent: componentSpy,
+      });
+
+      // then
+      const props = componentSpy.firstCall.firstArg;
+
+      expect(props).to.include({
+        readonly: true
+      });
+    });
+
+
+    it('should not handle change', function() {
+
+      // given
+      const componentSpy = sinon.spy(Textfield);
+
+      const onChangeSpy = sinon.spy();
+
+      // when
+      const { container } = createFormField({
+        field: {
+          ...defaultField,
+          readonly: true
         },
         FormFieldComponent: componentSpy,
         onChange: onChangeSpy

--- a/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
@@ -220,6 +220,33 @@ describe('FormField', function() {
       expect(onChangeSpy).not.to.have.been.called;
     });
 
+
+    it('should have precedence', function() {
+
+      // given
+      const componentSpy = sinon.spy(Textfield);
+
+      // when
+      createFormField({
+        field: {
+          ...defaultField,
+          disabled: true
+        },
+        FormFieldComponent: componentSpy,
+        properties: {
+          readOnly: true
+        }
+      });
+
+      // then
+      const props = componentSpy.firstCall.firstArg;
+
+      expect(props).to.include({
+        readonly: true,
+        disabled: false
+      });
+    });
+
   });
 
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -100,6 +100,21 @@ describe('Checkbox', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createCheckbox({
+      readonly: true
+    });
+
+    // then
+    const input = container.querySelector('input[type="checkbox"]');
+
+    expect(input).to.exist;
+    expect(input.readOnly).to.be.true;
+  });
+
+
   it('should render without label', function() {
 
     // when
@@ -200,6 +215,22 @@ describe('Checkbox', function() {
       await expectNoViolations(container);
     });
 
+
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createCheckbox({
+        value: true,
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -230,6 +261,7 @@ const defaultField = {
 function createCheckbox(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -239,6 +271,7 @@ function createCheckbox(options = {}) {
   return render(
     <Checkbox
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
@@ -149,6 +149,22 @@ describe('Checklist', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createChecklist({
+      readonly: true
+    });
+
+    // then
+    const inputs = container.querySelectorAll('input[type="checkbox"]');
+
+    inputs.forEach(input => {
+      expect(input.readOnly).to.be.true;
+    });
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -320,6 +336,22 @@ describe('Checklist', function() {
       await expectNoViolations(container);
     });
 
+
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createChecklist({
+        value: [ 'approver' ],
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -390,6 +422,7 @@ const dynamicFieldInitialData = {
 function createChecklist(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -399,6 +432,7 @@ function createChecklist(options = {}) {
   return render(WithFormContext(
     <Checklist
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
@@ -95,6 +95,20 @@ describe('Datetime', function() {
     });
 
 
+    it('should render readonly', function() {
+
+      // when
+      const { container } = createDatetime({ readonly: true, value: '1996-11-13' });
+
+      // then
+      const dateInput = container.querySelector('input[type="text"]');
+      expect(dateInput).to.exist;
+      expect(dateInput.value).to.be.equal('11/13/1996');
+      expect(dateInput.readOnly).to.be.true;
+
+    });
+
+
     it('should render custom label', function() {
 
       // when
@@ -420,6 +434,7 @@ describe('Datetime', function() {
 
     });
 
+
     it('should render disabled', function() {
 
       // when
@@ -430,6 +445,20 @@ describe('Datetime', function() {
       expect(timeInput).to.exist;
       expect(timeInput.value).to.equal('13:00');
       expect(timeInput.disabled).to.be.true;
+
+    });
+
+
+    it('should render readonly', function() {
+
+      // when
+      const { container } = createDatetime({ field: { ...timeField, use24h: true }, readonly: true, value: '13:00' });
+
+      // then
+      const timeInput = container.querySelector('input[type="text"]');
+      expect(timeInput).to.exist;
+      expect(timeInput.value).to.equal('13:00');
+      expect(timeInput.readOnly).to.be.true;
 
     });
 
@@ -973,6 +1002,19 @@ describe('Datetime', function() {
       await expectNoViolations(container);
     });
 
+
+    it('should have no violations for readonly - date', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createDatetime({ readonly: true });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors - date', async function() {
 
       // given
@@ -999,6 +1041,22 @@ describe('Datetime', function() {
       // then
       await expectNoViolations(container);
     });
+
+
+    it('should have no violations for readonly - time', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createDatetime({
+        field: timeField,
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
 
     it('should have no violations for errors - time', async function() {
 
@@ -1027,6 +1085,22 @@ describe('Datetime', function() {
       // then
       await expectNoViolations(container);
     });
+
+
+    it('should have no violations for readonly - datetime', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createDatetime({
+        field: datetimeField,
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
 
     it('should have no violations for errors - datetime', async function() {
 
@@ -1080,6 +1154,7 @@ const datetimeField = {
 function createDatetime(options = {}) {
   const {
     disabled,
+    readonly,
     field = dateField,
     value,
     onChange = () => {},
@@ -1089,6 +1164,7 @@ function createDatetime(options = {}) {
   return render(
     <Datetime
       disabled={ disabled }
+      readonly={ readonly }
       field={ field }
       value={ value }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -164,6 +164,21 @@ describe('Number', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createNumberField({
+      readonly: true
+    });
+
+    // then
+    const input = container.querySelector('input[type="text"]');
+
+    expect(input).to.exist;
+    expect(input.readOnly).to.be.true;
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -859,6 +874,22 @@ describe('Number', function() {
       await expectNoViolations(container);
     });
 
+
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createNumberField({
+        value: 123,
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -951,6 +982,7 @@ const stepField = {
 function createNumberField(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -960,6 +992,7 @@ function createNumberField(options = {}) {
   return render(
     <Number
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
@@ -153,6 +153,22 @@ describe('Radio', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createRadio({
+      readonly: true
+    });
+
+    // then
+    const inputs = container.querySelectorAll('input[type="radio"]');
+
+    inputs.forEach(input => {
+      expect(input.readOnly).to.be.true;
+    });
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -324,6 +340,22 @@ describe('Radio', function() {
       await expectNoViolations(container);
     });
 
+
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createRadio({
+        value: 'camunda-platform',
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -386,6 +418,7 @@ const dynamicFieldInitialData = {
 function createRadio(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -395,6 +428,7 @@ function createRadio(options = {}) {
   return render(WithFormContext(
     <Radio
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -148,6 +148,26 @@ describe('Select', function() {
     });
 
 
+    it('should render readonly', function() {
+
+      // when
+      const { container } = createSelect({ value: 'german', readonly: true });
+
+      // then
+      const select = container.querySelector('.fjs-input-group');
+      expect(select.classList.contains('readonly')).to.be.true;
+
+      const display = select.querySelector('.fjs-select-display');
+      expect(display.innerText).to.equal('German');
+
+      const cross = select.querySelector('.fjs-select-cross');
+      expect(cross).to.not.exist;
+
+      const arrow = select.querySelector('.fjs-select-arrow');
+      expect(arrow).to.exist;
+    });
+
+
     it('should render value changes', function() {
 
       // given
@@ -438,6 +458,32 @@ describe('Select', function() {
     });
 
 
+    it('should render readonly', function() {
+
+      // when
+      const { container } = createSelect({
+        field: { ...defaultField, searchable: true },
+        value: 'german',
+        readonly: true
+      });
+
+      // then
+      const select = container.querySelector('.fjs-input-group');
+      expect(select.classList.contains('readonly')).to.be.true;
+
+      const filter = container.querySelector('input[type="text"]');
+      expect(filter).to.exist;
+      expect(filter.readOnly).to.be.true;
+      expect(filter.value).to.equal('German');
+
+      const cross = select.querySelector('.fjs-select-cross');
+      expect(cross).to.not.exist;
+
+      const arrow = select.querySelector('.fjs-select-arrow');
+      expect(arrow).to.exist;
+    });
+
+
     it('should render value changes', function() {
 
       // given
@@ -714,6 +760,21 @@ describe('Select', function() {
     });
 
 
+    it('should have no violations - readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createSelect({
+        value: 'foo',
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations - searchable', async function() {
 
       // given
@@ -797,6 +858,7 @@ const dynamicFieldInitialData = {
 function createSelect(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     searchable = false,
@@ -807,6 +869,7 @@ function createSelect(options = {}) {
   return render(WithFormContext(
     <Select
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -197,6 +197,32 @@ describe('Taglist', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createTaglist({
+      readonly: true,
+      value: [ 'tag1' ]
+    });
+
+    // then
+    const filterInput = container.querySelector('input[type="text"]');
+    expect(filterInput.readOnly).to.be.true;
+
+    const taglist = container.querySelector('.fjs-taglist');
+    expect(taglist.classList.contains('fjs-readonly')).to.be.true;
+
+    const tag = taglist.querySelector('.fjs-taglist-tag');
+    expect(tag).to.exist;
+    expect(tag.innerText).to.equal('Tag1');
+    expect(tag.classList.contains('fjs-readonly')).to.be.true;
+
+    const cross = tag.querySelector('fjs-taglist-tag-remove');
+    expect(cross).to.not.exist;
+
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -684,6 +710,21 @@ describe('Taglist', function() {
     });
 
 
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createTaglist({
+        value: [ 'tag1', 'tag2', 'tag3' ],
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -838,6 +879,7 @@ const dynamicFieldInitialData = {
 function createTaglist(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -847,6 +889,7 @@ function createTaglist(options = {}) {
   return render(WithFormContext(
     <Taglist
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textarea.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textarea.spec.js
@@ -129,6 +129,21 @@ describe('Textarea', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createTextarea({
+      readonly: true
+    });
+
+    // then
+    const textarea = container.querySelector('textarea');
+
+    expect(textarea).to.exist;
+    expect(textarea.readOnly).to.be.true;
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -266,6 +281,21 @@ describe('Textarea', function() {
     });
 
 
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createTextarea({
+        value: 'This is a textarea value /nFollowed by a newline',
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -297,6 +327,7 @@ const defaultField = {
 function createTextarea(options = {}) {
   const {
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -306,6 +337,7 @@ function createTextarea(options = {}) {
   return render(WithFormContext(
     <Textarea
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -152,6 +152,21 @@ describe('Textfield', function() {
   });
 
 
+  it('should render readonly', function() {
+
+    // when
+    const { container } = createTextfield({
+      readonly: true
+    });
+
+    // then
+    const input = container.querySelector('input[type="text"]');
+
+    expect(input).to.exist;
+    expect(input.readOnly).to.be.true;
+  });
+
+
   it('should render description', function() {
 
     // when
@@ -378,6 +393,21 @@ describe('Textfield', function() {
     });
 
 
+    it('should have no violations for readonly', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createTextfield({
+        value: 'John Doe Company',
+        readonly: true
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+
     it('should have no violations for errors', async function() {
 
       // given
@@ -431,6 +461,7 @@ function createTextfield(options = {}) {
   const {
     appearance = {},
     disabled,
+    readonly,
     errors,
     field = defaultField,
     onChange,
@@ -441,6 +472,7 @@ function createTextfield(options = {}) {
     <Textfield
       appearance={ appearance }
       disabled={ disabled }
+      readonly={ readonly }
       errors={ errors }
       field={ field }
       onChange={ onChange }

--- a/packages/form-js/CHANGELOG.md
+++ b/packages/form-js/CHANGELOG.md
@@ -51,6 +51,17 @@ import { Button } from '@bpmn-io/form-js-viewer';
 console.log('Button default label is ' + Button.config.label);
 ```
 
+We changed the behavior when providing the `readOnly` property to a Form. From this version, the form fields will be rendered as `readOnly` if the property is set. Previously, the form fields were rendered as `disabled`. To restore the same behavior, please use the `disabled` property instead.
+
+```js
+const form = new Form({
+  container: document.querySelector('#form'),
+  properties: {
+    disabled: true
+  }
+});
+```
+
 ## 0.14.1
 
 ### Viewer

--- a/packages/form-js/test/spec/Form.spec.js
+++ b/packages/form-js/test/spec/Form.spec.js
@@ -128,7 +128,7 @@ describe('viewer exports', function() {
   it('should expose schemaVersion', function() {
     expect(typeof schemaVersion).to.eql('number');
 
-    expect(schemaVersion).to.eql(8);
+    expect(schemaVersion).to.eql(9);
   });
 
 


### PR DESCRIPTION
Related to #396 

This
* adds `readonly` property for all input fields
* configures `readonly` in the properties panel via toggle switch
* adds `properties.disabled` and adjusts the behavior of `properties.readonly` (cf. the breaking change below).
  => **Rationale**: I believe it makes sense to make this change now to clean up the behaviors. We still need `properties.disabled` to have the correct behavior in the editor where we don't want the inputs to be interactive (only the upper form elements).
* adds carbon styles for `readonly`

Demo (without Carbon): https://demo-396-readonly-property--camunda-form-playground.netlify.app/
To show the carbon styles:  `npm run start:carbon`

![Bildschirm­foto 2023-05-03 um 11 26 18](https://user-images.githubusercontent.com/9433996/235879695-095276be-b210-4f33-8331-ecf26452a521.png)

-------

BREAKING CHANGES (tbd)

We changed the behavior when providing the `readOnly` property to a Form. From this version, the form fields will be rendered as `readOnly` if the property is set. Previously, the form fields were rendered as `disabled`. To restore the same behavior, please use the `disabled` property instead.

```js
const form = new Form({
  container: document.querySelector('#form'),
  properties: {
    disabled: true
  }
});
```