### PR TITLE
fix: hide empty rows via css

### DIFF
--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -175,6 +175,10 @@
   position: relative;
 }
 
+.fjs-container .fjs-layout-row:empty {
+  display: none;
+}
+
 .fjs-container .fjs-column {
   flex-grow: 1;
 }


### PR DESCRIPTION
Closes  #684

Initially tried to approach this one programmatically, but it's not as clean as it seems, so I thought the simplest and most effective approach is to just not render the row if it has no children. 