### PR TITLE
FEEL for Labels and Descriptions

### DIFF
--- a/packages/form-js-editor/src/features/expression-language/EditorTemplating.js
+++ b/packages/form-js-editor/src/features/expression-language/EditorTemplating.js
@@ -1,0 +1,12 @@
+import { isString } from 'min-dash';
+
+export default class EditorTemplating {
+
+  // same rules as viewer templating
+  isTemplate(value) { return isString(value) && (value.startsWith('=') || /{{/.test(value)); }
+
+  // return the template raw, as we usually just want to display that
+  evaluate(template) { return template; }
+}
+
+EditorTemplating.$inject = [];

--- a/packages/form-js-editor/src/features/expression-language/index.js
+++ b/packages/form-js-editor/src/features/expression-language/index.js
@@ -1,7 +1,8 @@
-import { FeelExpressionLanguage, FeelersTemplating } from '@bpmn-io/form-js-viewer';
+import { FeelExpressionLanguage } from '@bpmn-io/form-js-viewer';
+import EditorTemplating from './EditorTemplating';
 
 export default {
   __init__: [ 'expressionLanguage', 'templating' ],
   expressionLanguage: [ 'type', FeelExpressionLanguage ],
-  templating: [ 'type', FeelersTemplating ]
+  templating: [ 'type', EditorTemplating ]
 };

--- a/packages/form-js-editor/src/features/properties-panel/entries/DescriptionEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DescriptionEntry.js
@@ -1,10 +1,10 @@
 import { get } from 'min-dash';
 
-import { useService } from '../hooks';
-
 import { INPUTS } from '../Util';
 
-import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
+import { useService, useVariables } from '../hooks';
+
+import { FeelTemplatingEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 
 export default function DescriptionEntry(props) {
@@ -25,7 +25,7 @@ export default function DescriptionEntry(props) {
       component: Description,
       editField: editField,
       field: field,
-      isEdited: isTextFieldEntryEdited
+      isEdited: isFeelEntryEdited
     });
   }
 
@@ -42,6 +42,8 @@ function Description(props) {
 
   const debounce = useService('debounce');
 
+  const variables = useVariables().map(name => ({ name }));
+
   const path = [ 'description' ];
 
   const getValue = () => {
@@ -52,12 +54,14 @@ function Description(props) {
     return editField(field, path, value);
   };
 
-  return TextFieldEntry({
+  return FeelTemplatingEntry({
     debounce,
     element: field,
     getValue,
     id,
     label: 'Field description',
-    setValue
+    singleLine: true,
+    setValue,
+    variables
   });
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/LabelEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/LabelEntry.js
@@ -1,10 +1,13 @@
 import { INPUTS } from '../Util';
 import { DATETIME_SUBTYPES, DATE_LABEL_PATH, TIME_LABEL_PATH } from '@bpmn-io/form-js-viewer';
-import { simpleStringEntryFactory } from './factories';
+import { useService, useVariables } from '../hooks';
+import { FeelTemplatingEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { get } from 'min-dash';
 
 export default function LabelEntry(props) {
   const {
-    field
+    field,
+    editField
   } = props;
 
   const {
@@ -17,35 +20,137 @@ export default function LabelEntry(props) {
   if (type === 'datetime') {
     if (subtype === DATETIME_SUBTYPES.DATE || subtype === DATETIME_SUBTYPES.DATETIME) {
       entries.push(
-        simpleStringEntryFactory({
+        {
           id: 'date-label',
-          path: DATE_LABEL_PATH,
-          label: 'Date label',
-          props
-        })
+          component: DateLabel,
+          editField,
+          field,
+          isEdited: isFeelEntryEdited
+        }
       );
     }
     if (subtype === DATETIME_SUBTYPES.TIME || subtype === DATETIME_SUBTYPES.DATETIME) {
       entries.push(
-        simpleStringEntryFactory({
+        {
           id: 'time-label',
-          path: TIME_LABEL_PATH,
-          label: 'Time label',
-          props
-        })
+          component: TimeLabel,
+          editField,
+          field,
+          isEdited: isFeelEntryEdited
+        }
       );
     }
   }
   else if (INPUTS.includes(type) || type === 'button') {
     entries.push(
-      simpleStringEntryFactory({
+      {
         id: 'label',
-        path: [ 'label' ],
-        label: 'Field label',
-        props
-      })
+        component: Label,
+        editField,
+        field,
+        isEdited: isFeelEntryEdited
+      }
     );
   }
 
   return entries;
+}
+
+function Label(props) {
+  const {
+    editField,
+    field,
+    id
+  } = props;
+
+  const debounce = useService('debounce');
+
+  const variables = useVariables().map(name => ({ name }));
+
+  const path = [ 'label' ];
+
+  const getValue = () => {
+    return get(field, path, '');
+  };
+
+  const setValue = (value) => {
+    return editField(field, path, value);
+  };
+
+  return FeelTemplatingEntry({
+    debounce,
+    element: field,
+    getValue,
+    id,
+    label: 'Field label',
+    singleLine: true,
+    setValue,
+    variables
+  });
+}
+
+function DateLabel(props) {
+  const {
+    editField,
+    field,
+    id
+  } = props;
+
+  const debounce = useService('debounce');
+
+  const variables = useVariables().map(name => ({ name }));
+
+  const path = DATE_LABEL_PATH;
+
+  const getValue = () => {
+    return get(field, path, '');
+  };
+
+  const setValue = (value) => {
+    return editField(field, path, value);
+  };
+
+  return FeelTemplatingEntry({
+    debounce,
+    element: field,
+    getValue,
+    id,
+    label: 'Date label',
+    singleLine: true,
+    setValue,
+    variables
+  });
+}
+
+function TimeLabel(props) {
+  const {
+    editField,
+    field,
+    id
+  } = props;
+
+  const debounce = useService('debounce');
+
+  const variables = useVariables().map(name => ({ name }));
+
+  const path = TIME_LABEL_PATH;
+
+  const getValue = () => {
+    return get(field, path, '');
+  };
+
+  const setValue = (value) => {
+    return editField(field, path, value);
+  };
+
+  return FeelTemplatingEntry({
+    debounce,
+    element: field,
+    getValue,
+    id,
+    label: 'Time label',
+    singleLine: true,
+    setValue,
+    variables
+  });
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/GeneralGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/GeneralGroup.spec.js
@@ -108,7 +108,7 @@ describe('GeneralGroup', function() {
       const { container } = renderGeneralGroup({ field });
 
       // then
-      const labelInput = findInput('label', container);
+      const labelInput = findFeelers('label', container);
 
       expect(labelInput).to.not.exist;
     });
@@ -123,10 +123,28 @@ describe('GeneralGroup', function() {
       const { container } = renderGeneralGroup({ field });
 
       // then
-      const labelInput = findInput('label', container);
+      const labelInput = findFeelers('label', container);
 
       expect(labelInput).to.exist;
     });
+
+
+    it('should render feel editor', function() {
+
+      // given
+      const field = {
+        type: 'button',
+        label: '=foobar'
+      };
+
+      // when
+      const { container } = renderGeneralGroup({ field });
+
+      // then
+      const labelInput = findTextbox('label', container);
+      expect(labelInput.textContent).to.equal('foobar');
+    });
+
 
     describe('for datetime', function() {
 
@@ -136,9 +154,9 @@ describe('GeneralGroup', function() {
         const { container } = renderGeneralGroup({ field: { type: 'datetime', subtype: 'date' } });
 
         // then
-        const dateLabelInput = findInput('date-label', container);
+        const dateLabelInput = findFeelers('date-label', container);
         expect(dateLabelInput).to.exist;
-        const timeLabelInput = findInput('time-label', container);
+        const timeLabelInput = findFeelers('time-label', container);
         expect(timeLabelInput).to.not.exist;
       });
 
@@ -149,9 +167,9 @@ describe('GeneralGroup', function() {
         const { container } = renderGeneralGroup({ field: { type: 'datetime', subtype: 'time' } });
 
         // then
-        const dateLabelInput = findInput('date-label', container);
+        const dateLabelInput = findFeelers('date-label', container);
         expect(dateLabelInput).to.not.exist;
-        const timeLabelInput = findInput('time-label', container);
+        const timeLabelInput = findFeelers('time-label', container);
         expect(timeLabelInput).to.exist;
       });
 
@@ -162,9 +180,9 @@ describe('GeneralGroup', function() {
         const { container } = renderGeneralGroup({ field: { type: 'datetime', subtype: 'datetime' } });
 
         // then
-        const dateLabelInput = findInput('date-label', container);
+        const dateLabelInput = findFeelers('date-label', container);
         expect(dateLabelInput).to.exist;
-        const timeLabelInput = findInput('time-label', container);
+        const timeLabelInput = findFeelers('time-label', container);
         expect(timeLabelInput).to.exist;
       });
     });
@@ -183,11 +201,10 @@ describe('GeneralGroup', function() {
         const { container } = renderGeneralGroup({ field });
 
         // then
-        const labelInput = findInput('label', container);
+        const labelInput = findFeelers('label', container);
         expect(labelInput).to.exist;
       }
     });
-
 
 
     it('should read', function() {
@@ -201,15 +218,15 @@ describe('GeneralGroup', function() {
       // when
       const { container } = renderGeneralGroup({ field });
 
-      const labelInput = findInput('label', container);
+      const labelInput = findFeelers('label', container);
 
       // then
       expect(labelInput).to.exist;
-      expect(labelInput.value).to.equal('foobar');
+      expect(labelInput.textContent).to.equal('foobar');
     });
 
 
-    it('should write', function() {
+    it('should write', async function() {
 
       // given
       const field = {
@@ -221,14 +238,41 @@ describe('GeneralGroup', function() {
 
       const { container } = renderGeneralGroup({ field, editField: editFieldSpy });
 
-      const labelInput = findInput('label', container);
+      const feelers = findFeelers('label', container);
+      const input = feelers.querySelector('div[contenteditable="true"]');
 
       // when
-      fireEvent.input(labelInput, { target: { value: 'newVal' } });
+      await setEditorValue(input, 'newVal');
 
       // then
       expect(editFieldSpy).to.have.been.calledOnce;
       expect(field.label).to.equal('newVal');
+    });
+
+
+    it('should write expression', async function() {
+
+      // given
+      const field = {
+        type: 'button',
+        label: '=foobar'
+      };
+
+      const editFieldSpy = sinon.spy((field, path, value) => set(field, path, value));
+
+      const { container } = renderGeneralGroup({ field, editField: editFieldSpy });
+
+      const labelInput = findTextbox('label', container);
+
+      // assume
+      expect(labelInput.textContent).to.equal('foobar');
+
+      // when
+      await setEditorValue(labelInput, 'newVal');
+
+      // then
+      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(field.label).to.equal('=newVal');
     });
 
   });
@@ -245,7 +289,7 @@ describe('GeneralGroup', function() {
       const { container } = renderGeneralGroup({ field });
 
       // then
-      const descriptionInput = findInput('description', container);
+      const descriptionInput = findFeelers('description', container);
 
       expect(descriptionInput).to.not.exist;
     });
@@ -262,7 +306,7 @@ describe('GeneralGroup', function() {
         const { container } = renderGeneralGroup({ field });
 
         // then
-        const descriptionInput = findInput('description', container);
+        const descriptionInput = findFeelers('description', container);
 
         expect(descriptionInput).to.exist;
       }
@@ -281,15 +325,15 @@ describe('GeneralGroup', function() {
       const { container } = renderGeneralGroup({ field });
 
       // then
-      const descriptionInput = findInput('description', container);
+      const descriptionInput = findFeelers('description', container);
 
       // then
       expect(descriptionInput).to.exist;
-      expect(descriptionInput.value).to.equal('foobar');
+      expect(descriptionInput.textContent).to.equal('foobar');
     });
 
 
-    it('should write', function() {
+    it('should write', async function() {
 
       // given
       const field = {
@@ -302,14 +346,41 @@ describe('GeneralGroup', function() {
       // when
       const { container } = renderGeneralGroup({ field, editField: editFieldSpy });
 
-      const descriptionInput = findInput('description', container);
+      const feelers = findFeelers('description', container);
+      const input = feelers.querySelector('div[contenteditable="true"]');
 
       // when
-      fireEvent.input(descriptionInput, { target: { value: 'newVal' } });
+      await setEditorValue(input, 'newVal');
 
       // then
       expect(editFieldSpy).to.have.been.calledOnce;
       expect(field.description).to.equal('newVal');
+    });
+
+
+    it('should write expression', async function() {
+
+      // given
+      const field = {
+        type: 'number',
+        description: '=foobar'
+      };
+
+      const editFieldSpy = sinon.spy((field, path, value) => set(field, path, value));
+
+      const { container } = renderGeneralGroup({ field, editField: editFieldSpy });
+
+      const descriptionInput = findTextbox('description', container);
+
+      // assume
+      expect(descriptionInput.textContent).to.equal('foobar');
+
+      // when
+      await setEditorValue(descriptionInput, 'newVal');
+
+      // then
+      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(field.description).to.equal('=newVal');
     });
 
   });

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -250,6 +250,9 @@
 .fjs-container .fjs-form-field-label {
   display: flex;
   align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  color: var(--color-text-light);
 }
 
 .fjs-container .fjs-incollapsible-label {
@@ -262,10 +265,6 @@
   font-size: var(--font-size-label);
   line-height: var(--line-height-label);
   letter-spacing: var(--letter-spacing-label);
-}
-
-.fjs-container .fjs-form-field-label {
-  color: var(--color-text-light);
 }
 
 .fjs-container .fjs-form-field-description {

--- a/packages/form-js-viewer/src/render/components/Description.js
+++ b/packages/form-js-viewer/src/render/components/Description.js
@@ -1,9 +1,14 @@
+import { useSingleLineTemplateEvaluation } from '../hooks';
+
+
 export default function Description(props) {
   const { description } = props;
 
-  if (!description) {
+  const evaluatedDescription = useSingleLineTemplateEvaluation(description || '', { debug: true });
+
+  if (!evaluatedDescription) {
     return null;
   }
 
-  return <div class="fjs-form-field-description">{ description }</div>;
+  return <div class="fjs-form-field-description">{ evaluatedDescription }</div>;
 }

--- a/packages/form-js-viewer/src/render/components/Label.js
+++ b/packages/form-js-viewer/src/render/components/Label.js
@@ -1,5 +1,7 @@
 import classNames from 'classnames';
 
+import { useSingleLineTemplateEvaluation } from '../hooks';
+
 export default function Label(props) {
   const {
     id,
@@ -8,10 +10,12 @@ export default function Label(props) {
     required = false
   } = props;
 
+  const evaluatedLabel = useSingleLineTemplateEvaluation(label || '', { debug: true });
+
   return (
     <label for={ id } class={ classNames('fjs-form-field-label', { 'fjs-incollapsible-label': !collapseOnEmpty }, props['class']) }>
       { props.children }
-      { label || '' }
+      { evaluatedLabel }
       {
         required && <span class="fjs-asterix">*</span>
       }

--- a/packages/form-js-viewer/src/render/hooks/index.js
+++ b/packages/form-js-viewer/src/render/hooks/index.js
@@ -4,4 +4,5 @@ export { default as useFilteredFormData } from './useFilteredFormData';
 export { default as useKeyDownAction } from './useKeyDownAction';
 export { default as useReadonly } from './useReadonly';
 export { default as useService } from './useService';
+export { default as useSingleLineTemplateEvaluation } from './useSingleLineTemplateEvaluation';
 export { default as useTemplateEvaluation } from './useTemplateEvaluation';

--- a/packages/form-js-viewer/src/render/hooks/useSingleLineTemplateEvaluation.js
+++ b/packages/form-js-viewer/src/render/hooks/useSingleLineTemplateEvaluation.js
@@ -1,0 +1,19 @@
+import useTemplateEvaluation from './useTemplateEvaluation';
+import { useMemo } from 'preact/hooks';
+
+/**
+ * Template a string reactively based on form data. If the string is not a template, it is returned as is.
+ * If the string contains multiple lines, only the first line is returned.
+ * Memoised to minimize re-renders
+ *
+ * @param {string} value
+ * @param {Object} [options]
+ * @param {boolean} [options.debug = false]
+ * @param {boolean} [options.strict = false]
+ * @param {Function} [options.buildDebugString]
+ *
+ */
+export default function useSingleLineTemplateEvaluation(value, options = {}) {
+  const evaluatedTemplate = useTemplateEvaluation(value, options);
+  return useMemo(() => evaluatedTemplate && evaluatedTemplate.split('\n')[0], [ evaluatedTemplate ]);
+}

--- a/packages/form-js-viewer/src/render/hooks/useTemplateEvaluation.js
+++ b/packages/form-js-viewer/src/render/hooks/useTemplateEvaluation.js
@@ -19,7 +19,7 @@ export default function useTemplateEvaluation(value, options) {
 
   return useMemo(() => {
 
-    if (templating.isTemplate(value)) {
+    if (templating && templating.isTemplate(value)) {
       return templating.evaluate(value, filteredData, options);
     }
 

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -7,12 +7,16 @@ export * from './form';
 
 const EXPRESSION_PROPERTIES = [
   'alt',
+  'description',
+  'label',
   'source',
   'readonly',
   'text'
 ];
 
 const TEMPLATE_PROPERTIES = [
+  'description',
+  'label',
   'text'
 ];
 

--- a/packages/form-js-viewer/test/spec/descriptions.json
+++ b/packages/form-js-viewer/test/spec/descriptions.json
@@ -1,0 +1,15 @@
+{
+  "components": [
+    {
+      "type": "textfield",
+      "description": "{{ foo }} and {{ bar }}",
+      "key": "template"
+    },
+    {
+      "type": "textfield",
+      "description": "=description_var",
+      "key": "expression"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-viewer/test/spec/labels.json
+++ b/packages/form-js-viewer/test/spec/labels.json
@@ -1,0 +1,15 @@
+{
+  "components": [
+    {
+      "type": "textfield",
+      "label": "{{ foo }} and {{ bar }}",
+      "key": "template"
+    },
+    {
+      "type": "textfield",
+      "label": "=label_var",
+      "key": "expression"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-viewer/test/spec/render/components/Description.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Description.spec.js
@@ -1,0 +1,136 @@
+import {
+  render
+} from '@testing-library/preact/pure';
+
+import Description from '../../../../src/render/components/Description';
+
+import {
+  createFormContainer,
+  expectNoViolations
+} from '../../../TestHelper';
+
+import { WithFormContext } from './form-fields/helper';
+
+let container;
+
+
+describe('Description', function() {
+
+  beforeEach(function() {
+    container = createFormContainer();
+  });
+
+  afterEach(function() {
+    container.remove();
+  });
+
+
+  it('should render', function() {
+
+    // when
+    const { container } = createDescription({
+      id: 'foo',
+      description: 'Foo'
+    });
+
+    // then
+    const description = container.querySelector('.fjs-form-field-description');
+
+    expect(description).to.exist;
+    expect(description.textContent).to.eql('Foo');
+  });
+
+
+  it('should not render empty', function() {
+
+    // when
+    const { container } = createDescription({
+      id: 'foo'
+    });
+
+    // then
+    const description = container.querySelector('.fjs-form-field-description');
+
+    expect(description).to.not.exist;
+  });
+
+
+  it('should render feel expression', function() {
+
+    // when
+    const { container } = createDescription({
+      initialData: {
+        myDescription: 'feel variable description'
+      },
+      id: 'foo',
+      description: '=myDescription'
+    });
+
+    // then
+    const description = container.querySelector('.fjs-form-field-description');
+
+    expect(description).to.exist;
+    expect(description.textContent).to.eql('feel variable description');
+  });
+
+
+  it('should render template', function() {
+
+    // when
+    const { container } = createDescription({
+      initialData: {
+        myDescription: 'template variable description'
+      },
+      id: 'foo',
+      description: 'A {{myDescription}}'
+    });
+
+    // then
+    const description = container.querySelector('.fjs-form-field-description');
+
+    expect(description).to.exist;
+    expect(description.textContent).to.eql('A template variable description');
+  });
+
+
+  describe('a11y', function() {
+
+    it('should have no violations', async function() {
+
+      // given
+      this.timeout(5000);
+
+      const { container } = createDescription({
+        id: 'foo',
+        description: 'Foo'
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+  });
+
+});
+
+// helpers //////////
+
+function createDescription(options = {}) {
+  const {
+    description,
+    id,
+    initialData
+  } = options;
+
+  return render(WithFormContext(
+    <Description
+      id={ id }
+      description={ description } />,
+    {
+      ...options,
+      initialData
+    }
+  ), {
+    container: options.container || container.querySelector('.fjs-form')
+  });
+}

--- a/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/FormField.spec.js
@@ -385,8 +385,25 @@ describe('FormField', function() {
   });
 
 
-  describe('condition', function() {
+  describe('label support', function() {
 
+    it('should display field when templating is unavailable', function() {
+
+      // when
+      const { container } = createFormField({
+        isTemplate: false
+      });
+
+      // then
+      const formField = container.querySelector('.fjs-form-field');
+
+      expect(formField).to.exist;
+    });
+
+  });
+
+
+  describe('condition', function() {
 
     it('should display field when condition checker is unavailable', function() {
 
@@ -479,7 +496,8 @@ function createFormField(options = {}) {
     onChange = () => {},
     properties = {},
     checkCondition = () => false,
-    isExpression = () => false
+    isExpression = () => false,
+    isTemplate = () => false
   } = options;
 
   const formContext = {
@@ -516,6 +534,12 @@ function createFormField(options = {}) {
         return isExpression !== false ? {
           isExpression(...args) {
             return isExpression(...args);
+          }
+        } : undefined;
+      } else if (type === 'templating') {
+        return isTemplate !== false ? {
+          isTemplate(...args) {
+            return isTemplate(...args);
           }
         } : undefined;
       }

--- a/packages/form-js-viewer/test/spec/render/components/Label.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Label.spec.js
@@ -9,6 +9,8 @@ import {
   expectNoViolations
 } from '../../../TestHelper';
 
+import { WithFormContext } from './form-fields/helper';
+
 let container;
 
 
@@ -87,6 +89,44 @@ describe('Label', function() {
   });
 
 
+  it('should render feel expression', function() {
+
+    // when
+    const { container } = createLabel({
+      initialData: {
+        myLabel: 'feel variable label'
+      },
+      id: 'myLabel',
+      label: '=myLabel'
+    });
+
+    // then
+    const label = container.querySelector('.fjs-form-field-label');
+
+    expect(label).to.exist;
+    expect(label.textContent).to.eql('feel variable label');
+  });
+
+
+  it('should render template', function() {
+
+    // when
+    const { container } = createLabel({
+      initialData: {
+        myLabel: 'template variable label'
+      },
+      id: 'myLabel',
+      label: 'A {{myLabel}}'
+    });
+
+    // then
+    const label = container.querySelector('.fjs-form-field-label');
+
+    expect(label).to.exist;
+    expect(label.textContent).to.eql('A template variable label');
+  });
+
+
   describe('a11y', function() {
 
     it('should have no violations', async function() {
@@ -112,17 +152,21 @@ describe('Label', function() {
 function createLabel(options = {}, children = null) {
   const {
     id,
+    initialData,
     label,
     required
   } = options;
 
-  return render(
+  return render(WithFormContext(
     <Label
       id={ id }
       label={ label }
       required={ required }>{ children }</Label>,
     {
-      container: options.container || container.querySelector('.fjs-form')
+      ...options,
+      initialData
     }
-  );
+  ), {
+    container: options.container || container.querySelector('.fjs-form')
+  });
 }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -10,6 +10,8 @@ import {
   expectNoViolations
 } from '../../../../TestHelper';
 
+import { WithFormContext } from './helper';
+
 const spy = sinon.spy;
 
 let container;
@@ -268,7 +270,7 @@ function createCheckbox(options = {}) {
     value
   } = options;
 
-  return render(
+  return render(WithFormContext(
     <Checkbox
       disabled={ disabled }
       readonly={ readonly }
@@ -276,8 +278,7 @@ function createCheckbox(options = {}) {
       field={ field }
       onChange={ onChange }
       value={ value } />,
-    {
-      container: options.container || container.querySelector('.fjs-form')
-    }
-  );
+  ), {
+    container: options.container || container.querySelector('.fjs-form')
+  });
 }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
@@ -7,6 +7,8 @@ import {
   expectNoViolations
 } from '../../../../TestHelper';
 
+import { WithFormContext } from './helper';
+
 let container;
 
 const spy = sinon.spy;
@@ -1161,7 +1163,7 @@ function createDatetime(options = {}) {
     errors
   } = options;
 
-  return render(
+  return render(WithFormContext(
     <Datetime
       disabled={ disabled }
       readonly={ readonly }
@@ -1169,8 +1171,7 @@ function createDatetime(options = {}) {
       value={ value }
       onChange={ onChange }
       errors={ errors } />,
-    {
-      container: options.container || container.querySelector('.fjs-form')
-    }
-  );
+  ), {
+    container: options.container || container.querySelector('.fjs-form')
+  });
 }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -6,6 +6,8 @@ import {
 
 import Number from '../../../../../src/render/components/form-fields/Number';
 
+import { WithFormContext } from './helper';
+
 import {
   createFormContainer,
   expectNoViolations
@@ -134,16 +136,17 @@ describe('Number', function() {
       onChange: () => {}
     };
 
-    const options = { container: container.querySelector('.fjs-form') };
+    createNumberField({
+      ...props,
+      value: '2'
+    });
 
-    const { rerender } = render(<Number { ...props } value={ 123 } />, options);
-
-    // when
-    rerender(<Number { ...props } value={ null } />, options);
-
-    // then
     const input = container.querySelector('input[type="text"]');
 
+    // when
+    fireEvent.change(input, { target: { value: null } });
+
+    // then
     expect(input).to.exist;
     expect(input.value).to.equal('');
   });
@@ -989,7 +992,7 @@ function createNumberField(options = {}) {
     value
   } = options;
 
-  return render(
+  return render(WithFormContext(
     <Number
       disabled={ disabled }
       readonly={ readonly }
@@ -997,8 +1000,7 @@ function createNumberField(options = {}) {
       field={ field }
       onChange={ onChange }
       value={ value } />,
-    {
-      container: options.container || container.querySelector('.fjs-form')
-    }
-  );
+  ), {
+    container: options.container || container.querySelector('.fjs-form')
+  });
 }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/preact/pure';
-import { FeelersTemplating, MarkdownRenderer } from '@bpmn-io/form-js-viewer';
 
 import Text from '../../../../../src/render/components/form-fields/Text';
 
@@ -697,19 +696,12 @@ const defaultField = {
   type: 'text'
 };
 
-const defaultTemplateEvaluator = new FeelersTemplating();
-
-const defaultMarkdownRenderer = new MarkdownRenderer();
-
 function createText(options = {}) {
   const {
     errors,
     data = {},
     initialData = {},
     field = defaultField,
-    isTemplate = defaultTemplateEvaluator.isTemplate,
-    evaluateTemplate = defaultTemplateEvaluator.evaluate,
-    markdownRenderer = defaultMarkdownRenderer,
     properties = {},
     onChange
   } = options;
@@ -721,9 +713,6 @@ function createText(options = {}) {
       onChange={ onChange } />,
     {
       ...options,
-      isTemplate,
-      evaluateTemplate,
-      markdownRenderer,
       properties,
       initialData,
       data

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textarea.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textarea.spec.js
@@ -99,16 +99,16 @@ describe('Textarea', function() {
       onChange: () => {}
     };
 
-    const options = { container: container.querySelector('.fjs-form') };
+    createTextarea({
+      ...props,
+      value: 'foo'
+    });
 
-    const { rerender } = render(<Textarea { ...props } value={ 'Sample text' } />, options);
-
-    // when
-    rerender(<Textarea { ...props } value={ undefined } />, options);
-
-    // then
     const textarea = container.querySelector('textarea');
 
+    fireEvent.change(textarea, { target: { value: null } });
+
+    // then
     expect(textarea).to.exist;
     expect(textarea.value).to.equal('');
   });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -122,16 +122,17 @@ describe('Textfield', function() {
       onChange: () => {}
     };
 
-    const options = { container: container.querySelector('.fjs-form') };
+    createTextfield({
+      ...props,
+      value: 'foo'
+    });
 
-    const { rerender } = render(<Textfield { ...props } value={ 'John Doe Company' } />, options);
-
-    // when
-    rerender(<Textfield { ...props } value={ undefined } />, options);
-
-    // then
     const input = container.querySelector('input[type="text"]');
 
+    // when
+    fireEvent.change(input, { target: { value: null } });
+
+    // then
     expect(input).to.exist;
     expect(input.value).to.equal('');
   });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/helper/index.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/helper/index.js
@@ -1,17 +1,21 @@
 import { FormContext } from '../../../../../../src/render/context';
 
+import { MarkdownRenderer, FeelersTemplating } from '../../../../../../src';
+
 export function WithFormContext(Component, options = {}, formId = 'foo') {
 
   function getService(type, strict) {
+
+    const defaultTemplating = new FeelersTemplating();
 
     const {
       data,
       errors,
       isExpression,
       evaluateExpression,
-      isTemplate,
-      evaluateTemplate,
-      markdownRenderer,
+      isTemplate = defaultTemplating.isTemplate,
+      evaluateTemplate = defaultTemplating.evaluate,
+      markdownRenderer = new MarkdownRenderer(),
       properties,
       initialData
     } = options;

--- a/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
+++ b/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
@@ -9,6 +9,8 @@ import expressionSchema from '../expression-external-variable.json';
 import templateSchema from '../template-variable.json';
 import complexTemplateSchema from '../template-variable-complex.json';
 import readonlyExpressionSchema from '../readonly-expression.json';
+import labelsSchema from '../labels.json';
+import descriptionsSchema from '../descriptions.json';
 
 describe('util/getSchemaVariables', () => {
 
@@ -75,6 +77,22 @@ describe('util/getSchemaVariables', () => {
     const variables = getSchemaVariables(readonlyExpressionSchema);
 
     expect(variables).to.eql([ 'amount', 'foo', 'bar', 'text' ]);
+  });
+
+
+  it('should include variables in labels', () => {
+
+    const variables = getSchemaVariables(labelsSchema);
+
+    expect(variables).to.eql([ 'template', 'foo', 'bar', 'expression', 'label_var' ]);
+  });
+
+
+  it('should include variables in descriptions', () => {
+
+    const variables = getSchemaVariables(descriptionsSchema);
+
+    expect(variables).to.eql([ 'template', 'foo', 'bar', 'expression', 'description_var' ]);
   });
 
 });


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

Related to #653 

Adds FEEL support for `label` and `description`.

Demo: https://demo-653-labels-descriptions-o--camunda-form-playground.netlify.app/