### PR TITLE
fix: validate instead of automatically resetting height entries

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/HeightEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/HeightEntry.js
@@ -41,13 +41,12 @@ function Height(props) {
     description,
     editField,
     field,
-    id,
-    defaultValue = 60 // default value for spacer
+    id
   } = props;
 
   const debounce = useService('debounce');
 
-  const getValue = (e) => get(field, [ 'height' ], defaultValue);
+  const getValue = (e) => get(field, [ 'height' ], null);
 
   const setValue = (value, error) => {
     if (error) {
@@ -77,7 +76,7 @@ function Height(props) {
   */
 const validate = (value) => {
   if (typeof value !== 'number') {
-    return null;
+    return 'A number is required.';
   }
 
   if (!Number.isInteger(value)) {

--- a/packages/form-js-editor/src/features/properties-panel/entries/IFrameHeightEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/IFrameHeightEntry.js
@@ -4,7 +4,6 @@ export function IFrameHeightEntry(props) {
   return [
     ...HeightEntry({
       ...props,
-      defaultValue: 300,
       description: 'Height of the container in pixels.',
       isDefaultVisible: (field) => field.type === 'iframe'
     })


### PR DESCRIPTION
Closes #956

![grafik](https://github.com/bpmn-io/form-js/assets/17801113/08bed5ea-1602-4495-9e63-14db1d0699a3)

Small change, but basically we don't automatically set the default value again every time we clear this field, as this used to feel really clumsy when wanting to change to a specific value.