### PR TITLE
fix: explicitly depend on lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16168,7 +16168,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -16191,7 +16190,8 @@
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -22153,7 +22153,7 @@
         "feelin": "^3.0.0",
         "flatpickr": "^4.6.13",
         "ids": "^1.0.0",
-        "lodash.isequal": "^4.5.0",
+        "lodash": "^4.5.0",
         "min-dash": "^4.0.0",
         "preact": "^10.5.14",
         "preact-markup": "^2.1.1",
@@ -23726,7 +23726,7 @@
         "feelin": "^3.0.0",
         "flatpickr": "^4.6.13",
         "ids": "^1.0.0",
-        "lodash.isequal": "^4.5.0",
+        "lodash": "^4.5.0",
         "min-dash": "^4.0.0",
         "preact": "^10.5.14",
         "preact-markup": "^2.1.1",
@@ -33567,8 +33567,7 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "dev": true
+      "version": "4.17.21"
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -33589,7 +33588,8 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",

--- a/packages/form-js-viewer/package.json
+++ b/packages/form-js-viewer/package.json
@@ -52,7 +52,7 @@
     "feelin": "^3.0.0",
     "flatpickr": "^4.6.13",
     "ids": "^1.0.0",
-    "lodash.isequal": "^4.5.0",
+    "lodash": "^4.5.0",
     "min-dash": "^4.0.0",
     "preact": "^10.5.14",
     "preact-markup": "^2.1.1",


### PR DESCRIPTION
Hi,

With recent release, the demo.bpmn.io website build started to fail due to problems with dependencies of the form viewer:

```
<s> [webpack.Progress] 100% 
       assets by status 7.26 MiB [cached] 70 assets
       orphan modules 6.97 MiB [orphan] 1038 modules
       runtime modules 13.7 KiB 48 modules
       cacheable modules 12.7 MiB (javascript) 452 KiB (asset)
         modules by path ./node_modules/cmmn-js/ 919 KiB (javascript) 81.8 KiB (asset) 165 modules
         modules by path ./client/ 10.5 MiB (javascript) 56.8 KiB (asset) 18 modules
         modules by path ./node_modules/bpmn-js-cli/ 20.7 KiB 16 modules
         modules by path ./node_modules/dmn-js/dist/assets/ 153 KiB (javascript) 62.1 KiB (asset) 12 modules
         modules by path ./node_modules/bpmn-js/dist/assets/ 82.6 KiB (javascript) 252 KiB (asset) 8 modules
         modules by path ./node_modules/style-loader/dist/runtime/*.js 5.75 KiB 6 modules
         modules by path ./node_modules/css-loader/dist/runtime/*.js 3.5 KiB 3 modules
         modules by path ./node_modules/@sentry/ 14.2 KiB 3 modules
         modules by path ./node_modules/object-refs/ 7.25 KiB 3 modules
         modules by path ./node_modules/@bpmn-io/ 341 KiB 2 modules
         + 15 modules
       
       ERROR in ./node_modules/@bpmn-io/form-js-viewer/dist/index.es.js 39:0-37
       Module not found: Error: Can't resolve 'lodash/isEqual' in '/tmp/build_d26ebde6/node_modules/@bpmn-io/form-js-viewer/dist'
       resolve 'lodash/isEqual' in '/tmp/build_d26ebde6/node_modules/@bpmn-io/form-js-viewer/dist'
         Parsed request is a module
         using description file: /tmp/build_d26ebde6/node_modules/@bpmn-io/form-js-viewer/package.json (relative path: ./dist)
           Field 'browser' doesn't contain a valid alias configuration
           resolve as module
             /tmp/build_d26ebde6/node_modules/@bpmn-io/form-js-viewer/dist/node_modules doesn't exist or is not a directory
             /tmp/build_d26ebde6/node_modules/@bpmn-io/form-js-viewer/node_modules doesn't exist or is not a directory
             /tmp/build_d26ebde6/node_modules/@bpmn-io/node_modules doesn't exist or is not a directory
             /tmp/build_d26ebde6/node_modules/node_modules doesn't exist or is not a directory
             looking for modules in /tmp/build_d26ebde6/node_modules
               /tmp/build_d26ebde6/node_modules/lodash doesn't exist
             /tmp/node_modules doesn't exist or is not a directory
             /node_modules doesn't exist or is not a directory
        @ ./node_modules/@bpmn-io/form-js/dist/index.es.js 1:0-40 1:0-40
        @ ./client/form/app.js 4:0-46 12:17-27
       
       webpack 5.75.0 compiled with 1 error in 89569 ms
-----> Build failed
```

I checked the source code of the viewer and found that in the library we import `isEqual` from `lodash` (via [`lodash/isEqual`](https://github.com/bpmn-io/form-js/blob/d3c930ad19aa6a68179e47b1a24fd8353e962ebf/packages/form-js-viewer/src/render/components/form-fields/Radio.js#L2)) while the package.json includes an obsolete [`lodash.isEqual` package](https://www.npmjs.com/package/lodash.isequal). Effectively, in the CI we use file `isEqual.js` in `lodash` which is a transitive dev dependency, but the `@bpmn-io/form-js-viewer` library does not declare `lodash` library as its dependency. This PR fixes the problem.
