### PR TITLE
feat: implement number field debouncing

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import classNames from 'classnames';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useMemo, useRef, useState } from 'preact/hooks';
 import { useFlushDebounce, usePrevious } from '../../hooks';
 
 import { Description } from '../Description';
@@ -63,11 +63,9 @@ export function Numberfield(props) {
 
   const previousCachedValue = usePrevious(value);
 
-  useEffect(() => {
-    if (previousCachedValue !== cachedValue) {
-      debouncedOnChange({ field, value: cachedValue });
-    }
-  }, [ debouncedOnChange, cachedValue, field, previousCachedValue ]);
+  if (previousCachedValue !== cachedValue) {
+    debouncedOnChange({ field, value: cachedValue });
+  }
 
   const onInputBlur = () => {
     flushOnChange && flushOnChange();
@@ -108,18 +106,13 @@ export function Numberfield(props) {
   }, [ sanitize ]);
 
   // when external changes occur independently of the input, we update the display and cache values of the component
-
   const previousValue = usePrevious(value);
+  const outerValueChanged = previousValue != value;
+  const outerValueEqualsCache = sanitize(value) === sanitize(cachedValue);
 
-  useEffect(() => {
-    const outerValueChanged = previousValue != value;
-    const outerValueEqualsCache = sanitize(value) === sanitize(cachedValue);
-
-    if (outerValueChanged && !outerValueEqualsCache) {
-      setValue(value && value.toString() || '');
-    }
-
-  }, [ cachedValue, previousValue, sanitize, setValue, value ]);
+  if (outerValueChanged && !outerValueEqualsCache) {
+    setValue(value && value.toString() || '');
+  }
 
   // caches the value an increment/decrement operation will be based on
   const incrementAmount = useMemo(() => {

--- a/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
@@ -12,6 +12,10 @@ export function isValidNumber(value) {
 
 export function willKeyProduceValidNumber(key, previousValue, caretIndex, selectionWidth, decimalDigits) {
 
+  if (previousValue === 'NaN') {
+    return false;
+  }
+
   // Dot and comma are both treated as dot
   previousValue = previousValue.replace(',', '.');
   const isFirstDot = !previousValue.includes('.') && (key === '.' || key === ',');

--- a/packages/form-js-viewer/src/render/hooks/index.js
+++ b/packages/form-js-viewer/src/render/hooks/index.js
@@ -8,6 +8,7 @@ export { useKeyDownAction } from './useKeyDownAction';
 export { useReadonly } from './useReadonly';
 export { useService } from './useService';
 export { usePrevious } from './usePrevious';
+export { useFlushDebounce } from './useFlushDebounce';
 export { useDeepCompareState } from './useDeepCompareState';
 export { useSingleLineTemplateEvaluation } from './useSingleLineTemplateEvaluation';
 export { useTemplateEvaluation } from './useTemplateEvaluation';

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -675,9 +675,10 @@ describe('Number', function() {
       fireEvent.input(input, { target: { value: '12.25a' } });
 
       // then
+      expect(input.value).to.equal('NaN');
       expect(onChangeSpy).to.have.been.calledWith({
         field: stringField,
-        value: 'NaN'
+        value: null
       });
 
     });


### PR DESCRIPTION
Closes #958
(again)

After a lot of reworks and problems I finally got this sorted.
For testing, make sure the debouncing is working, cleaning up when tabbing out. This should debounce when holding up or down arrow, when typing, and when clicking the arrows via the mouse. 

I've also as part of this removed some problem things, like the fact that we were still sending an onChange with 'NaN' (a concept we had removed, but not fully, via https://github.com/bpmn-io/form-js/issues/894), the test case is respectively changed. 

What we are keeping is the NaN state when pasting something that's not a valid number, this is only visual and is here to give users feedback, otherwise they might think pasting just doesn't do anything. In the future a toast element might be more appropriate. Anyways this state is also more robust now. 
