### PR TITLE
feat(editor): introduce `container` group

### DIFF
--- a/packages/form-js-editor/src/features/palette/components/Palette.js
+++ b/packages/form-js-editor/src/features/palette/components/Palette.js
@@ -47,6 +47,10 @@ export const PALETTE_GROUPS = [
     id: 'presentation'
   },
   {
+    label: 'Containers',
+    id: 'container'
+  },
+  {
     label: 'Action',
     id: 'action'
   }

--- a/packages/form-js-viewer/src/render/components/form-fields/Group.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Group.js
@@ -31,7 +31,7 @@ Group.config = {
   type: 'group',
   pathed: true,
   label: 'Group',
-  group: 'presentation',
+  group: 'container',
   create: (options = {}) => ({
     components: [],
     showOutline: true,

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Group.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Group.spec.js
@@ -120,7 +120,7 @@ describe('Group', () => {
     const { config } = Group;
     expect(config.type).to.eql('group');
     expect(config.label).to.eql('Group');
-    expect(config.group).to.eql('presentation');
+    expect(config.group).to.eql('container');
     expect(config.pathed).to.be.true;
 
     // when


### PR DESCRIPTION
Introducing the Containers group as this will become more relevant with the next to-be-added components (`dynamiclist`, `iFrame`).

![image](https://github.com/bpmn-io/form-js/assets/9433996/25ee9c22-62f6-4dcf-a715-650cfb444725)
