### PR TITLE
chore: document editor events

### DIFF
--- a/packages/form-js-editor/README.md
+++ b/packages/form-js-editor/README.md
@@ -110,6 +110,42 @@ Subscribe to an [event](#events).
 
 Remove form from editor the document.
 
+## Events
+
+### `selection.changed :: { selection }`
+
+### Properties panel events
+- `propertiesPanel.focusin`
+- `propertiesPanel.focusout`
+- `propertiesPanel.showEntry :: { id }`
+- `propertiesPanel.updated :: { formField }`
+
+### Form lifecycle events
+- `detach`
+- `attach`
+- `rendered`
+- `form.init`
+- `form.clear`
+- `form.destroy`
+- `diagram.clear`
+- `diagram.destroy`
+- `dragula.created`
+- `dragula.destroyed`
+- `editorActions.init :: { editorActions }`
+
+### Drag events
+- `drag.start :: { element, source }`
+- `drag.end :: { element }`
+- `drag.drop :: { element, target, source, sibling }`
+- `drag.hover :: { element, container, source }`
+- `drag.out :: { element, container, source }`
+- `drag.cancel :: { element, container, source }`
+
+### Form field events
+- `formField.add :: { formField }` 
+- `formField.remove :: { formField }`
+- `formField.updateId :: { formField, newId }`
+
 
 ## License
 

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -402,6 +402,9 @@ export default function FormEditor(props) {
 
   // fire event after render to notify interested parties
   useEffect(() => {
+    eventBus.fire('rendered');
+
+    // keep deprecated event to ensure backward compatibility
     eventBus.fire('formEditor.rendered');
   }, []);
 

--- a/packages/form-js-viewer/README.md
+++ b/packages/form-js-viewer/README.md
@@ -163,11 +163,11 @@ Fired off on form submission.
 ### `import.done :: { error, warnings }`
 Fired whenever a schema has finished importing, whether it succeeds or fails.
 
-### `form.layoutCalculated :: { rows }`
+### Layouting events
+- `form.layoutCleared`
+- `form.layoutCalculated :: { rows }`
 
-### `form.layoutCleared :: {}`
-
-### `<lifeCycleEvent> :: {}`
+### Lifecycle Events
 - `detach`
 - `attach`
 - `form.init`
@@ -176,11 +176,11 @@ Fired whenever a schema has finished importing, whether it succeeds or fails.
 - `diagram.clear`
 - `diagram.destroy`
 
-### `<formFieldEvent> :: { formField }`
-- `formField.add` 
-- `formField.remove` 
-- `formField.focus` 
-- `formField.blur` 
+### Formfield events
+- `formField.add :: { formField }` 
+- `formField.remove :: { formField }` 
+- `formField.focus :: { formField }` 
+- `formField.blur :: { formField }` 
 
 
 ## License


### PR DESCRIPTION
Closes #839

Added documentation of the editor events. Still quite simple for now, we can judge if we need to get into more detail later.
Also adjusted the viewer events to put the format individually, as I noticed the next event we need for form-fields doesn't match the usual format. 