### PR TITLE
fix(viewer): clean up errors for hidden fields

### DIFF
--- a/packages/form-js-viewer/src/features/expression-language/ConditionChecker.js
+++ b/packages/form-js-viewer/src/features/expression-language/ConditionChecker.js
@@ -19,10 +19,16 @@ export default class ConditionChecker {
    *
    * @param {Object<string, any>} properties
    * @param {Object<string, any>} data
+   * @param {Object} [options]
+   * @param {Function} [options.getFilterPath]
    */
-  applyConditions(properties, data = {}) {
+  applyConditions(properties, data = {}, options = {}) {
 
     const newProperties = clone(properties);
+
+    const {
+      getFilterPath = (field) => this._pathRegistry.getValuePath(field)
+    } = options;
 
     const form = this._formFieldRegistry.getAll().find((field) => field.type === 'default');
 
@@ -37,8 +43,7 @@ export default class ConditionChecker {
 
       // only clear the leaf nodes, as groups may both point to the same path
       if (context.isHidden && isClosed) {
-        const valuePath = this._pathRegistry.getValuePath(field);
-        this._clearObjectValueRecursively(valuePath, newProperties);
+        this._clearObjectValueRecursively(getFilterPath(field), newProperties);
       }
     });
 

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -14,6 +14,7 @@ import { spy } from 'sinon';
 import customButtonModule from './custom';
 
 import conditionSchema from './condition.json';
+import conditionErrorsSchema from './condition-errors.json';
 import hiddenFieldsConditionalSchema from './hidden-fields-conditional.json';
 import hiddenFieldsExpressionSchema from './hidden-fields-expression.json';
 import disabledSchema from './disabled.json';
@@ -581,23 +582,48 @@ describe('Form', function() {
   });
 
 
-  it('#validate', async function() {
+  describe('#validate', function() {
 
-    // given
-    const form = await createForm({
-      container,
-      schema
+    it('should add errors', async function() {
+
+      // given
+      const form = await createForm({
+        container,
+        schema
+      });
+
+      // when
+      const errors = form.validate();
+
+      // then
+      expect(errors).to.eql({
+        Creditor_ID: [
+          'Field is required.'
+        ]
+      });
     });
 
-    // when
-    const errors = form.validate();
 
-    // then
-    expect(errors).to.eql({
-      Creditor_ID: [
-        'Field is required.'
-      ]
+    it('should NOT add errors for hidden fields', async function() {
+
+      // given
+      const initialData = {
+        checkbox_4u82gk: true
+      };
+
+      const form = await createForm({
+        container,
+        data: initialData,
+        schema: conditionErrorsSchema
+      });
+
+      // when
+      const errors = form.validate();
+
+      // then
+      expect(errors).to.be.empty;
     });
+
   });
 
 
@@ -1294,6 +1320,29 @@ describe('Form', function() {
 
       // then
       expect(data).not.to.have.property('text');
+    });
+
+
+    it('should NOT submit errors for hidden fields', async function() {
+
+      // given
+      const initialData = {
+        checkbox_4u82gk: true
+      };
+
+      const form = await createForm({
+        container,
+        data: initialData,
+        schema: conditionErrorsSchema
+      });
+
+      // when
+      const { errors } = form.submit();
+      const { errors: stateErrors } = form._getState();
+
+      // then
+      expect(errors).to.not.have.property('Field_17uk1c9');
+      expect(stateErrors).to.not.have.property('Field_17uk1c9');
     });
 
   });

--- a/packages/form-js-viewer/test/spec/condition-errors.json
+++ b/packages/form-js-viewer/test/spec/condition-errors.json
@@ -1,0 +1,53 @@
+{
+  "components": [
+    {
+      "label": "Checkbox",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_0ifu9f7",
+        "columns": null
+      },
+      "id": "Field_0r8ir96",
+      "key": "checkbox_4u82gk"
+    },
+    {
+      "label": "Number",
+      "type": "number",
+      "layout": {
+        "row": "Row_0ifu9f7",
+        "columns": null
+      },
+      "id": "Field_17uk1c9",
+      "key": "number_o4f027",
+      "conditional": {
+        "hide": "=checkbox_4u82gk"
+      },
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "action": "reset",
+      "label": "Reset",
+      "type": "button",
+      "id": "Field_1jcm8tv",
+      "layout": {
+        "row": "Row_0ifu9f7"
+      }
+    },
+    {
+      "action": "submit",
+      "label": "Button",
+      "type": "button",
+      "layout": {
+        "row": "Row_15idciq",
+        "columns": null
+      },
+      "id": "Field_0bqqn6m"
+    }
+  ],
+  "type": "default",
+  "id": "Form_0k71hbi",
+  "exporter": {},
+  "schemaVersion": 11
+}


### PR DESCRIPTION
Closes #825

I actually wonder whether this worked beforehand, as conditions never refer to form field IDs, but their respective key.

Seems like we had a lack of test coverage over here. Feel free to check @Skaiir!