### PR TITLE
fix: serialize empty labels as empty string

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/LabelEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/LabelEntry.js
@@ -74,7 +74,7 @@ function Label(props) {
   };
 
   const setValue = (value) => {
-    return editField(field, path, value);
+    return editField(field, path, value || '');
   };
 
   return FeelTemplatingEntry({
@@ -107,7 +107,7 @@ function DateLabel(props) {
   };
 
   const setValue = (value) => {
-    return editField(field, path, value);
+    return editField(field, path, value || '');
   };
 
   return FeelTemplatingEntry({
@@ -140,7 +140,7 @@ function TimeLabel(props) {
   };
 
   const setValue = (value) => {
-    return editField(field, path, value);
+    return editField(field, path, value || '');
   };
 
   return FeelTemplatingEntry({


### PR DESCRIPTION
Related to https://github.com/camunda/web-modeler/issues/5483

Same change as [`85937c4` (#728)](https://github.com/bpmn-io/form-js/pull/728/commits/85937c410f83bd023acd1a1c1a50018c18344f0a), but for labels