### PR TITLE
ci: retry code cov upload

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,3 +44,5 @@ jobs:
       if: runner.os == 'Linux'
       with:
         fail_ci_if_error: true
+        max_attempts: 3
+        retry_on: error


### PR DESCRIPTION
Set a retry counter to the code coverage upload. If happens in the past that the upload failed because of some random errors. Let's see whether this improves it.