### PR TITLE
fix: prevent datetime from validating early

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
@@ -15,7 +15,7 @@ import { Timepicker } from './parts/Timepicker';
 
 import { formFieldClasses, prefixId } from '../Util';
 import { sanitizeDateTimePickerValue } from '../util/sanitizerUtil';
-import { parseIsoTime, serializeDate, serializeDateTime, serializeTime } from '../util/dateTimeUtil';
+import { parseIsoTime, serializeDate, serializeDateTime, serializeTime, getNullDateTime, isValidDate, isValidTime } from '../util/dateTimeUtil';
 
 const type = 'datetime';
 
@@ -49,13 +49,8 @@ export function Datetime(props) {
   const { formId } = useContext(FormContext);
   const dateTimeGroupRef = useRef();
 
-  const getNullDateTime = () => ({ date: new Date(Date.parse(null)), time: null });
-
   const [ dateTime, setDateTime ] = useState(getNullDateTime());
   const [ dateTimeUpdateRequest, setDateTimeUpdateRequest ] = useState(null);
-
-  const isValidDate = (date) => date && !isNaN(date.getTime());
-  const isValidTime = (time) => !isNaN(parseInt(time));
 
   const useDatePicker = useMemo(() => subtype === DATETIME_SUBTYPES.DATE || subtype === DATETIME_SUBTYPES.DATETIME, [ subtype ]);
   const useTimePicker = useMemo(() => subtype === DATETIME_SUBTYPES.TIME || subtype === DATETIME_SUBTYPES.DATETIME, [ subtype ]);
@@ -113,9 +108,13 @@ export function Datetime(props) {
       newDateTimeValue = serializeDateTime(date, time, timeSerializingFormat);
     }
 
+    if (value === newDateTimeValue) {
+      return;
+    }
+
     onChange({ value: newDateTimeValue, field });
 
-  }, [ field, onChange, subtype, timeSerializingFormat ]);
+  }, [ value, field, onChange, subtype, timeSerializingFormat ]);
 
   useEffect(() => {
     if (dateTimeUpdateRequest) {

--- a/packages/form-js-viewer/src/render/components/util/dateTimeUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/dateTimeUtil.js
@@ -212,6 +212,21 @@ export function isInvalidDateString(value) {
   return isNaN(new Date(Date.parse(value)).getTime());
 }
 
+export function getNullDateTime() {
+  return {
+    date: new Date(Date.parse(null)),
+    time: null
+  };
+}
+
+export function isValidDate(date) {
+  return date && !isNaN(date.getTime());
+}
+
+export function isValidTime(time) {
+  return !isNaN(parseInt(time));
+}
+
 function _getSignedPaddedHours(minutes) {
   if (minutes > 0) {
     return '-' + _getZeroPaddedString(Math.floor(minutes / 60));


### PR DESCRIPTION
Closes #1099

The root cause issue for this is the fact that the datetime component has a lot of funky synchronization code that leads to onChange being called when it initializes. The simplest and quickest way to fix this, is to not call onChange when newValue = oldValue, and it makes sense generally. 

But ideally, we wouldn't want this logic branch to be called on init at all. Now I'm not sure I can fix this without a full refactor of datetime, and this component is a house of cards so my suggestion is, we take the easy fix for now, and I've raised [this issue](https://github.com/bpmn-io/form-js/issues/1120) to provide a refactor to the component in the future.