### PR TITLE
style: do not show empty state while dragging

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -291,6 +291,10 @@
   height: 100%;
 }
 
+.fjs-cursor-grabbing .fjs-editor-container .fjs-empty-editor {
+  display: none;
+}
+
 .fjs-editor-container .fjs-empty-editor .fjs-empty-editor-card {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
I think it doesn't make sense to show during dragging. Let me know what you think.

We can also introduce another flag for dragging mode, but as we already set this one, I thought that would be enough.