### PR TITLE
ci: do not fail on codecov errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,3 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v3
       if: runner.os == 'Linux'
-      with:
-        fail_ci_if_error: true
-        max_attempts: 3
-        retry_on: error


### PR DESCRIPTION
This is to prevent that we run into CI errors just because of upload errors to codecov, which happens from time to time and already lead in other projects to remove this flag.

I also removed the other flags as they do not have any effect for this action 🐒 