### PR TITLE
chore: removed deprecated `shouldSort` properties panel attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/core": "^7.24.5",
         "@babel/plugin-transform-react-jsx": "^7.23.4",
         "@babel/plugin-transform-react-jsx-source": "^7.24.1",
-        "@bpmn-io/properties-panel": "^3.18.2",
+        "@bpmn-io/properties-panel": "^3.20.0",
         "@carbon/react": "^1.56.0",
         "@carbon/styles": "^1.56.0",
         "@playwright/test": "^1.43.1",
@@ -2059,9 +2059,10 @@
       }
     },
     "node_modules/@bpmn-io/feel-editor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.3.0.tgz",
-      "integrity": "sha512-FuNEICeLuRHFWM7OQ0iBMXhd/iuzitbdSQlOfr0DqswVDsVUq24vV/ZTM1UnjdPp4J2gwhMuYi6a2LaiVNzRKQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.5.0.tgz",
+      "integrity": "sha512-BOn9joh5ha0g5SdJX3LlKrQ8FV2jUSxasNvZQhtywd6DtyCQM+qw0OqXloLZqunxBo51DedpNO/i+vggz3uwXA==",
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@codemirror/autocomplete": "^6.12.0",
@@ -2119,11 +2120,12 @@
       "link": true
     },
     "node_modules/@bpmn-io/properties-panel": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.18.2.tgz",
-      "integrity": "sha512-IQ6NUZ4McSmr6KLyptnhnKxBind5Oz+FSZ5u8MJX/s/10RRj+RIVYCBS2UnfCKHZCE9YMWTdCHdA7XQ4lIjuzw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.20.0.tgz",
+      "integrity": "sha512-XjTijxyjJRByZiDHodoXM6x8EcCalbSmBW/yu3c6WZeSsEUO95gFOPu8pTu+fmfGWg3xyD2o7cIs86r8vNe3NA==",
+      "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-editor": "^1.3.0",
+        "@bpmn-io/feel-editor": "^1.5.0",
         "@codemirror/view": "^6.14.0",
         "classnames": "^2.3.1",
         "feelers": "^1.3.0",
@@ -13148,6 +13150,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-2.0.0.tgz",
       "integrity": "sha512-cMD6EIhb7vyXLs4kXmaphfZZNr5SkbRxmkfsZUjUJzOV5YxyKBF73VI/8fC3GDUifzs0lVo2DruVszk5igrddg==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.9.1",
         "@codemirror/language": "^6.9.1",
@@ -21162,7 +21165,7 @@
       "dependencies": {
         "@bpmn-io/draggle": "^4.0.0",
         "@bpmn-io/form-js-viewer": "^1.8.7",
-        "@bpmn-io/properties-panel": "^3.18.2",
+        "@bpmn-io/properties-panel": "^3.20.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
         "ids": "^1.0.5",
@@ -22637,9 +22640,9 @@
       }
     },
     "@bpmn-io/feel-editor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.3.0.tgz",
-      "integrity": "sha512-FuNEICeLuRHFWM7OQ0iBMXhd/iuzitbdSQlOfr0DqswVDsVUq24vV/ZTM1UnjdPp4J2gwhMuYi6a2LaiVNzRKQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.5.0.tgz",
+      "integrity": "sha512-BOn9joh5ha0g5SdJX3LlKrQ8FV2jUSxasNvZQhtywd6DtyCQM+qw0OqXloLZqunxBo51DedpNO/i+vggz3uwXA==",
       "requires": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@codemirror/autocomplete": "^6.12.0",
@@ -22684,7 +22687,7 @@
       "requires": {
         "@bpmn-io/draggle": "^4.0.0",
         "@bpmn-io/form-js-viewer": "^1.8.7",
-        "@bpmn-io/properties-panel": "^3.18.2",
+        "@bpmn-io/properties-panel": "^3.20.0",
         "array-move": "^3.0.1",
         "big.js": "^6.2.1",
         "ids": "^1.0.5",
@@ -22756,11 +22759,11 @@
       "version": "file:packages/form-json-schema"
     },
     "@bpmn-io/properties-panel": {
-      "version": "3.18.2",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.18.2.tgz",
-      "integrity": "sha512-IQ6NUZ4McSmr6KLyptnhnKxBind5Oz+FSZ5u8MJX/s/10RRj+RIVYCBS2UnfCKHZCE9YMWTdCHdA7XQ4lIjuzw==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.20.0.tgz",
+      "integrity": "sha512-XjTijxyjJRByZiDHodoXM6x8EcCalbSmBW/yu3c6WZeSsEUO95gFOPu8pTu+fmfGWg3xyD2o7cIs86r8vNe3NA==",
       "requires": {
-        "@bpmn-io/feel-editor": "^1.3.0",
+        "@bpmn-io/feel-editor": "^1.5.0",
         "@codemirror/view": "^6.14.0",
         "classnames": "^2.3.1",
         "feelers": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/core": "^7.24.5",
     "@babel/plugin-transform-react-jsx": "^7.23.4",
     "@babel/plugin-transform-react-jsx-source": "^7.24.1",
-    "@bpmn-io/properties-panel": "^3.18.2",
+    "@bpmn-io/properties-panel": "^3.20.0",
     "@carbon/react": "^1.56.0",
     "@carbon/styles": "^1.56.0",
     "@playwright/test": "^1.43.1",

--- a/packages/form-js-editor/package.json
+++ b/packages/form-js-editor/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@bpmn-io/draggle": "^4.0.0",
     "@bpmn-io/form-js-viewer": "^1.8.7",
-    "@bpmn-io/properties-panel": "^3.18.2",
+    "@bpmn-io/properties-panel": "^3.20.0",
     "array-move": "^3.0.1",
     "big.js": "^6.2.1",
     "ids": "^1.0.5",

--- a/packages/form-js-editor/src/features/properties-panel/entries/StaticColumnsSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/StaticColumnsSourceEntry.js
@@ -44,6 +44,5 @@ export function StaticColumnsSourceEntry(props) {
   return {
     items,
     add: addEntry,
-    shouldSort: false,
   };
 }

--- a/packages/form-js-editor/src/features/properties-panel/entries/StaticOptionsSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/StaticOptionsSourceEntry.js
@@ -61,7 +61,6 @@ export function StaticOptionsSourceEntry(props) {
   return {
     items,
     add: addEntry,
-    shouldSort: false,
   };
 }
 

--- a/packages/form-js-editor/src/features/properties-panel/groups/CustomPropertiesGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/CustomPropertiesGroup.js
@@ -71,7 +71,6 @@ export function CustomPropertiesGroup(field, editField) {
     label: 'Custom properties',
     tooltip:
       'Add properties directly to the form schema, useful to configure functionality in custom-built task applications and form renderers.',
-    shouldSort: false,
   };
 }
 

--- a/packages/form-json-schema/test/fixtures/package-lock.json
+++ b/packages/form-json-schema/test/fixtures/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "fixtures",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closes #1200

See https://github.com/bpmn-io/properties-panel/commit/bb1cfb05a41f3e7632ace7f34927e198e43ad775 if you want to look into why this was done. But basically, list autoSorting was deemed an antifeature. It is completely gone from the properties panel and only throws a log warning. This PR clears those warnings.