### PR TITLE
Allow defining FEEL Popup container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/core": "^7.18.10",
         "@babel/plugin-transform-react-jsx": "^7.14.5",
         "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-        "@bpmn-io/properties-panel": "^3.3.1",
+        "@bpmn-io/properties-panel": "^3.5.0",
         "@carbon/react": "^1.24.0",
         "@carbon/styles": "^1.23.1",
         "@playwright/test": "1.37.1",
@@ -2236,9 +2236,9 @@
       "link": true
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.3.1.tgz",
-      "integrity": "sha512-GMOKYA04m8XrvzYi0wl7wh/N4zL7LJmrZNuJCZ2ZYJTuWpt8tIBwYIkFE4IzNpbXFGJoUcN7Y1QOdkKArJVMvw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.5.0.tgz",
+      "integrity": "sha512-cPGwPoIpOOzDRXc3SM64FRulLkpBQQ65N+HcYNCeyAqnV80QUi9rUJynP5/KBPa2WFRDxeEAMJ8A0MrA7nzPIA==",
       "dependencies": {
         "@bpmn-io/feel-editor": "^0.9.0",
         "@codemirror/view": "^6.14.0",
@@ -20534,7 +20534,7 @@
       "dependencies": {
         "@bpmn-io/draggle": "^4.0.0",
         "@bpmn-io/form-js-viewer": "^1.3.0-alpha.0",
-        "@bpmn-io/properties-panel": "^3.3.1",
+        "@bpmn-io/properties-panel": "^3.5.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
         "ids": "^1.0.0",
@@ -22175,7 +22175,7 @@
       "requires": {
         "@bpmn-io/draggle": "^4.0.0",
         "@bpmn-io/form-js-viewer": "^1.3.0-alpha.0",
-        "@bpmn-io/properties-panel": "^3.3.1",
+        "@bpmn-io/properties-panel": "^3.5.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
         "ids": "^1.0.0",
@@ -22277,9 +22277,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.3.1.tgz",
-      "integrity": "sha512-GMOKYA04m8XrvzYi0wl7wh/N4zL7LJmrZNuJCZ2ZYJTuWpt8tIBwYIkFE4IzNpbXFGJoUcN7Y1QOdkKArJVMvw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.5.0.tgz",
+      "integrity": "sha512-cPGwPoIpOOzDRXc3SM64FRulLkpBQQ65N+HcYNCeyAqnV80QUi9rUJynP5/KBPa2WFRDxeEAMJ8A0MrA7nzPIA==",
       "requires": {
         "@bpmn-io/feel-editor": "^0.9.0",
         "@codemirror/view": "^6.14.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/core": "^7.18.10",
     "@babel/plugin-transform-react-jsx": "^7.14.5",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
-    "@bpmn-io/properties-panel": "^3.3.1",
+    "@bpmn-io/properties-panel": "^3.5.0",
     "@carbon/react": "^1.24.0",
     "@carbon/styles": "^1.23.1",
     "@playwright/test": "1.37.1",

--- a/packages/form-js-editor/assets/index.scss
+++ b/packages/form-js-editor/assets/index.scss
@@ -1,3 +1,3 @@
 @use 'form-js-editor-base.css';
 @use '@bpmn-io/draggle/dist/dragula.css';
-@use '@bpmn-io/properties-panel/assets/properties-panel.css';
+@use '@bpmn-io/properties-panel/dist/assets/properties-panel.css';

--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@bpmn-io/draggle": "^4.0.0",
     "@bpmn-io/form-js-viewer": "^1.3.0-alpha.0",
-    "@bpmn-io/properties-panel": "^3.3.1",
+    "@bpmn-io/properties-panel": "^3.5.0",
     "array-move": "^3.0.1",
     "big.js": "^6.2.1",
     "ids": "^1.0.0",

--- a/packages/form-js-editor/rollup.config.js
+++ b/packages/form-js-editor/rollup.config.js
@@ -70,7 +70,7 @@ export default [
         targets: [
           { src: 'assets/form-js-editor-base.css', dest: 'dist/assets' },
           { src: '../../node_modules/@bpmn-io/draggle/dist/dragula.css', dest: 'dist/assets' },
-          { src: '../../node_modules/@bpmn-io/properties-panel/assets/properties-panel.css', dest: 'dist/assets' }
+          { src: '../../node_modules/@bpmn-io/properties-panel/dist/assets/properties-panel.css', dest: 'dist/assets' }
         ]
       })
     ])

--- a/packages/form-js-editor/src/features/properties-panel/PropertiesPanel.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesPanel.js
@@ -54,6 +54,11 @@ export default function FormPropertiesPanel(props) {
   const formEditor = injector.get('formEditor');
   const modeling = injector.get('modeling');
   const selectionModule = injector.get('selection');
+  const propertiesPanelConfig = injector.get('config.propertiesPanel') || {};
+
+  const {
+    feelPopupContainer
+  } = propertiesPanelConfig;
 
   const [ state , setState ] = useState({ selectedFormField: selectionModule.get() || formEditor._getState().schema });
 
@@ -114,6 +119,7 @@ export default function FormPropertiesPanel(props) {
           groups={ getGroups(selectedFormField, editField, getService) }
           headerProvider={ PropertiesPanelHeaderProvider }
           placeholderProvider={ PropertiesPanelPlaceholderProvider }
+          feelPopupContainer={ feelPopupContainer }
         />
       </FormPropertiesPanelContext.Provider>
     </div>

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -3703,6 +3703,41 @@ describe('properties panel', function() {
 
   });
 
+
+  describe('feel popup', function() {
+
+    it('should render feel popup in given container', async function() {
+
+      // given
+      const editFieldSpy = spy();
+
+      const field = schema.components.find(({ source }) => source === '=logo');
+
+      createPropertiesPanel({
+        container,
+        editField: editFieldSpy,
+        field,
+        propertiesPanelConfig: {
+          feelPopupContainer: container
+        }
+      });
+
+      const openPopupBtn = findOpenFeelPopup('source', container);
+
+      // when
+      await act(() => {
+        fireEvent.click(openPopupBtn);
+      });
+
+      const feelPopup = domQuery('.bio-properties-panel-feel-popup', container);
+
+      // then
+      expect(feelPopup).to.exist;
+      expect(feelPopup.parentNode).to.eql(container);
+    });
+
+  });
+
 });
 
 
@@ -3830,6 +3865,10 @@ function findEntries(container, groupLabel, entryLabel) {
 
 function findFeelers(id, container) {
   return container.querySelector(`[data-entry-id="${id}"] .bio-properties-panel-feelers-editor`);
+}
+
+function findOpenFeelPopup(id, container) {
+  return container.querySelector(`[data-entry-id="${id}"] .bio-properties-panel-open-feel-popup`);
 }
 
 function findTextbox(id, container) {

--- a/packages/form-js-editor/test/spec/features/properties-panel/helper/index.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/helper/index.js
@@ -169,6 +169,10 @@ export class Injector {
     if (type === 'pathRegistry') {
       return this._options.pathRegistry || new PathRegistry();
     }
+
+    if (type === 'config.propertiesPanel') {
+      return this._options.propertiesPanelConfig || {};
+    }
   }
 }
 

--- a/packages/form-js-playground/src/Playground.js
+++ b/packages/form-js-playground/src/Playground.js
@@ -7,13 +7,21 @@ import mitt from 'mitt';
 import { PlaygroundRoot } from './components/PlaygroundRoot';
 
 /**
+ * @typedef { import('@bpmn-io/form-js-viewer/dist/types/types').FormProperties } FormProperties
+ * @typedef { import('@bpmn-io/form-js-editor/dist/types/types').FormEditorProperties } FormEditorProperties
+ *
  * @typedef { {
  *  actions?: { display: Boolean }
  *  container?: Element
  *  data: any
  *  editor?: { inlinePropertiesPanel: Boolean }
+ *  editorAdditionalModules?: Array<any>
+ *  editorProperties?: FormEditorProperties
  *  exporter?: { name: String, version: String }
+ *  propertiesPanel?: { parent: Element, feelPopupContainer: Element }
  *  schema: any
+ *  viewerAdditionalModules?: Array<any>
+ *  viewerProperties?: FormProperties
  * } } FormPlaygroundOptions
  */
 

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -31,7 +31,8 @@ export function PlaygroundRoot(props) {
     viewerProperties = {},
     editorProperties = {},
     viewerAdditionalModules = [],
-    editorAdditionalModules = []
+    editorAdditionalModules = [],
+    propertiesPanel: propertiesPanelConfig = {}
   } = props;
 
   const {
@@ -115,7 +116,8 @@ export function PlaygroundRoot(props) {
         parent: paletteContainerRef.current
       },
       propertiesPanel: {
-        parent: propertiesPanelContainerRef.current
+        parent: propertiesPanelContainerRef.current,
+        ...propertiesPanelConfig
       },
       exporter: exporterConfig,
       properties: {


### PR DESCRIPTION
Depends on https://github.com/bpmn-io/properties-panel/pull/280
Related to https://github.com/camunda/team-hto/issues/344
Required by https://github.com/camunda/form-playground/pull/101

This allows to provide a feel popup container via config.

```js
new FormPlayground({
  data,
  schema,
  propertiesPanel: {
    feelPopupContainer: rootRef.current
  },
});
```

Demo: https://feel-popup-root--camunda-form-playground.netlify.app/