### PR TITLE
fix: serialize empty text as empty string

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/TextEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/TextEntry.js
@@ -68,7 +68,7 @@ function Text(props) {
   };
 
   const setValue = (value) => {
-    return editField(field, path, value);
+    return editField(field, path, value || '');
   };
 
   const description = useMemo(() => <>Supports markdown and templating. <a href="https://docs.camunda.io/docs/components/modeler/forms/form-element-library/forms-element-library-text/" target="_blank">Learn more</a></>, []);


### PR DESCRIPTION
Related to https://github.com/camunda/web-modeler/issues/5483

Tested in desktop modeler. 