### PR TITLE
chore(getSchemaVariables): fixup JS docs

### DIFF
--- a/packages/form-js-viewer/src/util/index.js
+++ b/packages/form-js-viewer/src/util/index.js
@@ -111,6 +111,7 @@ export function clone(data, replacer) {
  * @param {object} [options]
  * @param {any} [options.expressionLanguage]
  * @param {any} [options.templating]
+ * @param {any} [options.formFields]
  * @param {boolean} [options.inputs=true]
  * @param {boolean} [options.outputs=true]
  *


### PR DESCRIPTION
We accidently broke the types when merging `master` to `develop` 