### PR TITLE
Readonly via expressions

### DIFF
--- a/.github/workflows/TASKLIST_CARBONISATION.yml
+++ b/.github/workflows/TASKLIST_CARBONISATION.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run visual regression
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.32.3-focal
+      image: mcr.microsoft.com/playwright:v1.34.1
       options: --user 1001:1000
     steps:
       - name: Checkout form-js

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/core": "^7.18.10",
         "@babel/plugin-transform-react-jsx": "^7.14.5",
         "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-        "@bpmn-io/properties-panel": "^2.0.0",
+        "@bpmn-io/properties-panel": "^2.1.0",
         "@carbon/react": "^1.24.0",
         "@carbon/styles": "^1.23.1",
         "@playwright/test": "1.34.1",
@@ -545,15 +545,18 @@
     },
     "node_modules/@bpmn-io/feel-editor/node_modules/component-event": {
       "version": "0.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "node_modules/@bpmn-io/feel-editor/node_modules/min-dash": {
-      "version": "4.0.0",
-      "license": "MIT"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.1.1.tgz",
+      "integrity": "sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg=="
     },
     "node_modules/@bpmn-io/feel-editor/node_modules/min-dom": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
+      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -593,9 +596,9 @@
       "link": true
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-2.0.0.tgz",
-      "integrity": "sha512-6xkKqXMHP1v71+iMrZDlbjbw/vFlbVUfo09aMsI5yNz/kP5liim7Km9hvseg/l/CUBTBH9S2svA0AUv6Nvt8jg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-2.1.0.tgz",
+      "integrity": "sha512-W0oQG8eSK6CArtASWHhe0T9z8T4oqaSkWwWAa9ItsqvGls2jpzZxC6Ub6S/Xuncpu9QPEFfIwDyqoF25SsRneQ==",
       "dependencies": {
         "@bpmn-io/feel-editor": "^0.7.1",
         "classnames": "^2.3.1",
@@ -11291,7 +11294,8 @@
     },
     "node_modules/lang-feel": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-0.1.0.tgz",
+      "integrity": "sha512-09oq5ey6+7HeZlE4Z1+N/z4VrlO96ypyUfIgKn8tHf5bbLirP3wu6e88uvTv81oEPVGjTNW0ZjU6MRG5xa8b2A==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -17766,7 +17770,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bpmn-io/form-js-viewer": "^0.15.0-alpha.0",
-        "@bpmn-io/properties-panel": "^2.0.0",
+        "@bpmn-io/properties-panel": "^2.1.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
         "dragula": "^3.7.3",
@@ -18195,13 +18199,19 @@
       },
       "dependencies": {
         "component-event": {
-          "version": "0.2.1"
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
+          "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
         },
         "min-dash": {
-          "version": "4.0.0"
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-4.1.1.tgz",
+          "integrity": "sha512-r+Z6vxXLSGr+otyCPx9NKPCSixw7LdfZREPTmqfd2a/d5D6w4NCdOxRJs+HyFO6v2pQkyHroGSiINWECK+OWPg=="
         },
         "min-dom": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
+          "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
           "requires": {
             "component-event": "^0.2.1",
             "domify": "^1.4.1",
@@ -18239,7 +18249,7 @@
       "version": "file:packages/form-js-editor",
       "requires": {
         "@bpmn-io/form-js-viewer": "^0.15.0-alpha.0",
-        "@bpmn-io/properties-panel": "^2.0.0",
+        "@bpmn-io/properties-panel": "^2.1.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
         "dragula": "^3.7.3",
@@ -18337,9 +18347,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-2.0.0.tgz",
-      "integrity": "sha512-6xkKqXMHP1v71+iMrZDlbjbw/vFlbVUfo09aMsI5yNz/kP5liim7Km9hvseg/l/CUBTBH9S2svA0AUv6Nvt8jg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-2.1.0.tgz",
+      "integrity": "sha512-W0oQG8eSK6CArtASWHhe0T9z8T4oqaSkWwWAa9ItsqvGls2jpzZxC6Ub6S/Xuncpu9QPEFfIwDyqoF25SsRneQ==",
       "requires": {
         "@bpmn-io/feel-editor": "^0.7.1",
         "classnames": "^2.3.1",
@@ -25473,6 +25483,8 @@
     },
     "lang-feel": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-0.1.0.tgz",
+      "integrity": "sha512-09oq5ey6+7HeZlE4Z1+N/z4VrlO96ypyUfIgKn8tHf5bbLirP3wu6e88uvTv81oEPVGjTNW0ZjU6MRG5xa8b2A==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/core": "^7.18.10",
     "@babel/plugin-transform-react-jsx": "^7.14.5",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-    "@bpmn-io/properties-panel": "^2.0.0",
+    "@bpmn-io/properties-panel": "^2.1.0",
     "@carbon/react": "^1.24.0",
     "@carbon/styles": "^1.23.1",
     "@playwright/test": "1.34.1",

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -189,8 +189,11 @@
   --list-entry-add-entry-background-color: var(--cds-interactive, var(--color-blue-205-100-50));
   --list-entry-add-entry-fill-color: var(--cds-icon-inverse, var(--color-white));
 
-  --feel-active-color: var(--cds-interactive, var(--color-blue-205-100-35));
+  --feel-background-color: var(--cds-field-02, var(--color-grey-225-10-97));
+  --feel-active-color: var(--cds-interactive, var(--color-blue-205-100-45));
   --feel-inactive-color: var(--cds-text-secondary, var(--color-grey-225-10-35));
+  --feel-hover-background-color: var(--cds-field-hover-02, var(--color-grey-225-10-90));
+  --feel-active-background-color: var(--cds-field-02, var(--color-grey-225-10-97));
 
   --feel-indicator-background-color: var(--cds-background-hover, var(--color-grey-225-10-90));
 }

--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@bpmn-io/form-js-viewer": "^0.15.0-alpha.0",
-    "@bpmn-io/properties-panel": "^2.0.0",
+    "@bpmn-io/properties-panel": "^2.1.0",
     "array-move": "^3.0.1",
     "big.js": "^6.2.1",
     "dragula": "^3.7.3",

--- a/packages/form-js-editor/src/features/properties-panel/entries/DisabledEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DisabledEntry.js
@@ -52,6 +52,7 @@ function Disabled(props) {
     getValue,
     id,
     label: 'Disabled',
+    inline: true,
     setValue
   });
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
@@ -2,7 +2,9 @@ import { get } from 'min-dash';
 
 import { INPUTS } from '../Util';
 
-import { ToggleSwitchEntry, isToggleSwitchEntryEdited } from '@bpmn-io/properties-panel';
+import { useService, useVariables } from '../hooks';
+
+import { FeelToggleSwitchEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 
 export default function ReadonlyEntry(props) {
@@ -23,7 +25,7 @@ export default function ReadonlyEntry(props) {
       component: Readonly,
       editField: editField,
       field: field,
-      isEdited: isToggleSwitchEntryEdited
+      isEdited: isFeelEntryEdited
     });
   }
 
@@ -37,6 +39,10 @@ function Readonly(props) {
     id
   } = props;
 
+  const debounce = useService('debounce');
+
+  const variables = useVariables().map(name => ({ name }));
+
   const path = [ 'readonly' ];
 
   const getValue = () => {
@@ -44,14 +50,17 @@ function Readonly(props) {
   };
 
   const setValue = (value) => {
-    return editField(field, path, value);
+    return editField(field, path, value || false);
   };
 
-  return ToggleSwitchEntry({
+  return FeelToggleSwitchEntry({
+    debounce,
     element: field,
+    feel: 'optional',
     getValue,
     id,
     label: 'Read only',
-    setValue
+    setValue,
+    variables
   });
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/GeneralGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/GeneralGroup.spec.js
@@ -880,7 +880,7 @@ describe('GeneralGroup', function() {
     });
 
 
-    it('should write', function() {
+    it('should write boolean', function() {
 
       // given
       const field = {
@@ -900,6 +900,30 @@ describe('GeneralGroup', function() {
       // then
       expect(editFieldSpy).to.have.been.calledOnce;
       expect(field.readonly).to.equal(false);
+    });
+
+
+    it('should write expression', async function() {
+
+      // given
+      const field = {
+        type: 'number',
+        readonly: '=foo'
+      };
+
+      const editFieldSpy = sinon.spy((field, path, value) => set(field, path, value));
+
+      const { container } = renderGeneralGroup({ field, editField: editFieldSpy });
+
+      const readonlyInput = findTextbox('readonly', container);
+      expect(readonlyInput.textContent).to.equal('foo');
+
+      // when
+      await setEditorValue(readonlyInput, 'bar');
+
+      // then
+      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(editFieldSpy).to.have.been.calledWith(field, [ 'readonly' ], '=bar');
     });
 
   });

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -83,20 +83,22 @@ describe('playground', function() {
     };
 
     // when
-    playground = new Playground({
-      container,
-      schema,
-      data
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema,
+        data
+      });
+    });
+
+    const formEditor = playground.getEditor();
+
+    formEditor.on('changed', event => {
+      console.log('Form Editor <changed>', event, formEditor.getSchema());
     });
 
     // then
     expect(playground).to.exist;
-
-    expect(playground.getState()).to.eql({
-      schema,
-      data
-    });
-
   });
 
 

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -4,8 +4,11 @@ import { get } from 'min-dash';
 
 import { FormRenderContext } from '../context';
 
-import useService from '../hooks/useService';
-import { useCondition } from '../hooks';
+import {
+  useCondition,
+  useReadonly,
+  useService
+} from '../hooks';
 
 import { findErrors } from '../../util';
 
@@ -45,7 +48,7 @@ export default function FormField(props) {
 
   const fieldErrors = findErrors(errors, field._path);
 
-  const readonly = properties.readOnly || field.readonly || false;
+  const readonly = useReadonly(field, properties);
 
   // add precedence: global readonly > form field disabled
   const disabled = !properties.readOnly && (

--- a/packages/form-js-viewer/src/render/hooks/index.js
+++ b/packages/form-js-viewer/src/render/hooks/index.js
@@ -2,5 +2,6 @@ export { default as useCondition } from './useCondition';
 export { default as useExpressionEvaluation } from './useExpressionEvaluation';
 export { default as useFilteredFormData } from './useFilteredFormData';
 export { default as useKeyDownAction } from './useKeyDownAction';
+export { default as useReadonly } from './useReadonly';
 export { default as useService } from './useService';
 export { default as useTemplateEvaluation } from './useTemplateEvaluation';

--- a/packages/form-js-viewer/src/render/hooks/useReadonly.js
+++ b/packages/form-js-viewer/src/render/hooks/useReadonly.js
@@ -1,0 +1,31 @@
+import useService from './useService.js';
+import useFilteredFormData from './useFilteredFormData.js';
+
+/**
+ * Retrieve readonly value of a form field, given it can be an
+ * expression optionally or configured globally.
+ *
+ * @typedef { import('../../types').FormProperties } FormProperties
+ *
+ * @param {any} formField
+ * @param {FormProperties} properties
+ *
+ * @returns {boolean}
+ */
+export default function useReadonly(formField, properties = {}) {
+  const expressionLanguage = useService('expressionLanguage');
+  const conditionChecker = useService('conditionChecker', false);
+  const filteredData = useFilteredFormData();
+
+  const { readonly } = formField;
+
+  if (properties.readOnly) {
+    return true;
+  }
+
+  if (expressionLanguage && expressionLanguage.isExpression(readonly)) {
+    return conditionChecker ? conditionChecker.check(readonly, filteredData) : false;
+  }
+
+  return readonly || false;
+}

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -8,6 +8,7 @@ export * from './form';
 const EXPRESSION_PROPERTIES = [
   'alt',
   'source',
+  'readonly',
   'text'
 ];
 

--- a/packages/form-js-viewer/test/spec/readonly-expression.json
+++ b/packages/form-js-viewer/test/spec/readonly-expression.json
@@ -1,0 +1,20 @@
+{
+  "components": [
+    {
+      "key": "amount",
+      "label": "Amount",
+      "type": "number",
+      "readonly": "=foo + bar = 2"
+    },
+    {
+      "label": "Text Field",
+      "type": "textfield",
+      "id": "Field",
+      "key": "text",
+      "readonly": true
+    }
+  ],
+  "type": "default",
+  "id": "Form",
+  "schemaVersion": 9
+}

--- a/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
@@ -329,6 +329,33 @@ describe('FormField', function() {
     });
 
 
+    it('should pass readonly expression', function() {
+
+      // given
+      const componentSpy = sinon.spy(Textfield);
+
+      const expression = '=true';
+
+      // when
+      createFormField({
+        field: {
+          ...defaultField,
+          readonly: expression
+        },
+        checkCondition: (value) => value === expression,
+        isExpression: () => true,
+        FormFieldComponent: componentSpy
+      });
+
+      // then
+      const props = componentSpy.firstCall.firstArg;
+
+      expect(props).to.include({
+        readonly: true
+      });
+    });
+
+
     it('should not handle change', function() {
 
       // given
@@ -451,7 +478,8 @@ function createFormField(options = {}) {
     initialData = {},
     onChange = () => {},
     properties = {},
-    checkCondition = () => false
+    checkCondition = () => false,
+    isExpression = () => false
   } = options;
 
   const formContext = {
@@ -482,6 +510,12 @@ function createFormField(options = {}) {
           },
           check(...args) {
             return checkCondition(...args);
+          }
+        } : undefined;
+      } else if (type === 'expressionLanguage') {
+        return isExpression !== false ? {
+          isExpression(...args) {
+            return isExpression(...args);
           }
         } : undefined;
       }

--- a/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
+++ b/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
@@ -8,6 +8,7 @@ import conditionalSchema from '../condition-external-variable.json';
 import expressionSchema from '../expression-external-variable.json';
 import templateSchema from '../template-variable.json';
 import complexTemplateSchema from '../template-variable-complex.json';
+import readonlyExpressionSchema from '../readonly-expression.json';
 
 describe('util/getSchemaVariables', () => {
 
@@ -66,6 +67,14 @@ describe('util/getSchemaVariables', () => {
     const variables = getSchemaVariables(expressionSchema);
 
     expect(variables).to.not.have.members([ 'This', 'is', 'just', 'an', 'image' ]);
+  });
+
+
+  it('should include variables in readonly expressions', () => {
+
+    const variables = getSchemaVariables(readonlyExpressionSchema);
+
+    expect(variables).to.eql([ 'amount', 'foo', 'bar', 'text' ]);
   });
 
 });


### PR DESCRIPTION
Closes #396 
Related to #653 

-----

Adds expression support for `readonly`.

Demo: https://demo-653-readonly-expressions--camunda-form-playground.netlify.app/

![image](https://github.com/bpmn-io/form-js/assets/9433996/2cc94603-1f04-4470-a44d-0a0f1408701e)


