### PR TITLE
Support FEEL for Multiselect Values

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/components/AutoFocusSelect.js
+++ b/packages/form-js-editor/src/features/properties-panel/components/AutoFocusSelect.js
@@ -1,0 +1,44 @@
+import {
+  useEffect
+} from 'preact/hooks';
+
+import {
+  SelectEntry,
+  usePrevious
+} from '@bpmn-io/properties-panel';
+
+import { useService } from '../hooks';
+
+
+export default function AutoFocusSelectEntry(props) {
+  const {
+    autoFocusEntry,
+    element,
+    getValue
+  } = props;
+
+  const value = getValue(element);
+  const prevValue = usePrevious(value);
+
+  const eventBus = useService('eventBus');
+
+  // auto focus specifc other entry when selected value changed
+  useEffect(() => {
+    if (autoFocusEntry && prevValue && value !== prevValue) {
+
+      // @Note(pinussilvestrus): There is an issue in the properties
+      // panel so we have to wait a bit before showing the entry.
+      // Cf. https://github.com/camunda/linting/blob/4f5328e2722f73ae60ae584c5f576eaec3999cb2/lib/modeler/Linting.js#L37
+      setTimeout(() => {
+        eventBus.fire('propertiesPanel.showEntry', {
+          id: autoFocusEntry
+        });
+      });
+
+    }
+  }, [ value, autoFocusEntry, prevValue, eventBus ]);
+
+  return (
+    <SelectEntry { ...props } />
+  );
+}

--- a/packages/form-js-editor/src/features/properties-panel/components/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/components/index.js
@@ -1,0 +1,1 @@
+export { default as AutoFocusSelectEntry } from './AutoFocusSelect';

--- a/packages/form-js-editor/src/features/properties-panel/entries/ValuesExpressionEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ValuesExpressionEntry.js
@@ -1,0 +1,62 @@
+import { FeelEntry, isFeelEntryEdited } from '@bpmn-io/properties-panel';
+import { get } from 'min-dash';
+import { useService, useVariables } from '../hooks';
+import { VALUES_SOURCES, VALUES_SOURCES_PATHS } from '@bpmn-io/form-js-viewer';
+
+
+export default function ValuesExpressionEntry(props) {
+  const {
+    editField,
+    field,
+    id
+  } = props;
+
+  return [
+    {
+      id: id + '-expression',
+      component: ValuesExpression,
+      label: 'Values expression',
+      isEdited: isFeelEntryEdited,
+      editField,
+      field
+    }
+  ];
+}
+
+function ValuesExpression(props) {
+  const {
+    editField,
+    field,
+    id
+  } = props;
+
+  const debounce = useService('debounce');
+
+  const variables = useVariables().map(name => ({ name }));
+
+  const path = VALUES_SOURCES_PATHS[VALUES_SOURCES.EXPRESSION];
+
+  const schema = '[\n  {\n    "label": "dollar",\n    "value": "$"\n  }\n]';
+
+  const description = <div>
+    Define an expression to populate the options from.
+    <br /><br />The expression may result in an array of simple values or alternatively follow this schema:
+    <pre><code>{schema}</code></pre>
+  </div>;
+
+  const getValue = () => get(field, path, '');
+
+  const setValue = (value) => editField(field, path, value || '');
+
+  return FeelEntry({
+    debounce,
+    description,
+    element: field,
+    feel: 'required',
+    getValue,
+    id,
+    label: 'Options expression',
+    setValue,
+    variables
+  });
+}

--- a/packages/form-js-editor/src/features/properties-panel/entries/ValuesSourceSelectEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ValuesSourceSelectEntry.js
@@ -1,5 +1,15 @@
-import { SelectEntry, isSelectEntryEdited } from '@bpmn-io/properties-panel';
-import { getValuesSource, VALUES_SOURCES, VALUES_SOURCES_DEFAULTS, VALUES_SOURCES_LABELS, VALUES_SOURCES_PATHS } from '@bpmn-io/form-js-viewer';
+import { isSelectEntryEdited } from '@bpmn-io/properties-panel';
+
+import { AutoFocusSelectEntry } from '../components';
+
+import {
+  getValuesSource,
+  VALUES_SOURCES,
+  VALUES_SOURCES_DEFAULTS,
+  VALUES_SOURCES_LABELS,
+  VALUES_SOURCES_PATHS
+} from '@bpmn-io/form-js-viewer';
+
 
 export default function ValuesSourceSelectEntry(props) {
   const {
@@ -54,7 +64,8 @@ function ValuesSourceSelect(props) {
     }));
   };
 
-  return SelectEntry({
+  return AutoFocusSelectEntry({
+    autoFocusEntry: getAutoFocusEntryId(field),
     label: 'Type',
     element: field,
     getOptions: getValuesSourceOptions,
@@ -62,4 +73,20 @@ function ValuesSourceSelect(props) {
     id,
     setValue
   });
+}
+
+// helpers //////////
+
+function getAutoFocusEntryId(field) {
+  const valuesSource = getValuesSource(field);
+
+  if (valuesSource === VALUES_SOURCES.EXPRESSION) {
+    return `${field.id}-valuesExpression-expression`;
+  } else if (valuesSource === VALUES_SOURCES.INPUT) {
+    return `${field.id}-dynamicValues-key`;
+  } else if (valuesSource === VALUES_SOURCES.STATIC) {
+    return `${field.id}-staticValues-0-label`;
+  }
+
+  return null;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/index.js
@@ -23,3 +23,4 @@ export { default as StaticValuesSourceEntry } from './StaticValuesSourceEntry';
 export { default as AdornerEntry } from './AdornerEntry';
 export { default as ReadonlyEntry } from './ReadonlyEntry';
 export { ConditionEntry } from './ConditionEntry';
+export { default as ValuesExpressionEntry } from './ValuesExpressionEntry';

--- a/packages/form-js-editor/src/features/properties-panel/groups/ValuesGroups.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/ValuesGroups.js
@@ -1,4 +1,10 @@
-import { ValuesSourceSelectEntry, StaticValuesSourceEntry, InputKeyValuesSourceEntry } from '../entries';
+import {
+  ValuesSourceSelectEntry,
+  StaticValuesSourceEntry,
+  InputKeyValuesSourceEntry,
+  ValuesExpressionEntry
+} from '../entries';
+
 import { getValuesSource, VALUES_SOURCES } from '@bpmn-io/form-js-viewer';
 
 import { Group, ListGroup } from '@bpmn-io/properties-panel';
@@ -42,14 +48,21 @@ export default function ValuesGroups(field, editField) {
       component: Group,
       entries: InputKeyValuesSourceEntry({ ...context, id: dynamicValuesId })
     });
-  }
-  else if (valuesSource === VALUES_SOURCES.STATIC) {
+  } else if (valuesSource === VALUES_SOURCES.STATIC) {
     const staticValuesId = `${fieldId}-staticValues`;
     groups.push({
       id: staticValuesId,
       label: 'Static options',
       component: ListGroup,
       ...StaticValuesSourceEntry({ ...context, id: staticValuesId })
+    });
+  } else if (valuesSource === VALUES_SOURCES.EXPRESSION) {
+    const valuesExpressionId = `${fieldId}-valuesExpression`;
+    groups.push({
+      id: valuesExpressionId,
+      label: 'Options expression',
+      component: Group,
+      entries: ValuesExpressionEntry({ ...context, id: valuesExpressionId })
     });
   }
 

--- a/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
+++ b/packages/form-js-viewer/src/render/hooks/useValuesAsync.js
@@ -51,15 +51,13 @@ export default function(field) {
       if (keyedValues && Array.isArray(keyedValues)) {
         values = keyedValues;
       }
-    }
 
     // static values
-    else if (staticValues !== undefined) {
+    } else if (staticValues !== undefined) {
       values = Array.isArray(staticValues) ? staticValues : [];
-    }
 
     // expression
-    else if (evaluatedValues && Array.isArray(evaluatedValues)) {
+    } else if (evaluatedValues && Array.isArray(evaluatedValues)) {
       values = evaluatedValues;
     } else {
       setValuesGetter(buildErrorState('No values source defined in the form definition'));

--- a/packages/form-js-viewer/src/util/constants/ValuesSourceConstants.js
+++ b/packages/form-js-viewer/src/util/constants/ValuesSourceConstants.js
@@ -4,7 +4,8 @@ import { get } from 'min-dash';
 
 export const VALUES_SOURCES = {
   STATIC: 'static',
-  INPUT: 'input'
+  INPUT: 'input',
+  EXPRESSION: 'expression',
 };
 
 export const VALUES_SOURCE_DEFAULT = VALUES_SOURCES.STATIC;
@@ -12,11 +13,13 @@ export const VALUES_SOURCE_DEFAULT = VALUES_SOURCES.STATIC;
 export const VALUES_SOURCES_LABELS = {
   [VALUES_SOURCES.STATIC]: 'Static',
   [VALUES_SOURCES.INPUT]: 'Input data',
+  [VALUES_SOURCES.EXPRESSION]: 'Expression',
 };
 
 export const VALUES_SOURCES_PATHS = {
   [VALUES_SOURCES.STATIC]: [ 'values' ],
   [VALUES_SOURCES.INPUT]: [ 'valuesKey' ],
+  [VALUES_SOURCES.EXPRESSION]: [ 'valuesExpression' ],
 };
 
 export const VALUES_SOURCES_DEFAULTS = {
@@ -27,6 +30,7 @@ export const VALUES_SOURCES_DEFAULTS = {
     }
   ],
   [VALUES_SOURCES.INPUT]: '',
+  [VALUES_SOURCES.EXPRESSION]: '='
 };
 
 // helpers ///////////////////

--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -16,7 +16,8 @@ const EXPRESSION_PROPERTIES = [
   'label',
   'source',
   'readonly',
-  'text'
+  'text',
+  'valuesExpression'
 ];
 
 const TEMPLATE_PROPERTIES = [

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -289,7 +289,7 @@ describe('Select', function() {
     });
 
 
-    describe('interaction (dynamic data)', function() {
+    describe('interaction (dynamic data, valuesKey)', function() {
 
       it('should set value through dropdown', function() {
 
@@ -339,6 +339,74 @@ describe('Select', function() {
         // then
         expect(onChangeSpy).to.have.been.calledWith({
           field: dynamicField,
+          value: null
+        });
+
+      });
+
+    });
+
+
+    describe('interaction (dynamic data, valuesExpression)', function() {
+
+      it('should set value through dropdown', function() {
+
+        // given
+        const onChangeSpy = spy();
+
+        const { container } = createSelect({
+          onChange: onChangeSpy,
+          value: 'value2',
+          isExpression: () => true,
+          evaluateExpression: () => [
+            ...expressionFieldInitialData.list1,
+            ...expressionFieldInitialData.list2
+          ],
+          field: expressionField,
+          initialData: expressionFieldInitialData
+        });
+
+        const select = container.querySelector('.fjs-input-group');
+
+        // when
+        fireEvent.focus(select);
+
+        const germanSelector = container.querySelector('.fjs-dropdownlist .fjs-dropdownlist-item');
+
+        fireEvent.mouseDown(germanSelector);
+
+        // then
+        expect(onChangeSpy).to.have.been.calledWith({
+          field: expressionField,
+          value: 'value1'
+        });
+      });
+
+
+      it('should clear', function() {
+
+        // given
+        const onChangeSpy = spy();
+
+        const { container } = createSelect({
+          onChange: onChangeSpy,
+          value: 'value1',
+          isExpression: () => true,
+          evaluateExpression: () => [
+            ...expressionFieldInitialData.list1,
+            ...expressionFieldInitialData.list2
+          ],
+          field: expressionField,
+          initialData: expressionFieldInitialData
+        });
+
+        // when
+        const cross = container.querySelector('.fjs-select-cross');
+        fireEvent.mouseDown(cross);
+
+        // then
+        expect(onChangeSpy).to.have.been.calledWith({
+          field: expressionField,
           value: null
         });
 
@@ -851,6 +919,37 @@ const dynamicFieldInitialData = {
     {
       label: 'Dynamic Value 2',
       value: 'dynamicValue2'
+    }
+  ]
+};
+
+const expressionField = {
+  id: 'Taglist_1',
+  key: 'tags',
+  label: 'Taglist',
+  type: 'taglist',
+  valuesExpression: '=concatenate(list1,list2)'
+};
+
+const expressionFieldInitialData = {
+  list1: [
+    {
+      label: 'Value 1',
+      value: 'value1'
+    },
+    {
+      label: 'Value 2',
+      value: 'value2'
+    }
+  ],
+  list2: [
+    {
+      label: 'Value 3',
+      value: 'value3'
+    },
+    {
+      label: 'Value 4',
+      value: 'value4'
     }
   ]
 };

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -104,7 +104,7 @@ describe('Taglist', function() {
   });
 
 
-  it('should render tags dynamically', function() {
+  it('should render tags via valuesKey', function() {
 
     // when
     const { container } = createTaglist({
@@ -127,7 +127,37 @@ describe('Taglist', function() {
 
     const tagCross = tagDeleteArea.querySelector('svg');
     expect(tagCross).to.exist;
+  });
 
+
+  it('should render tags via valuesExpression', function() {
+
+    // when
+    const { container } = createTaglist({
+      value: [ 'value1', 'value3' ],
+      onchange: () => { },
+      isExpression: () => true,
+      evaluateExpression: () => [
+        ...expressionFieldInitialData.list1,
+        ...expressionFieldInitialData.list2
+      ],
+      field: expressionField,
+      initialData: expressionFieldInitialData
+    });
+
+    // then
+    const tags = container.querySelectorAll('.fjs-taglist-tag');
+    expect(tags).to.have.length(2);
+
+    const tag = tags[0];
+    const tagLabelArea = tag.querySelector('.fjs-taglist-tag-label');
+    expect(tagLabelArea).to.exist;
+
+    const tagDeleteArea = tag.querySelector('.fjs-taglist-tag-remove');
+    expect(tagLabelArea).to.exist;
+
+    const tagCross = tagDeleteArea.querySelector('svg');
+    expect(tagCross).to.exist;
   });
 
 
@@ -855,6 +885,14 @@ const dynamicField = {
   valuesKey: 'dynamicValues'
 };
 
+const expressionField = {
+  id: 'Taglist_1',
+  key: 'tags',
+  label: 'Taglist',
+  type: 'taglist',
+  valuesExpression: '=concatenate(list1,list2)'
+};
+
 const dynamicFieldInitialData = {
   dynamicValues: [
     {
@@ -872,6 +910,29 @@ const dynamicFieldInitialData = {
     {
       label: 'Dynamic Value 4',
       value: 'dynamicValue4'
+    }
+  ]
+};
+
+const expressionFieldInitialData = {
+  list1: [
+    {
+      label: 'Value 1',
+      value: 'value1'
+    },
+    {
+      label: 'Value 2',
+      value: 'value2'
+    }
+  ],
+  list2: [
+    {
+      label: 'Value 3',
+      value: 'value3'
+    },
+    {
+      label: 'Value 4',
+      value: 'value4'
     }
   ]
 };

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/helper/index.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/helper/index.js
@@ -11,7 +11,7 @@ export function WithFormContext(Component, options = {}, formId = 'foo') {
     const {
       data,
       errors,
-      isExpression,
+      isExpression = () => false,
       evaluateExpression,
       isTemplate = defaultTemplating.isTemplate,
       evaluateTemplate = defaultTemplating.evaluate,

--- a/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
+++ b/packages/form-js-viewer/test/spec/util/GetSchemaVariables.spec.js
@@ -13,6 +13,7 @@ import labelsSchema from '../labels.json';
 import descriptionsSchema from '../descriptions.json';
 import adornersSchema from '../appearance.json';
 import imagesSchema from '../images.json';
+import valuesExpressionSchema from '../valuesExpression.json';
 
 describe('util/getSchemaVariables', () => {
 
@@ -21,7 +22,6 @@ describe('util/getSchemaVariables', () => {
     const variables = getSchemaVariables(schema);
 
     expect(variables).to.eql([ 'creditor', 'invoiceNumber', 'amount', 'approved', 'approvedBy', 'approverComments', 'product', 'mailto', 'language', 'conversation', 'tags' ]);
-
   });
 
 
@@ -30,7 +30,14 @@ describe('util/getSchemaVariables', () => {
     const variables = getSchemaVariables(dynamicSchema);
 
     expect(variables).to.eql([ 'product', 'xyzData', 'mailto', 'language', 'tags' ]);
+  });
 
+
+  it('should include variables in valuesExpression', () => {
+
+    const variables = getSchemaVariables(valuesExpressionSchema);
+
+    expect(variables).to.eql([ 'product', 'mailto', 'myList', 'foo', 'concatenate', 'myList2', 'myList3', 'myList4' ]);
   });
 
 

--- a/packages/form-js-viewer/test/spec/valuesExpression.json
+++ b/packages/form-js-viewer/test/spec/valuesExpression.json
@@ -1,0 +1,22 @@
+{
+  "components": [
+    {
+      "key": "product",
+      "label": "Product",
+      "type": "radio",
+      "values": []
+    },
+    {
+      "key": "mailto",
+      "label": "Email Summary To",
+      "type": "checklist",
+      "valuesExpression": "=myList"
+    },
+    {
+      "key": "foo",
+      "type": "taglist",
+      "valuesExpression": "=concatenate(myList2,myList3,myList4)"
+    }
+  ],
+  "type": "default"
+}


### PR DESCRIPTION
Closes #673 

* Adds `valuesExpression` property to populate multiselect options via FEEL
* Adds `AutoFocusSelectEntry` to focus another entry after select change

![image](https://github.com/bpmn-io/form-js/assets/9433996/4ccf4f11-b5bd-4685-9a20-c2d33dd74f4f)

Demo: https://demo-673-values-feel--camunda-form-playground.netlify.app/