### PR TITLE
Custom form fields support

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -652,7 +652,8 @@
   outline: solid 1px var(--color-palette-field-focus);
 }
 
-.fjs-palette-field .fjs-palette-field-icon {
+.fjs-palette-field .fjs-palette-field-icon,
+.fjs-palette-field .fjs-field-icon-image {
   margin: 0 auto;
 }
 

--- a/packages/form-js-editor/src/features/palette/components/Palette.js
+++ b/packages/form-js-editor/src/features/palette/components/Palette.js
@@ -56,9 +56,9 @@ export default function Palette(props) {
 
   const formFields = useService('formFields');
 
-  const initialPaletteEntries = collectPaletteEntries(formFields);
+  const initialPaletteEntries = useRef(collectPaletteEntries(formFields));
 
-  const [ paletteEntries, setPaletteEntries ] = useState(initialPaletteEntries);
+  const [ paletteEntries, setPaletteEntries ] = useState(initialPaletteEntries.current);
 
   const [ searchTerm, setSearchTerm ] = useState('');
 
@@ -90,7 +90,7 @@ export default function Palette(props) {
 
   // filter entries on search change
   useEffect(() => {
-    const entries = initialPaletteEntries.filter(filter);
+    const entries = initialPaletteEntries.current.filter(filter);
     setPaletteEntries(entries);
   }, [ filter, searchTerm ]);
 
@@ -214,7 +214,7 @@ export function getPaletteIcon(entry) {
   let Icon;
 
   if (iconUrl) {
-    Icon = () => <img class="fjs-field-icon-image" width={ 36 } alt={ label } src={ sanitizeImageSource(iconUrl) } />;
+    Icon = () => <img class="fjs-field-icon-image" width={ 36 } style={ { margin: 'auto' } } alt={ label } src={ sanitizeImageSource(iconUrl) } />;
   } else {
     Icon = icon || iconsByType(type);
   }

--- a/packages/form-js-editor/src/features/palette/components/Palette.js
+++ b/packages/form-js-editor/src/features/palette/components/Palette.js
@@ -214,7 +214,7 @@ export function getPaletteIcon(entry) {
   let Icon;
 
   if (iconUrl) {
-    Icon = () => <img class="fjs-field-icon-image" width={ 36 } style={ { margin: 'auto' } } alt={ label } src={ sanitizeImageSource(iconUrl) } />;
+    Icon = () => <img class="fjs-field-icon-image" width={ 36 } alt={ label } src={ sanitizeImageSource(iconUrl) } />;
   } else {
     Icon = icon || iconsByType(type);
   }

--- a/packages/form-js-editor/src/features/palette/components/PaletteEntry.js
+++ b/packages/form-js-editor/src/features/palette/components/PaletteEntry.js
@@ -1,19 +1,18 @@
-import {
-  iconsByType
-} from '../../../render/components/icons';
-
 import { useService } from '../../../render/hooks';
 
 export default function PaletteEntry(props) {
   const {
     type,
-    label
+    label,
+    icon,
+    iconUrl,
+    getPaletteIcon
   } = props;
 
   const modeling = useService('modeling');
   const formEditor = useService('formEditor');
 
-  const Icon = iconsByType(type);
+  const Icon = getPaletteIcon({ icon, iconUrl, label, type });
 
   const onKeyDown = (event) => {
     if (event.code === 'Enter') {

--- a/packages/form-js-editor/src/features/properties-panel/PropertiesPanelHeaderProvider.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesPanelHeaderProvider.js
@@ -4,25 +4,10 @@ import {
 
 import { iconsByType } from '../../render/components/icons';
 
-const labelsByType = {
-  button: 'BUTTON',
-  checkbox: 'CHECKBOX',
-  checklist: 'CHECKLIST',
-  columns: 'COLUMNS',
-  default: 'FORM',
-  datetime: 'DATETIME',
-  group: 'GROUP',
-  image: 'IMAGE VIEW',
-  number: 'NUMBER',
-  radio: 'RADIO',
-  select: 'SELECT',
-  separator: 'SEPARATOR',
-  spacer: 'SPACER',
-  taglist: 'TAGLIST',
-  text: 'TEXT VIEW',
-  textfield: 'TEXT FIELD',
-  textarea: 'TEXT AREA',
-};
+import { getPaletteIcon } from '../palette/components/Palette';
+
+import { useService } from './hooks';
+
 
 export const PropertiesPanelHeaderProvider = {
 
@@ -55,10 +40,17 @@ export const PropertiesPanelHeaderProvider = {
       type
     } = field;
 
-    const Icon = iconsByType(type);
+    // @Note: We know that we are inside the properties panel context,
+    // so we can savely use the hook here.
+    // eslint-disable-next-line
+    const fieldDefinition = useService('formFields').get(type).config;
+
+    const Icon = fieldDefinition.icon || iconsByType(type);
 
     if (Icon) {
       return () => <Icon width="36" height="36" viewBox="0 0 54 54" />;
+    } else if (fieldDefinition.iconUrl) {
+      return getPaletteIcon({ iconUrl: fieldDefinition.iconUrl, label: fieldDefinition.label });
     }
   },
 
@@ -67,6 +59,15 @@ export const PropertiesPanelHeaderProvider = {
       type
     } = field;
 
-    return labelsByType[type];
+    if (type === 'default') {
+      return 'Form';
+    }
+
+    // @Note: We know that we are inside the properties panel context,
+    // so we can savely use the hook here.
+    // eslint-disable-next-line
+    const fieldDefinition = useService('formFields').get(type).config;
+
+    return fieldDefinition.label || type;
   }
 };

--- a/packages/form-js-editor/src/features/properties-panel/PropertiesPanelHeaderProvider.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesPanelHeaderProvider.js
@@ -42,7 +42,7 @@ export const PropertiesPanelHeaderProvider = {
 
     // @Note: We know that we are inside the properties panel context,
     // so we can savely use the hook here.
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const fieldDefinition = useService('formFields').get(type).config;
 
     const Icon = fieldDefinition.icon || iconsByType(type);
@@ -65,7 +65,7 @@ export const PropertiesPanelHeaderProvider = {
 
     // @Note: We know that we are inside the properties panel context,
     // so we can savely use the hook here.
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const fieldDefinition = useService('formFields').get(type).config;
 
     return fieldDefinition.label || type;

--- a/packages/form-js-editor/src/features/properties-panel/PropertiesProvider.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesProvider.js
@@ -1,0 +1,84 @@
+import {
+  ConditionGroup,
+  AppearanceGroup,
+  CustomPropertiesGroup,
+  GeneralGroup,
+  SerializationGroup,
+  ConstraintsGroup,
+  ValidationGroup,
+  ValuesGroups,
+  LayoutGroup
+} from './groups';
+
+import { hasEntryConfigured } from './Util';
+
+export default class PropertiesProvider {
+  constructor(propertiesPanel, injector) {
+    this._injector = injector;
+    propertiesPanel.registerProvider(this);
+  }
+
+  _filterVisibleEntries(groups, field, getService) {
+    return groups.forEach(group => {
+      const {
+        entries
+      } = group;
+
+      const {
+        type
+      } = field;
+
+      const formFields = getService('formFields');
+
+      const fieldDefinition = formFields.get(type).config;
+
+      if (!entries) {
+        return;
+      }
+
+      group.entries = entries.filter(entry => {
+        const {
+          isDefaultVisible
+        } = entry;
+
+        if (!isDefaultVisible) {
+          return true;
+        }
+
+        return isDefaultVisible(field) || hasEntryConfigured(fieldDefinition, entry.id);
+      });
+    });
+  }
+
+  getGroups(field, editField) {
+    return (groups) => {
+      if (!field) {
+        return groups;
+      }
+
+      const getService = (type, strict = true) => this._injector.get(type, strict);
+
+      groups = [
+        ...groups,
+        GeneralGroup(field, editField, getService),
+        ConditionGroup(field, editField),
+        LayoutGroup(field, editField),
+        AppearanceGroup(field, editField),
+        SerializationGroup(field, editField),
+        ...ValuesGroups(field, editField, getService),
+        ConstraintsGroup(field, editField),
+        ValidationGroup(field, editField),
+        CustomPropertiesGroup(field, editField)
+      ].filter(group => group != null);
+
+      this._filterVisibleEntries(groups, field, getService);
+
+      // contract: if a group has no entries or items, it should not be displayed at all
+      return groups.filter(group => {
+        return group.items || group.entries && group.entries.length;
+      });
+    };
+  }
+}
+
+PropertiesProvider.$inject = [ 'propertiesPanel', 'injector' ];

--- a/packages/form-js-editor/src/features/properties-panel/Util.js
+++ b/packages/form-js-editor/src/features/properties-panel/Util.js
@@ -78,3 +78,23 @@ export const VALUES_INPUTS = [
   'select',
   'taglist'
 ];
+
+export function hasEntryConfigured(formFieldDefinition, entryId) {
+  const { propertiesPanelEntries = [] } = formFieldDefinition;
+
+  if (!propertiesPanelEntries.length) {
+    return false;
+  }
+
+  return propertiesPanelEntries.some(id => id === entryId);
+}
+
+export function hasValuesGroupsConfigured(formFieldDefinition) {
+  const { propertiesPanelEntries = [] } = formFieldDefinition;
+
+  if (!propertiesPanelEntries.length) {
+    return false;
+  }
+
+  return propertiesPanelEntries.some(id => id === 'values');
+}

--- a/packages/form-js-editor/src/features/properties-panel/entries/ActionEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ActionEntry.js
@@ -9,21 +9,16 @@ export default function ActionEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
-  if (type === 'button') {
-    entries.push({
-      id: 'action',
-      component: Action,
-      editField: editField,
-      field: field,
-      isEdited: isSelectEntryEdited
-    });
-  }
+  entries.push({
+    id: 'action',
+    component: Action,
+    editField: editField,
+    field: field,
+    isEdited: isSelectEntryEdited,
+    isDefaultVisible: (field) => field.type === 'button'
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/AdornerEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/AdornerEntry.js
@@ -9,10 +9,6 @@ export default function AdornerEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
   const onChange = (key) => {
@@ -29,27 +25,27 @@ export default function AdornerEntry(props) {
     };
   };
 
-  if ([ 'number', 'textfield' ].includes(type)) {
-    entries.push({
-      id: 'prefix-adorner',
-      component: PrefixAdorner,
-      isEdited: isFeelEntryEdited,
-      editField,
-      field,
-      onChange,
-      getValue
-    });
+  entries.push({
+    id: 'prefix-adorner',
+    component: PrefixAdorner,
+    isEdited: isFeelEntryEdited,
+    editField,
+    field,
+    onChange,
+    getValue,
+    isDefaultVisible: (field) => [ 'number', 'textfield' ].includes(field.type)
+  });
 
-    entries.push({
-      id: 'suffix-adorner',
-      component: SuffixAdorner,
-      isEdited: isFeelEntryEdited,
-      editField,
-      field,
-      onChange,
-      getValue
-    });
-  }
+  entries.push({
+    id: 'suffix-adorner',
+    component: SuffixAdorner,
+    isEdited: isFeelEntryEdited,
+    editField,
+    field,
+    onChange,
+    getValue,
+    isDefaultVisible: (field) => [ 'number', 'textfield' ].includes(field.type)
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/AltTextEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/AltTextEntry.js
@@ -10,21 +10,16 @@ export default function AltTextEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
-  if (type === 'image') {
-    entries.push({
-      id: 'alt',
-      component: AltText,
-      editField: editField,
-      field: field,
-      isEdited: isFeelEntryEdited
-    });
-  }
+  entries.push({
+    id: 'alt',
+    component: AltText,
+    editField: editField,
+    field: field,
+    isEdited: isFeelEntryEdited,
+    isDefaultVisible: (field) => [ 'image' ].includes(field.type)
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/DateTimeConstraintsEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DateTimeConstraintsEntry.js
@@ -11,36 +11,37 @@ export default function DateTimeConstraintsEntry(props) {
     id
   } = props;
 
-  const {
-    type,
-    subtype
-  } = field;
+  function isDefaultVisible(subtypes) {
+    return (field) => {
+      if (field.type !== 'datetime') {
+        return false;
+      }
 
-  if (type !== 'datetime') {
-    return [];
+      return subtypes.includes(field.subtype);
+    };
   }
 
   const entries = [];
 
-  if (subtype === DATETIME_SUBTYPES.TIME || subtype === DATETIME_SUBTYPES.DATETIME) {
-    entries.push({
-      id: id + '-timeInterval',
-      component: TimeIntervalSelect,
-      isEdited: isSelectEntryEdited,
-      editField,
-      field
-    });
-  }
+  entries.push({
+    id: id + '-timeInterval',
+    component: TimeIntervalSelect,
+    isEdited: isSelectEntryEdited,
+    editField,
+    field,
+    isDefaultVisible: isDefaultVisible([ DATETIME_SUBTYPES.TIME, DATETIME_SUBTYPES.DATETIME ])
+  });
 
-  if (subtype === DATETIME_SUBTYPES.DATE || subtype === DATETIME_SUBTYPES.DATETIME) {
-    entries.push({
-      id: id + '-disallowPassedDates',
-      component: DisallowPassedDates,
-      isEdited: isCheckboxEntryEdited,
-      editField,
-      field
-    });
-  }
+
+  entries.push({
+    id: id + '-disallowPassedDates',
+    component: DisallowPassedDates,
+    isEdited: isCheckboxEntryEdited,
+    editField,
+    field,
+    isDefaultVisible: isDefaultVisible([ DATETIME_SUBTYPES.DATE, DATETIME_SUBTYPES.DATETIME ])
+  });
+
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/DateTimeEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DateTimeEntry.js
@@ -21,36 +21,27 @@ export default function DateTimeEntry(props) {
     field
   } = props;
 
-  const {
-    type,
-    subtype
-  } = field;
-
-  if (type !== 'datetime') {
-    return [];
-  }
-
   const entries = [
     {
       id: 'subtype',
       component: DateTimeSubtypeSelect,
       isEdited: isSelectEntryEdited,
       editField,
-      field
+      field,
+      isDefaultVisible: (field) => field.type === 'datetime'
     }
   ];
 
-  if (subtype === DATETIME_SUBTYPES.TIME || subtype === DATETIME_SUBTYPES.DATETIME) {
-
-    entries.push({
-      id: 'use24h',
-      component: Use24h,
-      isEdited: isCheckboxEntryEdited,
-      editField,
-      field
-    });
-
-  }
+  entries.push({
+    id: 'use24h',
+    component: Use24h,
+    isEdited: isCheckboxEntryEdited,
+    editField,
+    field,
+    isDefaultVisible: (field) => field.type === 'datetime' && (
+      field.subtype === DATETIME_SUBTYPES.TIME || field.subtype === DATETIME_SUBTYPES.DATETIME
+    )
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/DateTimeSerializationEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DateTimeSerializationEntry.js
@@ -10,26 +10,18 @@ export default function DateTimeFormatEntry(props) {
     field
   } = props;
 
-  const {
-    type,
-    subtype
-  } = field;
-
-  if (type !== 'datetime') {
-    return [];
-  }
-
   const entries = [];
 
-  if (subtype === DATETIME_SUBTYPES.TIME || subtype === DATETIME_SUBTYPES.DATETIME) {
-    entries.push({
-      id: 'time-format',
-      component: TimeFormatSelect,
-      isEdited: isSelectEntryEdited,
-      editField,
-      field
-    });
-  }
+  entries.push({
+    id: 'time-format',
+    component: TimeFormatSelect,
+    isEdited: isSelectEntryEdited,
+    editField,
+    field,
+    isDefaultVisible: (field) => field.type === 'datetime' && (
+      field.subtype === DATETIME_SUBTYPES.TIME || field.subtype === DATETIME_SUBTYPES.DATETIME
+    )
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/DefaultValueEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DefaultValueEntry.js
@@ -29,9 +29,17 @@ export default function DefaultOptionEntry(props) {
 
   const entries = [];
 
-  // Only make default values available when they are statically defined
-  if (!INPUTS.includes(type) || VALUES_INPUTS.includes(type) && !field.values) {
-    return entries;
+  function isDefaultVisible(matchers) {
+    return (field) => {
+
+      // Only make default values available when they are statically defined
+      if (!INPUTS.includes(type) || VALUES_INPUTS.includes(type) && !field.values) {
+        return false;
+      }
+
+      return matchers(field);
+    };
+
   }
 
   const defaultOptions = {
@@ -41,47 +49,42 @@ export default function DefaultOptionEntry(props) {
     label: 'Default value'
   };
 
-  if (type === 'checkbox') {
-    entries.push({
-      ...defaultOptions,
-      component: DefaultValueCheckbox,
-      isEdited: isSelectEntryEdited
-    });
-  }
+  entries.push({
+    ...defaultOptions,
+    component: DefaultValueCheckbox,
+    isEdited: isSelectEntryEdited,
+    isDefaultVisible: isDefaultVisible((field) => field.type === 'checkbox')
+  });
 
-  if (type === 'number') {
-    entries.push({
-      ...defaultOptions,
-      component: DefaultValueNumber,
-      isEdited: isTextFieldEntryEdited
-    });
-  }
+  entries.push({
+    ...defaultOptions,
+    component: DefaultValueNumber,
+    isEdited: isTextFieldEntryEdited,
+    isDefaultVisible: isDefaultVisible((field) => field.type === 'number')
+  });
 
-  if (type === 'radio' || type === 'select') {
-    entries.push({
-      ...defaultOptions,
-      component: DefaultValueSingleSelect,
-      isEdited: isSelectEntryEdited
-    });
-  }
+  entries.push({
+    ...defaultOptions,
+    component: DefaultValueSingleSelect,
+    isEdited: isSelectEntryEdited,
+    isDefaultVisible: isDefaultVisible((field) => field.type === 'radio' || field.type === 'select')
+  });
 
   // todo(Skaiir): implement a multiselect equivalent (cf. https://github.com/bpmn-io/form-js/issues/265)
 
-  if (type === 'textfield') {
-    entries.push({
-      ...defaultOptions,
-      component: DefaultValueTextfield,
-      isEdited: isTextFieldEntryEdited
-    });
-  }
+  entries.push({
+    ...defaultOptions,
+    component: DefaultValueTextfield,
+    isEdited: isTextFieldEntryEdited,
+    isDefaultVisible: isDefaultVisible((field) => field.type === 'textfield')
+  });
 
-  if (type === 'textarea') {
-    entries.push({
-      ...defaultOptions,
-      component: DefaultValueTextarea,
-      isEdited: isTextAreaEntryEdited
-    });
-  }
+  entries.push({
+    ...defaultOptions,
+    component: DefaultValueTextarea,
+    isEdited: isTextAreaEntryEdited,
+    isDefaultVisible: isDefaultVisible((field) => field.type === 'textarea')
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/DescriptionEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DescriptionEntry.js
@@ -13,21 +13,16 @@ export default function DescriptionEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
-  if (INPUTS.includes(type)) {
-    entries.push({
-      id: 'description',
-      component: Description,
-      editField: editField,
-      field: field,
-      isEdited: isFeelEntryEdited
-    });
-  }
+  entries.push({
+    id: 'description',
+    component: Description,
+    editField: editField,
+    field: field,
+    isEdited: isFeelEntryEdited,
+    isDefaultVisible: (field) => INPUTS.includes(field.type)
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/DisabledEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DisabledEntry.js
@@ -11,21 +11,16 @@ export default function DisabledEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
-  if (INPUTS.includes(type)) {
-    entries.push({
-      id: 'disabled',
-      component: Disabled,
-      editField: editField,
-      field: field,
-      isEdited: isToggleSwitchEntryEdited
-    });
-  }
+  entries.push({
+    id: 'disabled',
+    component: Disabled,
+    editField: editField,
+    field: field,
+    isEdited: isToggleSwitchEntryEdited,
+    isDefaultVisible: (field) => INPUTS.includes(field.type)
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/IdEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/IdEntry.js
@@ -13,15 +13,14 @@ export default function IdEntry(props) {
 
   const entries = [];
 
-  if (field.type === 'default') {
-    entries.push({
-      id: 'id',
-      component: Id,
-      editField: editField,
-      field: field,
-      isEdited: isTextFieldEntryEdited
-    });
-  }
+  entries.push({
+    id: 'id',
+    component: Id,
+    editField: editField,
+    field: field,
+    isEdited: isTextFieldEntryEdited,
+    isDefaultVisible: (field) => field.type === 'default'
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/ImageSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ImageSourceEntry.js
@@ -10,21 +10,15 @@ export default function SourceEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
-
-  if (type === 'image') {
-    entries.push({
-      id: 'source',
-      component: Source,
-      editField: editField,
-      field: field,
-      isEdited: isFeelEntryEdited
-    });
-  }
+  entries.push({
+    id: 'source',
+    component: Source,
+    editField: editField,
+    field: field,
+    isEdited: isFeelEntryEdited,
+    isDefaultVisible: (field) => field.type === 'image'
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/KeyEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/KeyEntry.js
@@ -15,21 +15,16 @@ export default function KeyEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
-  if (INPUTS.includes(type)) {
-    entries.push({
-      id: 'key',
-      component: Key,
-      editField: editField,
-      field: field,
-      isEdited: isTextFieldEntryEdited
-    });
-  }
+  entries.push({
+    id: 'key',
+    component: Key,
+    editField: editField,
+    field: field,
+    isEdited: isTextFieldEntryEdited,
+    isDefaultVisible: (field) => INPUTS.includes(field.type)
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/LabelEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/LabelEntry.js
@@ -10,48 +10,50 @@ export default function LabelEntry(props) {
     editField
   } = props;
 
-  const {
-    type,
-    subtype
-  } = field;
-
   const entries = [];
 
-  if (type === 'datetime') {
-    if (subtype === DATETIME_SUBTYPES.DATE || subtype === DATETIME_SUBTYPES.DATETIME) {
-      entries.push(
-        {
-          id: 'date-label',
-          component: DateLabel,
-          editField,
-          field,
-          isEdited: isFeelEntryEdited
-        }
-      );
-    }
-    if (subtype === DATETIME_SUBTYPES.TIME || subtype === DATETIME_SUBTYPES.DATETIME) {
-      entries.push(
-        {
-          id: 'time-label',
-          component: TimeLabel,
-          editField,
-          field,
-          isEdited: isFeelEntryEdited
-        }
-      );
-    }
-  }
-  else if (INPUTS.includes(type) || type === 'button' || type === 'group') {
-    entries.push(
-      {
-        id: 'label',
-        component: Label,
-        editField,
-        field,
-        isEdited: isFeelEntryEdited
+  entries.push(
+    {
+      id: 'date-label',
+      component: DateLabel,
+      editField,
+      field,
+      isEdited: isFeelEntryEdited,
+      isDefaultVisible: function(field) {
+        return (
+          field.type === 'datetime' &&
+          (field.subtype === DATETIME_SUBTYPES.DATE || field.subtype === DATETIME_SUBTYPES.DATETIME)
+        );
       }
-    );
-  }
+    }
+  );
+
+  entries.push(
+    {
+      id: 'time-label',
+      component: TimeLabel,
+      editField,
+      field,
+      isEdited: isFeelEntryEdited,
+      isDefaultVisible: function(field) {
+        return (
+          field.type === 'datetime' &&
+          (field.subtype === DATETIME_SUBTYPES.TIME || field.subtype === DATETIME_SUBTYPES.DATETIME)
+        );
+      }
+    }
+  );
+
+  entries.push(
+    {
+      id: 'label',
+      component: Label,
+      editField,
+      field,
+      isEdited: isFeelEntryEdited,
+      isDefaultVisible: (field) => INPUTS.includes(field.type) || field.type === 'button' || field.type === 'group'
+    }
+  );
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/NumberEntries.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/NumberEntries.js
@@ -12,14 +12,6 @@ export default function NumberEntries(props) {
     id
   } = props;
 
-  const {
-    type
-  } = field;
-
-  if (type !== 'number') {
-    return [];
-  }
-
   const entries = [];
 
   entries.push({
@@ -27,7 +19,8 @@ export default function NumberEntries(props) {
     component: NumberDecimalDigits,
     isEdited: isNumberFieldEntryEdited,
     editField,
-    field
+    field,
+    isDefaultVisible: (field) => field.type === 'number'
   });
 
   entries.push({
@@ -35,7 +28,8 @@ export default function NumberEntries(props) {
     component: NumberArrowStep,
     isEdited: isTextFieldEntryEdited,
     editField,
-    field
+    field,
+    isDefaultVisible: (field) => field.type === 'number'
   });
 
   return entries;

--- a/packages/form-js-editor/src/features/properties-panel/entries/NumberSerializationEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/NumberSerializationEntry.js
@@ -10,14 +10,6 @@ export default function NumberSerializationEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
-  if (type !== 'number') {
-    return [];
-  }
-
   const entries = [];
 
   entries.push({
@@ -25,7 +17,8 @@ export default function NumberSerializationEntry(props) {
     component: SerializeToString,
     isEdited: isCheckboxEntryEdited,
     editField,
-    field
+    field,
+    isDefaultVisible: (field) => field.type === 'number'
   });
 
   return entries;

--- a/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
@@ -13,21 +13,16 @@ export default function ReadonlyEntry(props) {
     field
   } = props;
 
-  const {
-    type
-  } = field;
-
   const entries = [];
 
-  if (INPUTS.includes(type)) {
-    entries.push({
-      id: 'readonly',
-      component: Readonly,
-      editField: editField,
-      field: field,
-      isEdited: isFeelEntryEdited
-    });
-  }
+  entries.push({
+    id: 'readonly',
+    component: Readonly,
+    editField: editField,
+    field: field,
+    isEdited: isFeelEntryEdited,
+    isDefaultVisible: (field) => INPUTS.includes(field.type)
+  });
 
   return entries;
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/SelectEntries.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/SelectEntries.js
@@ -2,24 +2,13 @@
 import { simpleBoolEntryFactory } from './factories';
 
 export default function SelectEntries(props) {
-  const {
-    field,
-  } = props;
-
-  const {
-    type
-  } = field;
-
-  if (type !== 'select') {
-    return [];
-  }
-
   const entries = [
     simpleBoolEntryFactory({
       id: 'searchable',
       path: [ 'searchable' ],
       label: 'Searchable',
-      props
+      props,
+      isDefaultVisible: (field) => field.type === 'select'
     })
   ];
 

--- a/packages/form-js-editor/src/features/properties-panel/entries/SpacerEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/SpacerEntry.js
@@ -10,14 +10,6 @@ export default function SpacerEntry(props) {
     id
   } = props;
 
-  const {
-    type
-  } = field;
-
-  if (type !== 'spacer') {
-    return [];
-  }
-
   const entries = [];
 
   entries.push({
@@ -25,7 +17,8 @@ export default function SpacerEntry(props) {
     component: SpacerHeight,
     isEdited: isNumberFieldEntryEdited,
     editField,
-    field
+    field,
+    isDefaultVisible: (field) => field.type === 'spacer'
   });
 
   return entries;

--- a/packages/form-js-editor/src/features/properties-panel/entries/TextEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/TextEntry.js
@@ -11,20 +11,8 @@ import { useMemo } from 'preact/hooks';
 export default function TextEntry(props) {
   const {
     editField,
-
-    /* getService, */
     field
   } = props;
-
-  const {
-    type
-  } = field;
-
-  // const templating = getService('templating');
-
-  if (type !== 'text') {
-    return [];
-  }
 
   const entries = [
     {
@@ -32,7 +20,8 @@ export default function TextEntry(props) {
       component: Text,
       editField: editField,
       field: field,
-      isEdited: isFeelEntryEdited
+      isEdited: isFeelEntryEdited,
+      isDefaultVisible: (field) => field.type === 'text'
     }
   ];
 

--- a/packages/form-js-editor/src/features/properties-panel/entries/factories/simpleBoolEntryFactory.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/factories/simpleBoolEntryFactory.js
@@ -7,7 +7,8 @@ export default function simpleBoolEntryFactory(options) {
     label,
     description,
     path,
-    props
+    props,
+    isDefaultVisible
   } = options;
 
   const {
@@ -23,7 +24,8 @@ export default function simpleBoolEntryFactory(options) {
     editField,
     description,
     component: SimpleBoolComponent,
-    isEdited: isCheckboxEntryEdited
+    isEdited: isCheckboxEntryEdited,
+    isDefaultVisible
   };
 }
 

--- a/packages/form-js-editor/src/features/properties-panel/groups/ValidationGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/ValidationGroup.js
@@ -37,10 +37,6 @@ export default function ValidationGroup(field, editField) {
   const validate = get(field, [ 'validate' ], {});
   const isCustomValidation = [ undefined, VALIDATION_TYPE_OPTIONS.custom.value ].includes(validate.validationType);
 
-  if (!INPUTS.includes(type)) {
-    return null;
-  }
-
   const onChange = (key) => {
     return (value) => {
       const validate = get(field, [ 'validate' ], {});
@@ -62,78 +58,83 @@ export default function ValidationGroup(field, editField) {
       getValue,
       field,
       isEdited: isCheckboxEntryEdited,
-      onChange
+      onChange,
+      isDefaultVisible: (field) => INPUTS.includes(field.type)
     }
   ];
 
-  if (type === 'textfield') {
-    entries.push(
-      {
-        id: 'validationType',
-        component: ValidationType,
-        getValue,
-        field,
-        editField,
-        isEdited: isTextFieldEntryEdited,
-        onChange
-      }
-    );
-  }
+  entries.push(
+    {
+      id: 'validationType',
+      component: ValidationType,
+      getValue,
+      field,
+      editField,
+      isEdited: isTextFieldEntryEdited,
+      onChange,
+      isDefaultVisible: (field) => field.type === 'textfield'
+    }
+  );
 
-  if (type === 'textarea' || (type === 'textfield' && isCustomValidation)) {
-    entries.push(
-      {
-        id: 'minLength',
-        component: MinLength,
-        getValue,
-        field,
-        isEdited: isFeelEntryEdited,
-        onChange
-      },
-      {
-        id: 'maxLength',
-        component: MaxLength,
-        getValue,
-        field,
-        isEdited: isFeelEntryEdited,
-        onChange
-      }
-    );
-  }
+  entries.push(
+    {
+      id: 'minLength',
+      component: MinLength,
+      getValue,
+      field,
+      isEdited: isFeelEntryEdited,
+      onChange,
+      isDefaultVisible: (field) => INPUTS.includes(field.type) && (
+        type === 'textarea' || (type === 'textfield' && isCustomValidation)
+      )
+    },
+    {
+      id: 'maxLength',
+      component: MaxLength,
+      getValue,
+      field,
+      isEdited: isFeelEntryEdited,
+      onChange,
+      isDefaultVisible: (field) => INPUTS.includes(field.type) && (
+        type === 'textarea' || (type === 'textfield' && isCustomValidation)
+      )
+    }
+  );
 
-  if (type === 'textfield' && isCustomValidation) {
-    entries.push(
-      {
-        id: 'pattern',
-        component: Pattern,
-        getValue,
-        field,
-        isEdited: isTextFieldEntryEdited,
-        onChange
-      }
-    );
-  }
+  entries.push(
+    {
+      id: 'pattern',
+      component: Pattern,
+      getValue,
+      field,
+      isEdited: isTextFieldEntryEdited,
+      onChange,
+      isDefaultVisible: (field) => INPUTS.includes(field.type) && (
+        type === 'textfield' && isCustomValidation
+      )
+    }
+  );
 
-  if (type === 'number') {
-    entries.push(
-      {
-        id: 'min',
-        component: Min,
-        getValue,
-        field,
-        isEdited: isFeelEntryEdited,
-        onChange
-      },
-      {
-        id: 'max',
-        component: Max,
-        getValue,
-        field,
-        isEdited: isFeelEntryEdited,
-        onChange
-      }
-    );
-  }
+  entries.push(
+    {
+      id: 'min',
+      component: Min,
+      getValue,
+      field,
+      isEdited: isFeelEntryEdited,
+      onChange,
+      isDefaultVisible: (field) => field.type === 'number'
+    },
+    {
+      id: 'max',
+      component: Max,
+      getValue,
+      field,
+      isEdited: isFeelEntryEdited,
+      onChange,
+      isDefaultVisible: (field) => field.type === 'number'
+    }
+  );
 
   return {
     id: 'validation',

--- a/packages/form-js-editor/src/features/properties-panel/groups/ValuesGroups.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/ValuesGroups.js
@@ -10,16 +10,21 @@ import { getValuesSource, VALUES_SOURCES } from '@bpmn-io/form-js-viewer';
 import { Group, ListGroup } from '@bpmn-io/properties-panel';
 
 import {
-  VALUES_INPUTS
+  VALUES_INPUTS,
+  hasValuesGroupsConfigured
 } from '../Util';
 
-export default function ValuesGroups(field, editField) {
+export default function ValuesGroups(field, editField, getService) {
   const {
     type,
     id: fieldId
   } = field;
 
-  if (!VALUES_INPUTS.includes(type)) {
+  const formFields = getService('formFields');
+
+  const fieldDefinition = formFields.get(type).config;
+
+  if (!VALUES_INPUTS.includes(type) && !hasValuesGroupsConfigured(fieldDefinition)) {
     return [];
   }
 

--- a/packages/form-js-editor/src/features/properties-panel/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/index.js
@@ -1,4 +1,5 @@
 import PropertiesPanelModule from './PropertiesPanelRenderer';
+import PropertiesProvider from './PropertiesProvider';
 
 import { FeelPopupModule } from '@bpmn-io/properties-panel';
 
@@ -6,6 +7,7 @@ export default {
   __depends__: [
     FeelPopupModule
   ],
-  __init__: [ 'propertiesPanel' ],
-  propertiesPanel: [ 'type', PropertiesPanelModule ]
+  __init__: [ 'propertiesPanel', 'propertiesProvider' ],
+  propertiesPanel: [ 'type', PropertiesPanelModule ],
+  propertiesProvider: [ 'type', PropertiesProvider ]
 };

--- a/packages/form-js-editor/src/index.js
+++ b/packages/form-js-editor/src/index.js
@@ -7,6 +7,17 @@ export {
   schemaVersion
 };
 
+export {
+  useDebounce,
+  usePrevious,
+  useService
+} from './render/hooks';
+
+export {
+  useService as usePropertiesPanelService,
+  useVariables
+} from './features/properties-panel/hooks';
+
 /**
  * @typedef { import('./types').CreateFormEditorOptions } CreateFormEditorOptions
  */

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -28,7 +28,7 @@ import { DragAndDropContext } from '../context';
 import { DeleteIcon, DraggableIcon } from './icons';
 
 import ModularSection from './ModularSection';
-import Palette, { PALETTE_ENTRIES } from '../../features/palette/components/Palette';
+import Palette, { collectPaletteEntries, getPaletteIcon } from '../../features/palette/components/Palette';
 import InjectedRendersRoot from '../../features/render-injection/components/InjectedRendersRoot';
 
 import { SlotFillRoot } from '../../features/render-injection/slot-fill';
@@ -50,8 +50,6 @@ import {
 } from './FieldResizer';
 
 import { set as setCursor, unset as unsetCursor } from '../util/Cursor';
-
-import { iconsByType } from './icons';
 
 function ContextPad(props) {
   if (!props.children) {
@@ -503,6 +501,8 @@ function CreatePreview(props) {
 
   const { drake } = useContext(DragAndDropContext);
 
+  const formFields = useService('formFields');
+
   function handleCloned(clone, original, type) {
 
     const fieldType = clone.dataset.fieldType;
@@ -510,9 +510,15 @@ function CreatePreview(props) {
     // (1) field preview
     if (fieldType) {
 
-      const { label } = findPaletteEntry(fieldType);
+      const paletteEntry = findPaletteEntry(fieldType, formFields);
 
-      const Icon = iconsByType(fieldType);
+      if (!paletteEntry) {
+        return;
+      }
+
+      const { label } = paletteEntry;
+
+      const Icon = getPaletteIcon(paletteEntry);
 
       clone.innerHTML = '';
 
@@ -567,8 +573,8 @@ function CreatePreview(props) {
 
 // helper //////
 
-function findPaletteEntry(type) {
-  return PALETTE_ENTRIES.find(entry => entry.type === type);
+function findPaletteEntry(type, formFields) {
+  return collectPaletteEntries(formFields).find(entry => entry.type === type);
 }
 
 function defaultPropertiesPanel(propertiesPanelConfig) {

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanelHeaderProvider.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanelHeaderProvider.spec.js
@@ -3,6 +3,8 @@ import {
   render
 } from '@testing-library/preact/pure';
 
+import { FormFields } from '@bpmn-io/form-js-viewer';
+
 import { PropertiesPanelHeaderProvider } from '../../../../src/features/properties-panel/PropertiesPanelHeaderProvider';
 
 import { WithPropertiesPanelContext, WithPropertiesPanel } from './helper';
@@ -58,6 +60,91 @@ describe('PropertiesPanelHeaderProvider', function() {
     expect(label.innerText).to.eql(field.label);
   });
 
+
+  describe('extension support', function() {
+
+    it('should render type label from config', function() {
+
+      // given
+      const extension = {
+        config: {
+          label: 'Custom label',
+          group: 'basic-input'
+        }
+      };
+
+      const formFields = new FormFields();
+
+      formFields.register('custom', extension);
+
+      const field = { type: 'custom' };
+
+      // when
+      const { container } = renderHeader({ field, formFields });
+
+      // then
+      const label = container.querySelector('.bio-properties-panel-header-type');
+
+      expect(label).to.exist;
+      expect(label.innerText).to.eql(extension.config.label.toUpperCase());
+    });
+
+
+    it('should render icon from config', function() {
+
+      // given
+      const extension = {
+        config: {
+          label: 'Custom label',
+          group: 'basic-input',
+          icon: () => <div class="custom-icon">Custom Icon</div>
+        }
+      };
+
+      const formFields = new FormFields();
+
+      formFields.register('custom', extension);
+
+      const field = { type: 'custom' };
+
+      // when
+      const { container } = renderHeader({ field, formFields });
+
+      // then
+      const customIcon = container.querySelector('.custom-icon');
+
+      expect(customIcon).to.exist;
+    });
+
+
+    it('should render iconUrl from config', function() {
+
+      // given
+      const extension = {
+        config: {
+          label: 'Custom label',
+          group: 'basic-input',
+          iconUrl: 'https://example.com/icon.png'
+        }
+      };
+
+      const formFields = new FormFields();
+
+      formFields.register('custom', extension);
+
+      const field = { type: 'custom' };
+
+      // when
+      const { container } = renderHeader({ field, formFields });
+
+      // then
+      const customIcon = container.querySelector('.fjs-field-icon-image');
+
+      expect(customIcon).to.exist;
+    });
+
+  });
+
 });
 
 
@@ -65,11 +152,14 @@ describe('PropertiesPanelHeaderProvider', function() {
 
 function renderHeader(options) {
   const {
-    field
+    field,
+    formFields
   } = options;
 
   return render(WithPropertiesPanelContext(WithPropertiesPanel({
     field,
     headerProvider: PropertiesPanelHeaderProvider
-  })));
+  }), {
+    formFields
+  }));
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanelModule.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanelModule.spec.js
@@ -47,7 +47,8 @@ describe('features/propertiesPanel', function() {
   async function createEditor(schema, options = {}) {
     const {
       additionalModules = [
-        propertiesPanelModule
+        propertiesPanelModule,
+        ...options.additionalModules || []
       ]
     } = options;
 
@@ -304,6 +305,81 @@ describe('features/propertiesPanel', function() {
       expect(feelPopup.open).to.exist;
       expect(feelPopup.close).to.exist;
       expect(feelPopup.isOpen).to.exist;
+    });
+
+  });
+
+
+  describe('providers', function() {
+
+    it('should register provider', async function() {
+
+      // given
+      const provider = {
+        getGroups() {
+          return () => [];
+        }
+      };
+
+      const { formEditor } = await createEditor(schema);
+
+      const propertiesPanel = formEditor.get('propertiesPanel');
+
+      // assume
+      expect(propertiesPanel._getProviders()).to.have.length(1);
+
+      // when
+      propertiesPanel.registerProvider(provider);
+
+      // then
+      expect(propertiesPanel._getProviders()).to.have.length(2);
+    });
+
+
+    it('should ignore incompatible provider', async function() {
+
+      // given
+      const incompatibleProvider = {};
+
+      const { formEditor } = await createEditor(schema);
+
+      const propertiesPanel = formEditor.get('propertiesPanel');
+
+      // assume
+      expect(propertiesPanel._getProviders()).to.have.length(1);
+
+      // when
+      propertiesPanel.registerProvider(incompatibleProvider);
+
+      // then
+      // incompatible provider was not added
+      expect(propertiesPanel._getProviders()).to.have.length(1);
+    });
+
+
+    it('should fire <propertiesPanel.providersChanged>', async function() {
+
+      // given
+      const provider = {
+        getGroups() {
+          return () => [];
+        }
+      };
+
+      const { formEditor } = await createEditor(schema);
+
+      const eventBus = formEditor.get('eventBus');
+
+      const propertiesPanel = formEditor.get('propertiesPanel');
+
+      const spy = sinon.spy();
+
+      // when
+      eventBus.on('propertiesPanel.providersChanged', spy);
+      propertiesPanel.registerProvider(provider);
+
+      // then
+      expect(spy).to.have.been.called;
     });
 
   });

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/AppearanceGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/AppearanceGroup.spec.js
@@ -20,10 +20,10 @@ describe('AppearanceGroup', function() {
     // given
     const field = { type: 'checkbox' };
 
-    const group = AppearanceGroup(field);
+    renderAppearanceGroup({ field });
 
     // then
-    expect(group).to.not.exist;
+    expect(findGroup('appearance', document.body)).to.not.exist;
   });
 
 
@@ -236,4 +236,8 @@ function findFeelers(id, container) {
 
 function findTextbox(id, container) {
   return container.querySelector(`[name=${id}] [role="textbox"]`);
+}
+
+function findGroup(id, container) {
+  return container.querySelector(`.bio-properties-panel-group [data-group-id="group-${id}"]`);
 }

--- a/packages/form-js-editor/test/spec/features/properties-panel/groups/SerializationGroup.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/groups/SerializationGroup.spec.js
@@ -21,8 +21,8 @@ describe('SerializationGroup', function() {
 
     // then
     for (const type of types) {
-      const group = SerializationGroup({ type }, () => {});
-      expect(group).to.be.null;
+      renderSerializationGroup({ field : { type } });
+      expect(findGroup('serialization', document.body)).to.be.null;
     }
   });
 
@@ -32,8 +32,8 @@ describe('SerializationGroup', function() {
     const field = { type: 'datetime', subtype: 'date' };
 
     // then
-    const group = SerializationGroup(field, () => { });
-    expect(group).to.be.null;
+    renderSerializationGroup({ field });
+    expect(findGroup('serialization', document.body)).to.be.null;
   });
 
 
@@ -198,4 +198,8 @@ function findInput(id, container) {
 
 function findSelect(id, container) {
   return container.querySelector(`select[name="${id}"]`);
+}
+
+function findGroup(id, container) {
+  return container.querySelector(`.bio-properties-panel-group [data-group-id="group-${id}"]`);
 }

--- a/packages/form-js-playground/karma.conf.js
+++ b/packages/form-js-playground/karma.conf.js
@@ -1,3 +1,9 @@
+const path = require('path');
+
+const {
+  NormalModuleReplacementPlugin
+} = require('webpack');
+
 const coverage = process.env.COVERAGE;
 
 // configures browsers to run test against
@@ -64,6 +70,10 @@ module.exports = function(karma) {
             ]
           },
           {
+            test: /\.svg$/,
+            use: [ '@svgr/webpack' ]
+          },
+          {
             test: /\.m?js$/,
             exclude: /node_modules/,
             use: {
@@ -90,6 +100,30 @@ module.exports = function(karma) {
           }
         ]
       },
+      plugins: [
+        new NormalModuleReplacementPlugin(
+          /^(..\/preact|preact)(\/[^/]+)?$/,
+          function(resource) {
+
+            const replMap = {
+              'preact/hooks': path.resolve('../../node_modules/preact/hooks/dist/hooks.module.js'),
+              'preact/jsx-runtime': path.resolve('../../node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js'),
+              'preact': path.resolve('../../node_modules/preact/dist/preact.module.js'),
+              '../preact/hooks': path.resolve('../../node_modules/preact/hooks/dist/hooks.module.js'),
+              '../preact/jsx-runtime': path.resolve('../../node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js'),
+              '../preact': path.resolve('../../node_modules/preact/dist/preact.module.js')
+            };
+
+            const replacement = replMap[resource.request];
+
+            if (!replacement) {
+              return;
+            }
+
+            resource.request = replacement;
+          }
+        ),
+      ],
       devtool: 'eval-source-map'
     }
   };

--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -12,6 +12,7 @@ import { PlaygroundRoot } from './components/PlaygroundRoot';
  *
  * @typedef { {
  *  actions?: { display: Boolean }
+ *  additionalModules?: Array<any>
  *  container?: Element
  *  data: any
  *  editor?: { inlinePropertiesPanel: Boolean }

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -25,6 +25,7 @@ import './PlaygroundRoot.css';
 export function PlaygroundRoot(props) {
 
   const {
+    additionalModules = [], // goes into both editor + viewer
     actions: actionsConfig = {},
     emit,
     exporter: exporterConfig = {},
@@ -101,7 +102,10 @@ export function PlaygroundRoot(props) {
     });
 
     const form = formRef.current = new Form({
-      additionalModules: viewerAdditionalModules,
+      additionalModules: [
+        ...additionalModules,
+        ...viewerAdditionalModules
+      ],
       properties: {
         ...viewerProperties,
         'ariaLabel': 'Form Preview'
@@ -124,7 +128,10 @@ export function PlaygroundRoot(props) {
         ...editorProperties,
         'ariaLabel': 'Form Definition'
       },
-      additionalModules: editorAdditionalModules
+      additionalModules: [
+        ...additionalModules,
+        ...editorAdditionalModules
+      ]
     });
 
     paletteRef.current = formEditor.get('palette');

--- a/packages/form-js-playground/test/custom/editor.js
+++ b/packages/form-js-playground/test/custom/editor.js
@@ -1,0 +1,152 @@
+import { get, set } from 'min-dash';
+
+import {
+  NumberFieldEntry,
+  isNumberFieldEntryEdited
+} from '@bpmn-io/properties-panel';
+
+
+class CustomPropertiesProvider {
+  constructor(propertiesPanel) {
+    propertiesPanel.registerProvider(this, 500);
+  }
+
+  getGroups(field, editField) {
+    return (groups) => {
+
+      if (field.type !== 'range') {
+        return groups;
+      }
+
+      const generalIdx = findGroupIdx(groups, 'general');
+
+      groups.splice(generalIdx + 1, 0, {
+        id: 'range',
+        label: 'Range',
+        entries: RangeEntries(field, editField)
+      });
+
+      return groups;
+    };
+  }
+}
+
+CustomPropertiesProvider.$inject = [ 'propertiesPanel' ];
+
+function RangeEntries(field, editField) {
+
+  const onChange = (key) => {
+    return (value) => {
+      const range = get(field, [ 'range' ], {});
+
+      editField(field, [ 'range' ], set(range, [ key ], value));
+    };
+  };
+
+  const getValue = (key) => {
+    return () => {
+      return get(field, [ 'range', key ]);
+    };
+  };
+
+  return [
+    {
+      id: 'range-min',
+      component: Min,
+      getValue,
+      field,
+      isEdited: isNumberFieldEntryEdited,
+      onChange
+    },
+    {
+      id: 'range-max',
+      component: Max,
+      getValue,
+      field,
+      isEdited: isNumberFieldEntryEdited,
+      onChange
+    },
+    {
+      id: 'range-step',
+      component: Step,
+      getValue,
+      field,
+      isEdited: isNumberFieldEntryEdited,
+      onChange
+    }
+  ];
+
+}
+
+function Min(props) {
+  const {
+    field,
+    getValue,
+    id,
+    onChange
+  } = props;
+
+  const debounce = (fn) => fn;
+
+  return NumberFieldEntry({
+    debounce,
+    element: field,
+    getValue: getValue('min'),
+    id,
+    label: 'Minimum',
+    setValue: onChange('min')
+  });
+}
+
+function Max(props) {
+  const {
+    field,
+    getValue,
+    id,
+    onChange
+  } = props;
+
+  const debounce = (fn) => fn;
+
+  return NumberFieldEntry({
+    debounce,
+    element: field,
+    getValue: getValue('max'),
+    id,
+    label: 'Maximum',
+    setValue: onChange('max')
+  });
+}
+
+function Step(props) {
+  const {
+    field,
+    getValue,
+    id,
+    onChange
+  } = props;
+
+  const debounce = (fn) => fn;
+
+  return NumberFieldEntry({
+    debounce,
+    element: field,
+    getValue: getValue('step'),
+    id,
+    min: 0,
+    label: 'Step',
+    setValue: onChange('step')
+  });
+}
+
+
+export default {
+  __init__: [ 'customPropertiesProvider' ],
+  customPropertiesProvider: [ 'type', CustomPropertiesProvider ]
+};
+
+// helper //////////////////////
+
+function findGroupIdx(groups, id) {
+  return groups.findIndex(g => g.id === id);
+}

--- a/packages/form-js-playground/test/custom/range.svg
+++ b/packages/form-js-playground/test/custom/range.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 72 72" id="emoji" xmlns="http://www.w3.org/2000/svg">
+  <g id="color"/>
+  <g id="hair"/>
+  <g id="skin"/>
+  <g id="skin-shadow"/>
+  <g id="line">
+    <line x1="8.0416" x2="64.0416" y1="29" y2="29" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <line x1="8.0416" x2="8.0416" y1="26" y2="34" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <line x1="64.0416" x2="64.0416" y1="26" y2="34" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <line x1="36.0416" x2="36.0416" y1="26" y2="34" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <line x1="22.0416" x2="22.0416" y1="26" y2="32" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <line x1="50.0416" x2="50.0416" y1="26" y2="32" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M8.0085,45.9053L8.0085,45.9053c-1.0579,0-1.9155-0.8576-1.9155-1.9155v-3.1689c0-1.0579,0.8576-1.9156,1.9155-1.9156l0,0 c1.058,0,1.9156,0.8577,1.9156,1.9156v3.1689C9.9241,45.0477,9.0665,45.9053,8.0085,45.9053z"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M61.8334,40.6119c0.2005-0.9798,1.0674-1.7169,2.1065-1.7169l0,0c0.5937,0,1.1313,0.2407,1.5204,0.6298 c0.6053,0.6053,0.5494,1.6111-0.0185,2.2515l-3.6521,4.1187h4.3004"/>
+    <polyline fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="35.1209,40.4123 37.0588,38.9605 37.0588,45.9605"/>
+  </g>
+</svg>

--- a/packages/form-js-playground/test/custom/styles.css
+++ b/packages/form-js-playground/test/custom/styles.css
@@ -1,0 +1,4 @@
+.range-group {
+  display: flex;
+  flex-direction: row;
+}

--- a/packages/form-js-playground/test/custom/viewer.js
+++ b/packages/form-js-playground/test/custom/viewer.js
@@ -1,0 +1,122 @@
+
+import {
+  Errors,
+  FormContext,
+  Numberfield,
+  Description,
+  Label
+} from '@bpmn-io/form-js-viewer';
+
+import { useContext } from 'preact/hooks';
+
+import classNames from 'classnames';
+
+import RangeIcon from './range.svg';
+
+const rangeType = 'range';
+
+function RangeRenderer(props) {
+
+  const {
+    disabled,
+    errors = [],
+    field,
+    readonly,
+    value
+  } = props;
+
+  const {
+    description,
+    range = {},
+    id,
+    label
+  } = field;
+
+  const {
+    min,
+    max,
+    step
+  } = range;
+
+  const { formId } = useContext(FormContext);
+
+  const errorMessageId = errors.length === 0 ? undefined : `${prefixId(id, formId)}-error-message`;
+
+  const onChange = ({ target }) => {
+    props.onChange({
+      field,
+      value: Number(target.value)
+    });
+  };
+
+  return <div class={ formFieldClasses(rangeType) }>
+    <Label
+      id={ prefixId(id, formId) }
+      label={ label } />
+    <div class="range-group">
+      <input
+        type="range"
+        disabled={ disabled }
+        id={ prefixId(id, formId) }
+        max={ max }
+        min={ min }
+        onInput={ onChange }
+        readOnly={ readonly }
+        value={ value }
+        step={ step } />
+      <div class="range-value">{ value }</div>
+    </div>
+    <Description description={ description } />
+    <Errors errors={ errors } id={ errorMessageId } />
+  </div>;
+}
+
+RangeRenderer.config = {
+  ...Numberfield.config,
+  type: rangeType,
+  keyed: true,
+  label: 'Range',
+  group: 'basic-input',
+  propertiesPanelEntries: [
+    'key',
+    'label',
+    'description',
+    'min',
+    'max'
+  ],
+  icon: RangeIcon
+};
+
+class CustomFormFields {
+  constructor(formFields) {
+    formFields.register(rangeType, RangeRenderer);
+  }
+}
+
+export default {
+  __init__: [ 'customFormFields' ],
+  customFormFields: [ 'type', CustomFormFields ]
+};
+
+
+// helper //////////////////////
+
+function formFieldClasses(type, { errors = [], disabled = false, readonly = false } = {}) {
+  if (!type) {
+    throw new Error('type required');
+  }
+
+  return classNames('fjs-form-field', `fjs-form-field-${type}`, {
+    'fjs-has-errors': errors.length > 0,
+    'fjs-disabled': disabled,
+    'fjs-readonly': readonly
+  });
+}
+
+function prefixId(id, formId) {
+  if (formId) {
+    return `fjs-form-${ formId }-${ id }`;
+  }
+
+  return `fjs-form-${ id }`;
+}

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -17,6 +17,11 @@ import {
 import schema from './form.json';
 import otherSchema from './other-form.json';
 import rowsSchema from './rows-form.json';
+import customSchema from './custom.json';
+
+import customViewerModule from '../custom/viewer';
+import customEditorModule from '../custom/editor';
+import customStyles from '../custom/styles.css';
 
 import {
   insertCSS,
@@ -32,9 +37,12 @@ insertCSS('Test.css', `
   }
 `);
 
+insertCSS('custom.css', customStyles);
+
 const singleStartBasic = isSingleStart('basic');
 const singleStartRows = isSingleStart('rows');
-const singleStart = singleStartBasic || singleStartRows;
+const singleStartCustom = isSingleStart('custom');
+const singleStart = singleStartBasic || singleStartRows || singleStartCustom;
 
 
 describe('playground', function() {
@@ -125,6 +133,33 @@ describe('playground', function() {
     // then
     expect(playground).to.exist;
 
+  });
+
+
+  (singleStartCustom ? it.only : it)('should support custom element', async function() {
+
+    // given
+    const data = {
+      creditor: 'John Doe Company',
+      amount: 25
+    };
+
+    // when
+    // viewer and editor
+    playground = new Playground({
+      container,
+      schema: customSchema,
+      data,
+      additionalModules: [
+        customViewerModule
+      ],
+      editorAdditionalModules: [
+        customEditorModule
+      ]
+    });
+
+    // then
+    expect(playground).to.exist;
   });
 
 

--- a/packages/form-js-playground/test/spec/custom.json
+++ b/packages/form-js-playground/test/spec/custom.json
@@ -1,0 +1,28 @@
+{
+  "components": [
+    {
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "key": "amount",
+      "type": "range",
+      "label": "Amount",
+      "range": {
+        "min": 0,
+        "max": 100,
+        "step": 5
+      }
+    },
+    {
+      "type": "button",
+      "action": "submit",
+      "label": "Submit"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js-viewer/src/render/components/index.js
+++ b/packages/form-js-viewer/src/render/components/index.js
@@ -17,6 +17,16 @@ import Text from './form-fields/Text';
 import Textfield from './form-fields/Textfield';
 import Textarea from './form-fields/Textarea';
 
+import Label from './Label';
+import Description from './Description';
+import Errors from './Errors';
+
+export {
+  Label,
+  Description,
+  Errors
+};
+
 export {
   Button,
   Checkbox,
@@ -58,3 +68,4 @@ export const formFields = [
 ];
 
 export * from './icons';
+export * from './Sanitizer';

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -26,6 +26,7 @@ import textTemplateSchema from './text-template.json';
 import stress from './stress.json';
 import rowsSchema from './rows.json';
 import focusables from './focusables.json';
+import customFieldSchema from './customField.json';
 
 import {
   insertCSS,
@@ -44,14 +45,15 @@ const singleStartStress = isSingleStart('stress');
 const singleStartRows = isSingleStart('rows');
 const singleStartTheme = isSingleStart('theme');
 const singleStartNoTheme = isSingleStart('no-theme');
-
+const singleStartCustom = isSingleStart('custom');
 const singleStart =
   singleStartBasic ||
   singleStartGroups ||
   singleStartStress ||
   singleStartRows ||
   singleStartTheme ||
-  singleStartNoTheme;
+  singleStartNoTheme ||
+  singleStartCustom;
 
 describe('Form', function() {
 
@@ -958,33 +960,31 @@ describe('Form', function() {
   });
 
 
-  it('should be customizable', async function() {
+  (singleStartCustom ? it.only : it)('should be customizable', async function() {
 
     // given
     const data = {
       creditor: 'John Doe Company',
-      amount: 456,
-      invoiceNumber: 'C-123',
-      approved: true,
-      approvedBy: 'John Doe',
-      mailto: [ 'regional-manager', 'approver' ],
-      product: 'camunda-cloud',
-      tags: [ 'tag1', 'tag2', 'tag3' ],
-      language: 'english'
+      amount: 25
     };
 
     // when
-    await createForm({
+    const form = await createForm({
       container,
       data,
-      schema,
+      schema: customFieldSchema,
       additionalModules: [
         customButtonModule
       ]
     });
 
+    form.on('changed', event => {
+      console.log('Form <changed>', event);
+    });
+
     // then
     expect(document.querySelector('.custom-button')).to.exist;
+    expect(document.querySelector('.fjs-form-field-range')).to.exist;
   });
 
 

--- a/packages/form-js-viewer/test/spec/custom/index.js
+++ b/packages/form-js-viewer/test/spec/custom/index.js
@@ -1,6 +1,16 @@
-import { formFieldClasses } from '../../../src/render/components/Util';
+import {
+  formFieldClasses,
+  prefixId
+} from '../../../src/render/components/Util';
 
-const type = 'button';
+import { Numberfield, Button } from '../../../src';
+
+import { FormContext } from '../../../src/render/context';
+
+import { useContext } from 'preact/hooks';
+
+const btnType = Button.config.type;
+const rangeType = 'range';
 
 function CustomButton(props) {
   const {
@@ -10,29 +20,75 @@ function CustomButton(props) {
 
   const { action = 'submit' } = field;
 
-  return <div class={ formFieldClasses(type) }>
+  return <div class={ formFieldClasses(btnType) }>
     <button class="fjs-button custom-button" type={ action } disabled={ disabled }>{ field.label }</button>
   </div>;
 }
 
 CustomButton.config = {
-  type,
-  keyed: true,
+  ...Button.config,
   label: 'Custom Button',
-  group: 'action',
   create: (options = {}) => ({
     action: 'submit',
     ...options
   })
 };
 
-class CustomButtonRegistrer {
+function Range(props) {
+
+  const {
+    field,
+    value
+  } = props;
+
+  const {
+    min,
+    max,
+    step,
+    id,
+    label
+  } = field;
+
+  const { formId } = useContext(FormContext);
+
+  const onChange = ({ target }) => {
+    props.onChange({
+      field,
+      value: Number(target.value)
+    });
+  };
+
+  return <div class={ formFieldClasses(rangeType) }>
+    <label class="fjs-form-field-label" for={ prefixId(id, formId) }>
+      { label }
+    </label>
+    <input
+      type="range"
+      id={ prefixId(id, formId) }
+      onInput={ onChange }
+      min={ min }
+      max={ max }
+      value={ value }
+      step={ step } />
+  </div>;
+}
+
+Range.config = {
+  ...Numberfield.config,
+  type: rangeType,
+  keyed: true,
+  label: 'Range',
+  group: 'basic-input'
+};
+
+class CustomFormFields {
   constructor(formFields) {
-    formFields.register(type, CustomButton);
+    formFields.register(btnType, CustomButton);
+    formFields.register(rangeType, Range);
   }
 }
 
 export default {
-  __init__: [ 'customButtonRegisterer' ],
-  customButtonRegisterer: [ 'type', CustomButtonRegistrer ]
+  __init__: [ 'customFormFields' ],
+  customFormFields: [ 'type', CustomFormFields ]
 };

--- a/packages/form-js-viewer/test/spec/customField.json
+++ b/packages/form-js-viewer/test/spec/customField.json
@@ -1,0 +1,26 @@
+{
+  "components": [
+    {
+      "key": "creditor",
+      "label": "Creditor",
+      "type": "textfield",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "key": "amount",
+      "type": "range",
+      "label": "Amount",
+      "min": 0,
+      "max": 100,
+      "step": 5
+    },
+    {
+      "type": "button",
+      "action": "submit",
+      "label": "Submit"
+    }
+  ],
+  "type": "default"
+}

--- a/packages/form-js/CHANGELOG.md
+++ b/packages/form-js/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to [form-js](https://github.com/bpmn-io/form-js) are documen
 
 ___Note:__ Yet to be released changes appear here._
 
+### General 
+
+* `FEAT`: support custom form fields ([#123](https://github.com/bpmn-io/form-js/issues/123))
+
+### Viewer
+
+* `FEAT`: provide more customization options, as of ([#776](https://github.com/bpmn-io/form-js/pull/776))
+  * extending form field config via `icon`, `iconUrl`, `propertiesPanelEntries`
+  * re-export core components as `Label`, `Description`, `Errors`
+
+### Editor
+
+* `FEAT`: add properties panel providers mechanism ([#776](https://github.com/bpmn-io/form-js/pull/776))
+* `FEAT`: collect palette entries and properties panel header information via form field configs ([#776](https://github.com/bpmn-io/form-js/pull/776))
+* `FEAT`: add `isDefaultVisible` control to all properties panel entries ([#776](https://github.com/bpmn-io/form-js/pull/776))
+* `FEAT`: re-export hooks
+
+### Playground
+
+`FEAT`: provide `additionalModules` to both viewer and editor ([#776](https://github.com/bpmn-io/form-js/pull/776))
+
 ## 1.3.2
 
 ### Viewer

--- a/packages/form-js/src/editor.js
+++ b/packages/form-js/src/editor.js
@@ -1,5 +1,1 @@
-export {
-  createFormEditor,
-  FormEditor,
-  schemaVersion
-} from '@bpmn-io/form-js-editor';
+export * from '@bpmn-io/form-js-editor';

--- a/packages/form-js/src/index.js
+++ b/packages/form-js/src/index.js
@@ -1,3 +1,3 @@
 export * from './viewer';
-export { createFormEditor, FormEditor } from './editor';
+export * from './editor';
 export * from './playground';

--- a/packages/form-js/src/viewer.js
+++ b/packages/form-js/src/viewer.js
@@ -1,6 +1,1 @@
-export {
-  createForm,
-  Form,
-  schemaVersion,
-  getSchemaVariables
-} from '@bpmn-io/form-js-viewer';
+export * from '@bpmn-io/form-js-viewer';


### PR DESCRIPTION
Related to https://github.com/camunda/team-hto/issues/299
Closes https://github.com/bpmn-io/form-js/issues/123

This adds more extension capabilities by

#### Viewer
* Extending form field config via `icon`, `iconUrl`, `propertiesPanelEntries`
* Re-export more core components as `Label`, `Description`, `Errors` 

#### Editor
* Collect palette entries and properties panel header information via form field configs
* Support custom properties panel extensions
  * Mirror `bpmn-js-properties-panel` API, [example](https://github.com/bpmn-io/bpmn-js-examples/tree/master/properties-panel-extension)
  * Add default properties panel provider
* Add `isDefaultVisible` control to all properties panel entries
* Re-export `hooks`

##### Playground
* Make it possible to provide extensions to both editor and viewer together via `additionalModules`

Gather [the example extension](https://github.com/bpmn-io/form-js/tree/spike-custom-form-elements/packages/form-js-playground/test/custom) for more information.

Check out [the demo environment](https://github.com/bpmn-io/form-js/issues/123#issuecomment-1723356618) to play around with custom components in a Sandbox.