### PR TITLE
WCAG 2.1 AA rule sets

### DIFF
--- a/e2e/test-fixtures.js
+++ b/e2e/test-fixtures.js
@@ -5,6 +5,8 @@ const DEFAULT_AXE_TAGS = [
   'best-practice',
   'wcag2a',
   'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
   'cat.semantics',
   'cat.forms'
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@types/node": "^20.6.3",
         "@types/sinon": "^10.0.0",
         "@types/sinon-chai": "^3.2.5",
-        "axe-core": "4.4.3",
+        "axe-core": "^4.8.2",
         "babel-loader": "^9.0.0",
         "babel-plugin-istanbul": "^6.1.1",
         "chai": "^4.3.5",
@@ -96,15 +96,6 @@
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
-      }
-    },
-    "node_modules/@axe-core/playwright/node_modules/axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/cli": {
@@ -7480,9 +7471,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
-      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -20724,14 +20715,6 @@
       "dev": true,
       "requires": {
         "axe-core": "^4.7.0"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "4.7.2",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-          "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
-          "dev": true
-        }
       }
     },
     "@babel/cli": {
@@ -26042,9 +26025,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
-      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",
+      "integrity": "sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==",
       "dev": true
     },
     "axios": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/node": "^20.6.3",
     "@types/sinon": "^10.0.0",
     "@types/sinon-chai": "^3.2.5",
-    "axe-core": "4.4.3",
+    "axe-core": "^4.8.2",
     "babel-loader": "^9.0.0",
     "babel-plugin-istanbul": "^6.1.1",
     "chai": "^4.3.5",

--- a/packages/form-js-viewer/test/helper/index.js
+++ b/packages/form-js-viewer/test/helper/index.js
@@ -27,6 +27,8 @@ const DEFAULT_AXE_RULES = [
   'best-practice',
   'wcag2a',
   'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
   'cat.semantics',
   'cat.forms'
 ];

--- a/packages/form-js-viewer/test/spec/render/components/Description.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/Description.spec.js
@@ -100,13 +100,24 @@ describe('Description', function() {
       // given
       this.timeout(5000);
 
-      const { container } = createDescription({
-        id: 'foo',
-        description: 'Foo'
-      });
+      // @Note(pinussilvestrus): we need to render a bit more here as
+      // Firefox + Ubuntu has problems with the description element on its own
+      // cf. https://github.com/bpmn-io/form-js/pull/824
+      const result =
+        render(WithFormContext(
+          <>
+            <label for="foo">Foo</label>
+            <input id="foo" />
+            <Description
+              id="foo"
+              description="This a description" />
+          </>
+        ), {
+          container
+        });
 
       // then
-      await expectNoViolations(container);
+      await expectNoViolations(result.container);
     });
 
   });


### PR DESCRIPTION
Related to https://github.com/camunda/team-hto/issues/360

Add `wcag21a` and `wcag21aa` rule sets to our a11y test setup.

Context: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md#wcag-21-level-a--aa-rules