### PR TITLE
chore: fix preact usages across application

### DIFF
--- a/packages/form-js-editor/src/features/render-injection/slot-fill/SlotFillRoot.js
+++ b/packages/form-js-editor/src/features/render-injection/slot-fill/SlotFillRoot.js
@@ -2,19 +2,26 @@ import FillContext from './FillContext';
 import SlotContext from './SlotContext';
 import { useMemo, useState } from 'preact/hooks';
 
+const noop = () => {};
+
 export default (props) => {
   const [ fills, setFills ] = useState([]);
+
+  const {
+    onSetFill = noop,
+    onRemoveFill = noop
+  } = props;
 
   const fillContext = useMemo(() => ({
     addFill: (fill) => {
       setFills((fills) => [ ...fills.filter((f) => f.id !== fill.id), fill ]);
-      props.onSetFill && props.onSetFill(fill);
+      onSetFill(fill);
     },
     removeFill: (id) => {
       setFills((fills) => fills.filter((f) => f.id !== id));
-      props.onRemoveFill && props.onRemoveFill(id);
+      onRemoveFill(id);
     }
-  }), []);
+  }), [ onRemoveFill, onSetFill ]);
 
   const slotContext = useMemo(() => ({ fills }), [ fills ]);
 

--- a/packages/form-js-editor/src/render/hooks/useDebounce.js
+++ b/packages/form-js-editor/src/render/hooks/useDebounce.js
@@ -5,14 +5,16 @@ import {
 
 import useService from './useService';
 
-
-export default function useDebounce(fn, dependencies = []) {
+/**
+ * @param {Function} fn - function to debounce
+ */
+export default function useDebounce(fn) {
 
   const debounce = useService('debounce');
 
   const callback = useMemo(() => {
     return debounce(fn);
-  }, dependencies);
+  }, [ debounce, fn ]);
 
   // cleanup async side-effect if callback #flush is provided.
   useEffect(() => {

--- a/packages/form-js-editor/src/render/hooks/usePrevious.js
+++ b/packages/form-js-editor/src/render/hooks/usePrevious.js
@@ -4,10 +4,10 @@ import {
 } from 'preact/hooks';
 
 
-export default function usePrevious(value) {
-  const ref = useRef();
+export default function usePrevious(value, defaultValue = null) {
+  const ref = useRef(defaultValue);
 
-  useEffect(() => ref.current = value);
+  useEffect(() => ref.current = value, [ value ]);
 
   return ref.current;
 }

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -33,7 +33,9 @@ export function PlaygroundRoot(props) {
     editorProperties = {},
     viewerAdditionalModules = [],
     editorAdditionalModules = [],
-    propertiesPanel: propertiesPanelConfig = {}
+    propertiesPanel: propertiesPanelConfig = {},
+    onInit: onPlaygroundInit,
+    onStateChanged
   } = props;
 
   const {
@@ -66,7 +68,7 @@ export function PlaygroundRoot(props) {
 
   // pipe to playground API
   useEffect(() => {
-    props.onInit({
+    onPlaygroundInit({
       attachDataContainer: (node) => dataEditorRef.current.attachTo(node),
       attachEditorContainer: (node) => formEditorRef.current.attachTo(node),
       attachFormContainer: (node) => formRef.current.attachTo(node),
@@ -82,7 +84,7 @@ export function PlaygroundRoot(props) {
       setSchema: setInitialSchema,
       saveSchema: () => formEditorRef.current.saveSchema()
     });
-  });
+  }, [ onPlaygroundInit ]);
 
   useEffect(() => {
     setInitialSchema(props.schema || {});
@@ -230,11 +232,11 @@ export function PlaygroundRoot(props) {
   }, [ resultData ]);
 
   useEffect(() => {
-    props.onStateChanged({
+    onStateChanged && onStateChanged({
       schema,
       data
     });
-  }, [ schema, data ]);
+  }, [ onStateChanged, schema, data ]);
 
   const handleDownload = useCallback(() => {
 

--- a/packages/form-js-viewer/src/features/repeatRender/RepeatRenderManager.js
+++ b/packages/form-js-viewer/src/features/repeatRender/RepeatRenderManager.js
@@ -80,10 +80,10 @@ export default class RepeatRenderManager {
     return (
       <>
         {displayValues.map((value, index) => {
-          const elementProps = {
+          const elementProps = useMemo(() => ({
             ...restProps,
-            indexes: { ...(indexes || {}), [ repeaterField.id ]: index },
-          };
+            indexes: { ...(indexes || {}), [ repeaterField.id ]: index }
+          }), [ index ]);
 
           const localExpressionContextInfo = useMemo(() => ({
             data: parentExpressionContextInfo.data,

--- a/packages/form-js-viewer/src/render/Renderer.js
+++ b/packages/form-js-viewer/src/render/Renderer.js
@@ -34,7 +34,7 @@ export default function Renderer(config, eventBus, form, injector) {
       setState(newState);
     });
 
-    const onChange = useCallback((update) => form._update(update), [ form ]);
+    const onChange = useCallback((update) => form._update(update), []);
 
     const { properties } = state;
 
@@ -44,9 +44,9 @@ export default function Renderer(config, eventBus, form, injector) {
       if (!readOnly) {
         form.submit();
       }
-    }, [ form, readOnly ]);
+    }, [ readOnly ]);
 
-    const onReset = useCallback(() => form.reset(), [ form ]);
+    const onReset = useCallback(() => form.reset(), []);
 
     const { schema } = state;
 

--- a/packages/form-js-viewer/src/render/components/FormField.js
+++ b/packages/form-js-viewer/src/render/components/FormField.js
@@ -77,7 +77,7 @@ export default function FormField(props) {
     if (viewerCommands && initialValue) {
       viewerCommands.updateFieldValidation(field, initialValue, indexes);
     }
-  }, [ viewerCommands, field, initialValue, JSON.stringify(indexes) ]);
+  }, [ viewerCommands, field, initialValue, indexes ]);
 
   const hidden = useCondition(field.conditional && field.conditional.hide || null);
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'preact/hooks';
 
-import { useService } from '../../hooks';
+import { useDeepCompareState, useService } from '../../hooks';
 import useOptionsAsync, { LOAD_STATES } from '../../hooks/useOptionsAsync';
 import useCleanupMultiSelectValues from '../../hooks/useCleanupMultiSelectValues';
 import { useGetLabelCorrelation } from '../../hooks/useGetLabelCorrelation';
@@ -35,7 +35,7 @@ export default function Taglist(props) {
     onBlur,
     field,
     readonly,
-    value : values = []
+    value
   } = props;
 
   const {
@@ -58,6 +58,9 @@ export default function Taglist(props) {
     options
   } = useOptionsAsync(field);
 
+  // ensures we render based on array content instead of reference
+  const values = useDeepCompareState(value || [], []);
+
   useCleanupMultiSelectValues({
     field,
     loadState,
@@ -70,7 +73,6 @@ export default function Taglist(props) {
 
   const hasOptionsLeft = useMemo(() => options.length > values.length, [ options.length, values.length ]);
 
-  // Usage of stringify is necessary here because we want this effect to only trigger when there is a value change to the array
   const filteredOptions = useMemo(() => {
     if (loadState !== LOAD_STATES.LOADED) {
       return [];
@@ -82,7 +84,7 @@ export default function Taglist(props) {
     };
 
     return options.filter(isValidFilteredOption);
-  }, [ filter, options, JSON.stringify(values), loadState ]);
+  }, [ filter, options, values, loadState ]);
 
 
   const selectValue = (value) => {

--- a/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
@@ -38,7 +38,7 @@ export default function Textarea(props) {
       field,
       value: target.value
     });
-  }, [ props.onChange ]);
+  });
 
   const onInputBlur = () => {
     flushOnChange && flushOnChange();

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -42,7 +42,7 @@ export default function Textfield(props) {
       field,
       value: target.value
     });
-  }, [ props.onChange ]);
+  });
 
   const onInputBlur = () => {
     flushOnChange && flushOnChange();

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/Datepicker.js
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import CalendarIcon from '../icons/Calendar.svg';
 import InputAdorner from './InputAdorner';
 import Label from '../../Label';
+import { useDeepCompareState } from '../../../hooks';
 
 export default function Datepicker(props) {
 
@@ -18,7 +19,7 @@ export default function Datepicker(props) {
     required,
     disabled,
     disallowPassedDates,
-    date,
+    date: dateObject,
     readonly,
     setDate
   } = props;
@@ -30,6 +31,9 @@ export default function Datepicker(props) {
   const [ isInputDirty, setIsInputDirty ] = useState(false);
   const [ forceFocusCalendar, setForceFocusCalendar ] = useState(false);
 
+  // ensures we render based on date value instead of reference
+  const date = useDeepCompareState(dateObject, null);
+
   // shorts the date value back to the source
   useEffect(() => {
 
@@ -38,7 +42,7 @@ export default function Datepicker(props) {
     flatpickrInstance.setDate(date, true);
     setIsInputDirty(false);
 
-  }, [ flatpickrInstance, date.toString() ]);
+  }, [ flatpickrInstance, date ]);
 
   useEffect(() => {
 

--- a/packages/form-js-viewer/src/render/components/form-fields/parts/SimpleSelect.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/parts/SimpleSelect.js
@@ -53,7 +53,7 @@ export default function SimpleSelect(props) {
     ds.displayCross = ds.componentReady && value !== null && value !== undefined;
     ds.displayDropdown = !disabled && !readonly && isDropdownExpanded;
     return ds;
-  }, [ disabled, isDropdownExpanded, loadState, value ]);
+  }, [ disabled, isDropdownExpanded, loadState, readonly, value ]);
 
   const onMouseDown = useCallback((e) => {
     const input = inputRef.current;

--- a/packages/form-js-viewer/src/render/hooks/useCleanupMultiSelectValues.js
+++ b/packages/form-js-viewer/src/render/hooks/useCleanupMultiSelectValues.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'preact/hooks';
 import { LOAD_STATES } from './useOptionsAsync';
 import { hasEqualValue } from '../components/util/sanitizerUtil';
+import useDeepCompareState from './useDeepCompareState';
 
 export default function(props) {
 
@@ -9,10 +10,12 @@ export default function(props) {
     options,
     loadState,
     onChange,
-    values
+    values: valuesArray
   } = props;
 
-  // Ensures that the values are always a subset of the possible options
+  const values = useDeepCompareState(valuesArray, []);
+
+  // ensures that the values are always a subset of the possible options
   useEffect(() => {
 
     if (loadState !== LOAD_STATES.LOADED) {
@@ -29,6 +32,6 @@ export default function(props) {
       });
     }
 
-  }, [ field, options, onChange, JSON.stringify(values), loadState ]);
+  }, [ field, options, onChange, values, loadState ]);
 
 }

--- a/packages/form-js-viewer/src/render/hooks/useCleanupMultiSelectValues.js
+++ b/packages/form-js-viewer/src/render/hooks/useCleanupMultiSelectValues.js
@@ -10,10 +10,10 @@ export default function(props) {
     options,
     loadState,
     onChange,
-    values: valuesArray
+    values
   } = props;
 
-  const values = useDeepCompareState(valuesArray, []);
+  const memoizedValues = useDeepCompareState(values, []);
 
   // ensures that the values are always a subset of the possible options
   useEffect(() => {
@@ -23,15 +23,15 @@ export default function(props) {
     }
 
     const optionValues = options.map(o => o.value);
-    const hasValuesNotInOptions = values.some(v => !hasEqualValue(v, optionValues));
+    const hasValuesNotInOptions = memoizedValues.some(v => !hasEqualValue(v, optionValues));
 
     if (hasValuesNotInOptions) {
       onChange({
         field,
-        value: values.filter(v => hasEqualValue(v, optionValues))
+        value: memoizedValues.filter(v => hasEqualValue(v, optionValues))
       });
     }
 
-  }, [ field, options, onChange, values, loadState ]);
+  }, [ field, options, onChange, memoizedValues, loadState ]);
 
 }

--- a/packages/form-js-viewer/src/render/hooks/useDeepCompareState.js
+++ b/packages/form-js-viewer/src/render/hooks/useDeepCompareState.js
@@ -4,6 +4,7 @@ import {
 } from 'preact/hooks';
 
 import usePrevious from './usePrevious';
+import isEqual from 'lodash/isEqual';
 
 /**
  * A custom hook to manage state changes with deep comparison.
@@ -18,7 +19,7 @@ export default function useDeepCompareState(value, defaultValue) {
 
   const previous = usePrevious(value, defaultValue, [ value ]);
 
-  const changed = !compare(previous, value);
+  const changed = !isEqual(previous, value);
 
   useEffect(() => {
     if (changed) {
@@ -27,11 +28,4 @@ export default function useDeepCompareState(value, defaultValue) {
   }, [ changed, value ]);
 
   return state;
-
-}
-
-// helpers //////////////////////////
-
-function compare(a, b) {
-  return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/packages/form-js-viewer/src/render/hooks/useDeepCompareState.js
+++ b/packages/form-js-viewer/src/render/hooks/useDeepCompareState.js
@@ -17,7 +17,7 @@ export default function useDeepCompareState(value, defaultValue) {
 
   const [ state, setState ] = useState(defaultValue);
 
-  const previous = usePrevious(value, defaultValue, [ value ]);
+  const previous = usePrevious(value, defaultValue);
 
   const changed = !isEqual(previous, value);
 

--- a/packages/form-js-viewer/src/render/hooks/useFlushDebounce.js
+++ b/packages/form-js-viewer/src/render/hooks/useFlushDebounce.js
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'preact/hooks';
 import useService from './useService';
 
-function useFlushDebounce(func, additionalDeps = []) {
+function useFlushDebounce(func) {
 
   const timeoutRef = useRef(null);
   const lastArgsRef = useRef(null);
@@ -29,7 +29,7 @@ function useFlushDebounce(func, additionalDeps = []) {
       lastArgsRef.current = null;
     }, delay);
 
-  }, [ func, delay, shouldDebounce, ...additionalDeps ]);
+  }, [ func, delay, shouldDebounce ]);
 
   const flushFunc = useCallback(() => {
 
@@ -42,7 +42,7 @@ function useFlushDebounce(func, additionalDeps = []) {
       timeoutRef.current = null;
     }
 
-  }, [ func, ...additionalDeps ]);
+  }, [ func ]);
 
   return [ debounceFunc, flushFunc ];
 }

--- a/packages/form-js-viewer/src/render/hooks/usePrevious.js
+++ b/packages/form-js-viewer/src/render/hooks/usePrevious.js
@@ -4,10 +4,10 @@ import {
 } from 'preact/hooks';
 
 
-export default function usePrevious(value, defaultValue, dependencies) {
+export default function usePrevious(value, defaultValue = null) {
   const ref = useRef(defaultValue);
 
-  useEffect(() => ref.current = value, dependencies);
+  useEffect(() => ref.current = value, [ value ]);
 
   return ref.current;
 }

--- a/packages/form-js-viewer/test/helper/preactDebuggers.js
+++ b/packages/form-js-viewer/test/helper/preactDebuggers.js
@@ -4,11 +4,11 @@ const usePrevious = (value, initialValue) => {
   const ref = useRef(initialValue);
   useEffect(() => {
     ref.current = value;
-  });
+  }, [ value ]);
   return ref.current;
 };
 
-export function useEffectDebugger(effectHook, dependencies, dependencyNames = [], effectName = 'noname') {
+export function useEffectDebugger(effect, dependencies, dependencyNames = [], effectName = 'noname') {
   const previousDeps = usePrevious(dependencies, []);
 
   const changedDeps = dependencies.reduce((accum, dependency, index) => {
@@ -30,7 +30,7 @@ export function useEffectDebugger(effectHook, dependencies, dependencyNames = []
     console.log('[use-effect-debugger] (' + effectName + ') ', changedDeps);
   }
 
-  useEffect(effectHook, dependencies);
+  useEffect(effect, [ effect, ...dependencies ]);
 }
 
 export function useCallbackDebugger(callback, dependencies, dependencyNames = [], callbackName = 'noname') {
@@ -55,5 +55,5 @@ export function useCallbackDebugger(callback, dependencies, dependencyNames = []
     console.log('[use-callback-debugger] (' + callbackName + ') ', changedDeps);
   }
 
-  return useCallback(callback, dependencies);
+  return useCallback(callback, [ callback, ...dependencies ]);
 }


### PR DESCRIPTION
Related to https://github.com/camunda/team-hto/issues/444

This is only the first part of the changes. There's one big misuse left but it's super core and might take a bit for me to diagnose completely. But I've reduced down the warnings from 35ish to 1 which is progress.

I've still got another part of this on a local branch which is to merge the properties panel render tree with that of the rest of the editor, but still need a little bit of debugging for that one. Won't be long though. But let's merge as we go along.