### PR TITLE
ci: Prevent auto-update of visual regression screenshots

### DIFF
--- a/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
+++ b/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.pull_request.state != 'closed' && (github.event.label.name == 'update-snapshots' || contains( github.event.pull_request.labels.*.name, 'update-snapshots'))
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.41.0
+      image: mcr.microsoft.com/playwright:v1.40.1
       options: --user 1001:1000
 
     steps:

--- a/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
+++ b/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-snapshots:
-    if: github.event.pull_request.state != 'closed' && (github.event.label.name == 'deploy-preview' || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    if: github.event.pull_request.state != 'closed' && (github.event.label.name == 'update-snapshots' || contains( github.event.pull_request.labels.*.name, 'update-snapshots'))
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.41.0

--- a/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
+++ b/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
@@ -30,10 +30,7 @@ jobs:
       run: npm run start:visual-preview
     - name: Run Playwright tests
       run: npm run test:visual -- --update-snapshots
-    - name: Overwrite Playwright snapshots
-      run: |
-          git config user.name '${{ secrets.BPMN_IO_USERNAME }}'
-          git config user.email '${{ secrets.BPMN_IO_EMAIL }}'
-          git add -A
-          git commit -m "chore(CI): updated snapshots" || echo "No changes to commit"
-          git push
+    - name: Commit screenshots
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "chore: updated snapshots"

--- a/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
+++ b/.github/workflows/UPDATE_VISUAL_SNAPSHOTS.yml
@@ -1,0 +1,39 @@
+name: Update Visual Regression Snapshots
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  update-snapshots:
+    if: github.event.pull_request.state != 'closed' && (github.event.label.name == 'deploy-preview' || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.41.0
+      options: --user 1001:1000
+
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+    - name: Setup NPM cache
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+        cache: "npm"
+    - name: Install node dependencies
+      run: npm ci
+    - name: Build frontend
+      run: npm run build
+    - name: Build mock website
+      run: npm run build:e2e
+    - name: Start server
+      run: npm run start:visual-preview
+    - name: Run Playwright tests
+      run: npm run test:visual -- --update-snapshots
+    - name: Overwrite Playwright snapshots
+      run: |
+          git config user.name '${{ secrets.BPMN_IO_USERNAME }}'
+          git config user.email '${{ secrets.BPMN_IO_EMAIL }}'
+          git add -A
+          git commit -m "chore(CI): updated snapshots" || echo "No changes to commit"
+          git push

--- a/.github/workflows/VISUAL_REGRESSION.yml
+++ b/.github/workflows/VISUAL_REGRESSION.yml
@@ -26,16 +26,6 @@ jobs:
       - name: Run Playwright tests
         if: github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/master'
         run: npm run test:visual
-      - name: Overwrite Playwright snapshots
-        if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master'
-        run: |
-          npm run test:visual -- --update-snapshots
-          git config user.name '${{ secrets.BPMN_IO_USERNAME }}'
-          git config user.email '${{ secrets.BPMN_IO_EMAIL }}'
-          git add -A
-          git commit -m "chore(CI): updated snapshots [skip ci]" || echo "No changes to commit"
-          git push
-
       - uses: actions/upload-artifact@v4
         if: always()
         with:


### PR DESCRIPTION
I don't believe the auto-update of screenshots is working out, it just makes us ignore the visual regression CI run on PRs and if we there's problems when we merge master to develop or vice-versa it updates the baseline screenshots wrongly like in [here](https://github.com/bpmn-io/form-js/commit/648c5d1e3d49952111a13958330c5095905b70b5) (and this is not the first time I noticed an update that shouldn't happen)

We have the instructions on how to update the screenshots [here](https://github.com/bpmn-io/form-js/blob/develop/e2e/README.md), it takes less than 5 min to update so I believe it's not a blocker
