### PR TITLE
fix: Prevent demo data from being created on edited tables

### DIFF
--- a/packages/form-js-playground/rollup.config.js
+++ b/packages/form-js-playground/rollup.config.js
@@ -60,7 +60,8 @@ export default [
       '@codemirror/language',
       'codemirror',
       'classnames',
-      'min-dom'
+      'min-dom',
+      'min-dash'
     ],
     onwarn
   },

--- a/packages/form-js-playground/src/components/PlaygroundRoot.js
+++ b/packages/form-js-playground/src/components/PlaygroundRoot.js
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, useCallback } from 'preact/hooks';
-
+import { isFunction } from 'min-dash';
 import download from 'downloadjs';
 
 import classNames from 'classnames';
@@ -142,8 +142,14 @@ export function PlaygroundRoot(props) {
     formEditor.on('formField.add', ({ formField }) => {
       const formFields = formEditor.get('formFields');
       const { config } = formFields.get(formField.type);
-      const { initialDemoData } = config;
+      const { generateInitialDemoData } = config;
       const { id } = formField;
+
+      if (!isFunction(generateInitialDemoData)) {
+        return;
+      }
+
+      const initialDemoData = generateInitialDemoData(formField);
 
       if ([ initialDemoData, id ].includes(undefined)) {
         return;

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -170,8 +170,21 @@ describe('playground', function() {
     const attrs = {
       id: 'table',
       type: 'table',
-      dataSource: 'people',
-      columnsExpression: 'peopleColumns'
+      dataSource: '=table',
+      columns: [
+        {
+          key: 'id',
+          label: 'ID'
+        },
+        {
+          key: 'name',
+          label: 'Name'
+        },
+        {
+          key: 'date',
+          label: 'Date'
+        }
+      ]
     };
 
     await act(() => {
@@ -201,6 +214,38 @@ describe('playground', function() {
       { id: 2, name: 'Erika Muller', date: '20.02.2023' },
       { id: 3, name: 'Dominic Leaf', date: '11.03.2023' }
     ]);
+  });
+
+  it('should not append sample data', async function() {
+
+    // given
+    const attrs = {
+      id: 'table',
+      type: 'table',
+      dataSource: '=table',
+      columnsExpression: '=peopleColumns'
+    };
+
+    await act(() => {
+      playground = new Playground({
+        container,
+        schema
+      });
+    });
+
+    const editor = playground.getEditor();
+    const modeling = editor.get('modeling');
+
+    // when
+    await act(() => {
+      const { schema } = editor._getState();
+      modeling.addFormField(attrs, schema, 0);
+    });
+
+    // then
+    const dataEditor = playground.getDataEditor();
+
+    expect(dataEditor.getValue()).to.be.empty;
   });
 
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Table.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Table.js
@@ -23,14 +23,16 @@ const type = 'table';
  * @property {string} label
  * @property {string} key
  *
+ * @typedef Field
+ * @property {string} id
+ * @property {Array<Column>} [columns]
+ * @property {string} [columnsExpression]
+ * @property {string} [label]
+ * @property {number} [rowCount]
+ * @property {string} [dataSource]
+ *
  * @typedef Props
- * @property {Object} field
- * @property {string} field.id
- * @property {Array<Column>} [field.columns]
- * @property {string} [field.columnsExpression]
- * @property {string} [field.label]
- * @property {number} [field.rowCount]
- * @property {string} [field.dataSource]
+ * @property {Field} field
  *
  * @param {Props} props
  * @returns {import("preact").JSX.Element}
@@ -263,11 +265,30 @@ Table.config = {
       ],
     };
   },
-  initialDemoData: [
-    { id: 1, name: 'John Doe', date: '31.01.2023' },
-    { id: 2, name: 'Erika Muller', date: '20.02.2023' },
-    { id: 3, name: 'Dominic Leaf', date: '11.03.2023' }
-  ],
+
+  /**
+   *
+   * @param {Field} field
+   */
+  generateInitialDemoData: (field) => {
+    const demoData = [
+      { id: 1, name: 'John Doe', date: '31.01.2023' },
+      { id: 2, name: 'Erika Muller', date: '20.02.2023' },
+      { id: 3, name: 'Dominic Leaf', date: '11.03.2023' }
+    ];
+    const demoDataKeys = Object.keys(demoData[0]);
+    const { columns, id, dataSource } = field;
+
+    if (!Array.isArray(columns) || columns.length === 0 || dataSource !== `=${id}`) {
+      return;
+    }
+
+    if (!columns.map(({ key })=>key).every(key => demoDataKeys.includes(key))) {
+      return;
+    }
+
+    return demoData;
+  }
 };
 
 // helpers /////////////////////////////

--- a/packages/form-js-viewer/src/render/components/form-fields/Table.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Table.js
@@ -267,7 +267,9 @@ Table.config = {
   },
 
   /**
+   * @experimental
    *
+   * A function that generates demo data for a new field on the form playground.
    * @param {Field} field
    */
   generateInitialDemoData: (field) => {


### PR DESCRIPTION
With the table component we added the concept of adding demo data to the new component, this data was being added when importing forms into the modeler.
This PR prevents this from happening and only adds the demo data when the schema matches with the demo data

Closes #997

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  * => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)