### PR TITLE
FEEL for image properties and adorners

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/AdornerEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/AdornerEntry.js
@@ -1,7 +1,7 @@
-import { TextFieldEntry, isTextFieldEntryEdited } from '@bpmn-io/properties-panel';
+import { FeelTemplatingEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 import { get, set } from 'min-dash';
-import { useService } from '../hooks';
+import { useService, useVariables } from '../hooks';
 
 export default function AdornerEntry(props) {
   const {
@@ -33,7 +33,7 @@ export default function AdornerEntry(props) {
     entries.push({
       id: 'prefix-adorner',
       component: PrefixAdorner,
-      isEdited: isTextFieldEntryEdited,
+      isEdited: isFeelEntryEdited,
       editField,
       field,
       onChange,
@@ -43,7 +43,7 @@ export default function AdornerEntry(props) {
     entries.push({
       id: 'suffix-adorner',
       component: SuffixAdorner,
-      isEdited: isTextFieldEntryEdited,
+      isEdited: isFeelEntryEdited,
       editField,
       field,
       onChange,
@@ -64,13 +64,18 @@ function PrefixAdorner(props) {
 
   const debounce = useService('debounce');
 
-  return TextFieldEntry({
+  const variables = useVariables().map(name => ({ name }));
+
+  return FeelTemplatingEntry({
     debounce,
     element: field,
+    feel: 'optional',
     getValue: getValue('prefixAdorner'),
     id,
     label: 'Prefix',
-    setValue: onChange('prefixAdorner')
+    setValue: onChange('prefixAdorner'),
+    singleLine: true,
+    variables
   });
 }
 
@@ -84,12 +89,16 @@ function SuffixAdorner(props) {
 
   const debounce = useService('debounce');
 
-  return TextFieldEntry({
+  const variables = useVariables().map(name => ({ name }));
+
+  return FeelTemplatingEntry({
     debounce,
     element: field,
     getValue: getValue('suffixAdorner'),
     id,
     label: 'Suffix',
-    setValue: onChange('suffixAdorner')
+    setValue: onChange('suffixAdorner'),
+    singleLine: true,
+    variables
   });
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/AltTextEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/AltTextEntry.js
@@ -2,7 +2,7 @@ import { get } from 'min-dash';
 
 import { useService, useVariables } from '../hooks';
 
-import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { FeelTemplatingEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 export default function AltTextEntry(props) {
   const {
@@ -50,7 +50,7 @@ function AltText(props) {
     return editField(field, path, value);
   };
 
-  return FeelEntry({
+  return FeelTemplatingEntry({
     debounce,
     element: field,
     feel: 'optional',
@@ -58,6 +58,7 @@ function AltText(props) {
     id,
     label: 'Alternative text',
     setValue,
+    singleLine: true,
     variables
   });
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/ImageSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ImageSourceEntry.js
@@ -2,7 +2,7 @@ import { get } from 'min-dash';
 
 import { useService, useVariables } from '../hooks';
 
-import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { FeelTemplatingEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
 
 export default function SourceEntry(props) {
   const {
@@ -50,7 +50,7 @@ function Source(props) {
     return editField(field, path, value);
   };
 
-  return FeelEntry({
+  return FeelTemplatingEntry({
     debounce,
     description: 'Expression or static value (link/data URI)',
     element: field,
@@ -59,6 +59,7 @@ function Source(props) {
     id,
     label: 'Image source',
     setValue,
+    singleLine: true,
     variables
   });
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -2955,11 +2955,13 @@ describe('properties panel', function() {
           });
 
           // assume
-          const input = domQuery('input[name=alt]', container);
-          expect(input.value).to.equal('The bpmn.io logo');
+          const feelers = findFeelers('alt', container);
+          expect(feelers.textContent).to.equal('The bpmn.io logo');
+
+          const input = feelers.querySelector('div[contenteditable="true"]');
 
           // when
-          fireEvent.input(input, { target: { value: 'An image' } });
+          await setEditorValue(input, 'An image');
 
           // then
           expect(editFieldSpy).to.have.been.calledOnce;
@@ -2967,7 +2969,7 @@ describe('properties panel', function() {
         });
 
 
-        it('should remove alt text', function() {
+        it('should remove alt text', async function() {
 
           // given
           const editFieldSpy = spy();
@@ -2981,11 +2983,13 @@ describe('properties panel', function() {
           });
 
           // assume
-          const input = domQuery('input[name=alt]', container);
-          expect(input.value).to.equal('The bpmn.io logo');
+          const feelers = findFeelers('alt', container);
+          expect(feelers.textContent).to.equal('The bpmn.io logo');
+
+          const input = feelers.querySelector('div[contenteditable="true"]');
 
           // when
-          fireEvent.input(input, { target: { value: '' } });
+          await setEditorValue(input, '');
 
           // then
           expect(editFieldSpy).to.have.been.calledOnce;
@@ -3259,6 +3263,10 @@ function findEntries(container, groupLabel, entryLabel) {
 
     return Array.from(entries).filter(entry => entry.textContent === entryLabel);
   }
+}
+
+function findFeelers(id, container) {
+  return container.querySelector(`[data-entry-id="${id}"] .bio-properties-panel-feelers-editor`);
 }
 
 function getListOrdering(list) {

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/AppearanceGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/AppearanceGroup.spec.js
@@ -1,12 +1,13 @@
 import {
   cleanup,
-  fireEvent,
   render
 } from '@testing-library/preact/pure';
 
 import { AppearanceGroup } from '../../../../../src/features/properties-panel/groups';
 
 import { WithPropertiesPanelContext, WithPropertiesPanel } from '../helper';
+
+import { setEditorValue } from '../../../../helper';
 
 
 describe('AppearanceGroup', function() {
@@ -37,7 +38,7 @@ describe('AppearanceGroup', function() {
       const { container } = renderAppearanceGroup({ field });
 
       // then
-      const input = findInput('suffix-adorner', container);
+      const input = findFeelers('suffix-adorner', container);
 
       expect(input).to.exist;
     });
@@ -57,15 +58,15 @@ describe('AppearanceGroup', function() {
       const { container } = renderAppearanceGroup({ field });
 
       // then
-      const input = findInput('suffix-adorner', container);
+      const input = findFeelers('suffix-adorner', container);
 
       // then
       expect(input).to.exist;
-      expect(input.value).to.eql('foo');
+      expect(input.textContent).to.eql('foo');
     });
 
 
-    it('should write', function() {
+    it('should write', async function() {
 
       // given
       const field = {
@@ -79,14 +80,40 @@ describe('AppearanceGroup', function() {
 
       const { container } = renderAppearanceGroup({ field, editField: editFieldSpy });
 
-      const input = findInput('suffix-adorner', container);
+      const feelers = findFeelers('suffix-adorner', container);
+      const input = feelers.querySelector('div[contenteditable="true"]');
 
       // when
-      fireEvent.input(input, { target: { value: 'bar' } });
+      await setEditorValue(input, 'newVal');
 
       // then
       expect(editFieldSpy).to.have.been.calledOnce;
-      expect(field.appearance.suffixAdorner).to.eql('bar');
+      expect(field.appearance.suffixAdorner).to.eql('newVal');
+    });
+
+
+    it('should write expression', async function() {
+
+      // given
+      const field = {
+        type: 'textfield',
+        appearance: {
+          suffixAdorner: '=foo'
+        }
+      };
+
+      const editFieldSpy = sinon.spy();
+
+      const { container } = renderAppearanceGroup({ field, editField: editFieldSpy });
+
+      const input = findTextbox('suffix-adorner', container);
+
+      // when
+      await setEditorValue(input, 'newVal');
+
+      // then
+      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(field.appearance.suffixAdorner).to.eql('=newVal');
     });
 
   });
@@ -103,7 +130,7 @@ describe('AppearanceGroup', function() {
       const { container } = renderAppearanceGroup({ field });
 
       // then
-      const input = findInput('prefix-adorner', container);
+      const input = findFeelers('prefix-adorner', container);
 
       expect(input).to.exist;
     });
@@ -123,15 +150,15 @@ describe('AppearanceGroup', function() {
       const { container } = renderAppearanceGroup({ field });
 
       // then
-      const input = findInput('prefix-adorner', container);
+      const input = findFeelers('prefix-adorner', container);
 
       // then
       expect(input).to.exist;
-      expect(input.value).to.eql('foo');
+      expect(input.textContent).to.eql('foo');
     });
 
 
-    it('should write', function() {
+    it('should write', async function() {
 
       // given
       const field = {
@@ -145,14 +172,41 @@ describe('AppearanceGroup', function() {
 
       const { container } = renderAppearanceGroup({ field, editField: editFieldSpy });
 
-      const input = findInput('prefix-adorner', container);
+      const feelers = findFeelers('prefix-adorner', container);
+
+      const input = feelers.querySelector('div[contenteditable="true"]');
 
       // when
-      fireEvent.input(input, { target: { value: 'bar' } });
+      await setEditorValue(input, 'newVal');
 
       // then
       expect(editFieldSpy).to.have.been.calledOnce;
-      expect(field.appearance.prefixAdorner).to.eql('bar');
+      expect(field.appearance.prefixAdorner).to.eql('newVal');
+    });
+
+
+    it('should write expression', async function() {
+
+      // given
+      const field = {
+        type: 'textfield',
+        appearance: {
+          prefixAdorner: '=foo'
+        }
+      };
+
+      const editFieldSpy = sinon.spy();
+
+      const { container } = renderAppearanceGroup({ field, editField: editFieldSpy });
+
+      const input = findTextbox('prefix-adorner', container);
+
+      // when
+      await setEditorValue(input, 'newVal');
+
+      // then
+      expect(editFieldSpy).to.have.been.calledOnce;
+      expect(field.appearance.prefixAdorner).to.eql('=newVal');
     });
 
   });
@@ -176,6 +230,10 @@ function renderAppearanceGroup(options) {
   })));
 }
 
-function findInput(id, container) {
-  return container.querySelector(`input[name="${id}"]`);
+function findFeelers(id, container) {
+  return container.querySelector(`[data-entry-id="${id}"] .bio-properties-panel-feelers-editor`);
+}
+
+function findTextbox(id, container) {
+  return container.querySelector(`[name=${id}] [role="textbox"]`);
 }

--- a/packages/form-js-viewer/src/render/components/form-fields/Image.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Image.js
@@ -2,7 +2,7 @@ import { useContext, useMemo } from 'preact/hooks';
 
 import { FormContext } from '../../context';
 
-import { useExpressionEvaluation } from '../../hooks';
+import { useSingleLineTemplateEvaluation } from '../../hooks';
 import { sanitizeImageSource } from '../Sanitizer';
 
 import {
@@ -27,11 +27,11 @@ export default function Image(props) {
   } = field;
 
 
-  const evaluatedImageSource = useExpressionEvaluation(source);
+  const evaluatedImageSource = useSingleLineTemplateEvaluation(source, { debug: true });
 
   const safeSource = useMemo(() => sanitizeImageSource(evaluatedImageSource), [ evaluatedImageSource ]);
 
-  const altText = useExpressionEvaluation(alt);
+  const altText = useSingleLineTemplateEvaluation(alt, { debug: true });
 
   const { formId } = useContext(FormContext);
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -7,7 +7,7 @@ import { FormContext } from '../../context';
 import Description from '../Description';
 import Errors from '../Errors';
 import Label from '../Label';
-import InputAdorner from './parts/InputAdorner';
+import InputAdorner from './parts/TemplatedInputAdorner';
 
 import AngelDownIcon from './icons/AngelDown.svg';
 import AngelUpIcon from './icons/AngelUp.svg';

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -6,7 +6,7 @@ import { FormContext } from '../../context';
 import Description from '../Description';
 import Errors from '../Errors';
 import Label from '../Label';
-import InputAdorner from './parts/InputAdorner';
+import InputAdorner from './parts/TemplatedInputAdorner';
 
 import {
   formFieldClasses,

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/TemplatedInputAdorner.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/TemplatedInputAdorner.js
@@ -1,0 +1,17 @@
+import InputAdorner from './InputAdorner';
+
+import { useSingleLineTemplateEvaluation } from '../../../hooks';
+
+export default function TemplatedInputAdorner(props) {
+
+  const {
+    pre,
+    post
+  } = props;
+
+  const evaluatedPre = useSingleLineTemplateEvaluation(pre, { debug: true });
+  const evaluatedPost = useSingleLineTemplateEvaluation(post, { debug: true });
+
+  return <InputAdorner { ...props } pre={ evaluatedPre } post={ evaluatedPost } />;
+
+}

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -1,12 +1,17 @@
 import FeelExpressionLanguage from '../features/expression-language/FeelExpressionLanguage.js';
 import FeelersTemplating from '../features/expression-language/FeelersTemplating.js';
 
+import { get } from 'min-dash';
+
 export * from './constants';
 export * from './injector';
 export * from './form';
 
 const EXPRESSION_PROPERTIES = [
   'alt',
+  'appearance.prefixAdorner',
+  'appearance.suffixAdorner',
+  'conditional.hide',
   'description',
   'label',
   'source',
@@ -15,8 +20,12 @@ const EXPRESSION_PROPERTIES = [
 ];
 
 const TEMPLATE_PROPERTIES = [
+  'alt',
+  'appearance.prefixAdorner',
+  'appearance.suffixAdorner',
   'description',
   'label',
+  'source',
   'text'
 ];
 
@@ -99,8 +108,7 @@ export function getSchemaVariables(schema, expressionLanguage = new FeelExpressi
     const {
       key,
       valuesKey,
-      type,
-      conditional
+      type
     } = component;
 
     if ([ 'button' ].includes(type)) {
@@ -115,15 +123,8 @@ export function getSchemaVariables(schema, expressionLanguage = new FeelExpressi
       variables = [ ...variables, valuesKey ];
     }
 
-    if (conditional && conditional.hide) {
-
-      const conditionVariables = expressionLanguage.getVariableNames(conditional.hide, { type: 'unaryTest' });
-
-      variables = [ ...variables, ...conditionVariables ];
-    }
-
     EXPRESSION_PROPERTIES.forEach((prop) => {
-      const property = component[prop];
+      const property = get(component, prop.split('.'));
 
       if (property && expressionLanguage.isExpression(property)) {
 
@@ -134,7 +135,7 @@ export function getSchemaVariables(schema, expressionLanguage = new FeelExpressi
     });
 
     TEMPLATE_PROPERTIES.forEach((prop) => {
-      const property = component[prop];
+      const property = get(component, prop.split('.'));
 
       if (property && !expressionLanguage.isExpression(property) && templating.isTemplate(property)) {
 

--- a/packages/form-js-viewer/test/spec/appearance.json
+++ b/packages/form-js-viewer/test/spec/appearance.json
@@ -1,0 +1,21 @@
+{
+  "components": [
+    {
+      "type": "textfield",
+      "key": "adorner_expression",
+      "appearance": {
+        "prefixAdorner": "=prefix_expression",
+        "suffixAdorner": "=suffix_expression"
+      }
+    },
+    {
+      "type": "textfield",
+      "key": "adorner_template",
+      "appearance": {
+        "prefixAdorner": "{{ prefix_template }}",
+        "suffixAdorner": "{{ suffix_template }}"
+      }
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-viewer/test/spec/images.json
+++ b/packages/form-js-viewer/test/spec/images.json
@@ -1,0 +1,21 @@
+{
+  "components": [
+    {
+      "source": "=logo_expression",
+      "type": "image"
+    },
+    {
+      "alt": "=alt_expression",
+      "type": "image"
+    },
+    {
+      "source": "{{ logo_template }}",
+      "type": "image"
+    },
+    {
+      "alt": "{{ alt_template }}",
+      "type": "image"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Image.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Image.spec.js
@@ -66,15 +66,36 @@ describe('Image', function() {
 
     // when
     const { container } = createImage({
-      data: {
+      initialData: {
         foo: IMAGE_DATA_URI
       },
       field: {
         ...defaultField,
         source: '=foo'
+      }
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    const image = formField.querySelector('.fjs-image');
+
+    expect(image).to.exist;
+    expect(image.src).to.eql(IMAGE_DATA_URI);
+  });
+
+
+  it('should render image (template)', function() {
+
+    // when
+    const { container } = createImage({
+      initialData: {
+        foo: IMAGE_DATA_URI
       },
-      isExpression: () => true,
-      evaluateExpression: () => IMAGE_DATA_URI
+      field: {
+        ...defaultField,
+        source: '{{ foo }}'
+      }
     });
 
     // then
@@ -180,9 +201,32 @@ describe('Image', function() {
       field: {
         ...defaultField,
         alt: '=altText'
+      }
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    const image = formField.querySelector('.fjs-image');
+
+    expect(image).to.exist;
+    expect(image.alt).to.eql(altText);
+  });
+
+
+  it('should render image alt text (template)', function() {
+
+    // when
+    const altText = 'foo';
+
+    const { container } = createImage({
+      initialData: {
+        altText
       },
-      isExpression: (expression) => expression.startsWith('='),
-      evaluateExpression: () => altText
+      field: {
+        ...defaultField,
+        alt: '{{ altText }}'
+      }
     });
 
     // then

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -99,6 +99,60 @@ describe('Textfield', function() {
   });
 
 
+  it('should render adorners (expression)', function() {
+
+    // when
+    const { container } = createTextfield({
+      initialData: {
+        prefix: 'prefix_expression',
+        suffix: 'suffix_expression'
+      },
+      field: {
+        ...defaultField,
+        appearance: {
+          prefixAdorner: '=prefix',
+          suffixAdorner: '=suffix'
+        }
+      },
+      value: 123
+    });
+
+    // then
+    const adorners = container.querySelectorAll('.fjs-input-adornment');
+
+    expect(adorners.length).to.equal(2);
+    expect(adorners[0].innerText).to.equal('prefix_expression');
+    expect(adorners[1].innerText).to.equal('suffix_expression');
+  });
+
+
+  it('should render adorners (template)', function() {
+
+    // when
+    const { container } = createTextfield({
+      initialData: {
+        prefix: 'prefix_template',
+        suffix: 'suffix_template'
+      },
+      field: {
+        ...defaultField,
+        appearance: {
+          prefixAdorner: '{{ prefix }}',
+          suffixAdorner: '{{ suffix }}'
+        }
+      },
+      value: 123
+    });
+
+    // then
+    const adorners = container.querySelectorAll('.fjs-input-adornment');
+
+    expect(adorners.length).to.equal(2);
+    expect(adorners[0].innerText).to.equal('prefix_template');
+    expect(adorners[1].innerText).to.equal('suffix_template');
+  });
+
+
   it('should render default value (\'\')', function() {
 
     // when
@@ -477,7 +531,8 @@ function createTextfield(options = {}) {
       errors={ errors }
       field={ field }
       onChange={ onChange }
-      value={ value } />
+      value={ value } />,
+    options
   ), {
     container: options.container || container.querySelector('.fjs-form')
   });

--- a/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
+++ b/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
@@ -11,6 +11,8 @@ import complexTemplateSchema from '../template-variable-complex.json';
 import readonlyExpressionSchema from '../readonly-expression.json';
 import labelsSchema from '../labels.json';
 import descriptionsSchema from '../descriptions.json';
+import adornersSchema from '../appearance.json';
+import imagesSchema from '../images.json';
 
 describe('util/getSchemaVariables', () => {
 
@@ -93,6 +95,34 @@ describe('util/getSchemaVariables', () => {
     const variables = getSchemaVariables(descriptionsSchema);
 
     expect(variables).to.eql([ 'template', 'foo', 'bar', 'expression', 'description_var' ]);
+  });
+
+
+  it('should include variables in adorners', () => {
+
+    const variables = getSchemaVariables(adornersSchema);
+
+    expect(variables).to.eql([
+      'adorner_expression',
+      'prefix_expression',
+      'suffix_expression',
+      'adorner_template',
+      'prefix_template',
+      'suffix_template'
+    ]);
+  });
+
+
+  it('should include variables in images', () => {
+
+    const variables = getSchemaVariables(imagesSchema);
+
+    expect(variables).to.eql([
+      'logo_expression',
+      'alt_expression',
+      'logo_template',
+      'alt_template'
+    ]);
   });
 
 });


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

Related to #653 

Adds FEEL support for `alt`, `source` and adorners.

Demo: https://demo-653-adorners-images--camunda-form-playground.netlify.app/