### PR TITLE
style: improve placeholder color ratio

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -216,6 +216,17 @@
   display: none;
 }
 
+.fjs-no-json-lint .cm-activeLine,
+.fjs-no-json-lint .cm-activeLineGutter {
+  background: none;
+}
+
+.fjs-no-json-lint .cm-placeholder {
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--cds-text-placeholder, var(--color-grey-225-10-35));
+}
+
 .fjs-editor-container .fjs-form-editor {
   display: flex;
   flex: 1;


### PR DESCRIPTION
Related to https://github.com/camunda/team-hto/issues/384

I had to increase the placeholder text color a bit as it still reported less contrast in Axe. 

![image](https://github.com/bpmn-io/form-js/assets/9433996/8fec43fd-098b-4d0e-9773-3d34722d0745)
