### PR TITLE
fix: resize textarea on input changes

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
@@ -33,7 +33,7 @@ export function Textarea(props) {
   const { required } = validate;
   const textareaRef = useRef();
 
-  const [ onInputChange, flushOnChange ] = useFlushDebounce(({ target }) => {
+  const [ onChange, flushOnChange ] = useFlushDebounce(({ target }) => {
     props.onChange({
       field,
       value: target.value
@@ -47,6 +47,11 @@ export function Textarea(props) {
 
   const onInputFocus = () => {
     onFocus && onFocus();
+  };
+
+  const onInputChange = (event) => {
+    onChange({ target: event.target });
+    autoSizeTextarea(textareaRef.current);
   };
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Closes #1011

We need to also recalculate the text-area size on input changes so that it doesn't wait for deboucing to kick in. 

This implementation ends up making the call twice (once on typing, once when the value change actually happens through debouncing), but we need to keep the value change one active so that the textarea still resizes when externals change its state.

Well it's only running twice if you type on character every 301ms. It's better to say it runs one extra time

Differentiating a self-triggered value change from an external one does not seem worth the effort. So I think this is the right fix. 