### PR TITLE
fix: readonly number fields should not show controls

### DIFF
--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -599,6 +599,10 @@
   color: var(--cds-text-inverse, var(--color-text));
 }
 
+.fjs-container .fjs-form-field-number.fjs-readonly .fjs-number-arrow-container {
+  display: none;
+}
+
 .fjs-container .fjs-radio {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->

Closes #

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  * => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)