### PR TITLE
fix: move dynamic options hint to tooltip

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/InputKeyValuesSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/InputKeyValuesSourceEntry.js
@@ -11,20 +11,10 @@ export default function InputKeyValuesSourceEntry(props) {
     id
   } = props;
 
-  const schema = '[\n  {\n    "label": "dollar",\n    "value": "$"\n  }\n]';
-
-  const description = <div>
-    Define which input property to populate the values from.
-    <br /><br />The input property may be an array of simple values or alternatively follow this schema:
-    <pre><code>{schema}</code></pre>
-  </div>;
-
   return [
     {
       id: id + '-key',
       component: InputValuesKey,
-      label: 'Input values key',
-      description,
       isEdited: isTextFieldEntryEdited,
       editField,
       field,
@@ -36,14 +26,19 @@ function InputValuesKey(props) {
   const {
     editField,
     field,
-    id,
-    label,
-    description
+    id
   } = props;
 
   const debounce = useService('debounce');
 
   const path = VALUES_SOURCES_PATHS[VALUES_SOURCES.INPUT];
+
+  const schema = '[\n  {\n    "label": "dollar",\n    "value": "$"\n  }\n]';
+
+  const tooltip = <div>
+    The input property may be an array of simple values or alternatively follow this schema:
+    <pre><code>{schema}</code></pre>
+  </div>;
 
   const getValue = () => get(field, path, '');
 
@@ -69,11 +64,12 @@ function InputValuesKey(props) {
 
   return TextFieldEntry({
     debounce,
-    description,
+    description: 'Define which input property to populate the values from',
+    tooltip,
     element: field,
     getValue,
     id,
-    label,
+    label: 'Input values key',
     setValue,
     validate
   });

--- a/packages/form-js-editor/src/features/properties-panel/entries/ValuesExpressionEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ValuesExpressionEntry.js
@@ -15,7 +15,6 @@ export default function ValuesExpressionEntry(props) {
     {
       id: id + '-expression',
       component: ValuesExpression,
-      label: 'Values expression',
       isEdited: isFeelEntryEdited,
       editField,
       field
@@ -38,9 +37,8 @@ function ValuesExpression(props) {
 
   const schema = '[\n  {\n    "label": "dollar",\n    "value": "$"\n  }\n]';
 
-  const description = <div>
-    Define an expression to populate the options from.
-    <br /><br />The expression may result in an array of simple values or alternatively follow this schema:
+  const tooltip = <div>
+    The expression may result in an array of simple values or alternatively follow this schema:
     <pre><code>{schema}</code></pre>
   </div>;
 
@@ -50,7 +48,8 @@ function ValuesExpression(props) {
 
   return FeelEntry({
     debounce,
-    description,
+    description: 'Define an expression to populate the options from.',
+    tooltip,
     element: field,
     feel: 'required',
     getValue,


### PR DESCRIPTION
Closes #305

There's a mild styling issue which are going to be fixed via https://github.com/bpmn-io/properties-panel/pull/300/commits, but since we're eventually going to bump the properties panel and the visuals aren't that big a deal, I feel like it's not worth monkey patching or syncing. If you think we should still wait lmk.