### PR TITLE
fix: palette style improvements

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -68,7 +68,7 @@
     var(--cds-border-strong-01, var(--color-grey-225-10-55))
   );
   --cursor-palette-field: grab;
-  --palette-width: 250px;
+  --palette-width: 246px;
 }
 
 .fjs-properties-container {
@@ -543,8 +543,7 @@
   display: flex;
   flex-direction: row;
   padding: 4px;
-  margin: 15px;
-  margin-top: 12px;
+  margin: 12px;
   color: var(--color-palette-search);
   border: 1px solid var(--color-palette-search-border);
   background-color: var(--color-palette-search-background);

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -58,11 +58,15 @@
     var(--cds-layer-01, var(--color-white))
   );
   --color-palette-field-border: var(
-    --cds-border-strong,
-    var(--cds-border-strong-01, var(--color-grey-225-10-80))
+    --cds-border-subtle,
+    var(--cds-border-subtle-01, var(--color-grey-225-10-93))
   );
   --color-palette-field-focus: var(--cds-border-interactive, var(--color-blue-205-100-45));
   --color-palette-field-hover-background: var(--cds-background-hover, var(--color-grey-225-10-90));
+  --color-palette-field-hover-border: var(
+    --cds-border-strong,
+    var(--cds-border-strong-01, var(--color-grey-225-10-55))
+  );
   --cursor-palette-field: grab;
   --palette-width: 250px;
 }
@@ -620,7 +624,7 @@
 }
 
 .fjs-palette-field {
-  height: 68px;
+  height: 64px;
   margin: 5px 0;
   display: flex;
   flex-direction: column;
@@ -631,11 +635,14 @@
   font-family: inherit;
   user-select: none;
   color: var( --color-palette-field);
-  background: var(--color-palette-field-background);
+  background-color: var(--color-palette-field-background);
+  outline: solid 1px var(--color-palette-field-border);
+  outline-offset: 0px;
+  transition: all ease-in-out 0.05s;
 }
 
 .fjs-palette-container .fjs-palette-field {
-  width: 68px;
+  width: 64px;
 }
 
 .fjs-palette-container .fjs-palette-field:focus {
@@ -653,7 +660,7 @@
 }
 
 .fjs-palette-container .fjs-palette-field:hover {
-  background-color: var(--color-palette-field-hover-background);
+  outline: solid 1px var(--color-palette-field-hover-border);
   cursor: var(--cursor-palette-field);
 }
 

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -650,8 +650,7 @@
 }
 
 .fjs-palette-container .fjs-palette-field:focus {
-  outline: none;
-  border: solid 1px var(--color-palette-field-focus);
+  outline: solid 1px var(--color-palette-field-focus);
 }
 
 .fjs-palette-field .fjs-palette-field-icon {

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -599,33 +599,37 @@
 }
 
 .fjs-palette-container .fjs-palette-entries {
-  height: 100%;
+  display: flex;
+  flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
+  gap: 20px;
+  padding-bottom: 20px;
 }
 
 .fjs-palette-container .fjs-palette-group {
-  padding: 5px 15px;
-  padding-right: 0px;
+  display: flex;
+  flex-direction: column;
+  width: 212px;
+  margin: auto;
 }
 
 .fjs-palette-container .fjs-palette-group-title {
   font-size: 14px;
   font-weight: 500;
+  margin-bottom: 4px;
   color: var(--color-palette-group-title);
   user-select: none;
 }
 
 .fjs-palette-container .fjs-palette-fields {
-  height: 100%;
   display: flex;
   flex-wrap: wrap;
-  gap: 3%;
+  gap: 10px;
 }
 
 .fjs-palette-field {
   height: 64px;
-  margin: 5px 0;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
Closes #848
Closes #539

Improved the alignment of palette elements when scrollbar is visible, changed the focus to an outline instead of a margin to prevent blinking. Gave elements a small outline to make them pop. Made hover state also an outline. Compressed the palette a tiny bit.