### PR TITLE
fix: fix carbonization

### DIFF
--- a/e2e/carbon/carbon.scss
+++ b/e2e/carbon/carbon.scss
@@ -1,15 +1,15 @@
 @use '@carbon/styles' as * with (
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: '@ibm/plex'
 );
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme';
 
 @import '@bpmn-io/form-js-carbon-styles/src/carbon-styles';
 
-.cds--g10 {
+[data-carbon-theme='g10'] {
   @include theme.theme(themes.$g10);
 }
 
-.cds--g100 {
+[data-carbon-theme='g100'] {
   @include theme.theme(themes.$g100);
 }

--- a/e2e/carbon/index.html
+++ b/e2e/carbon/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-carbon-theme="g100">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -20,7 +20,7 @@
       }
     </style>
   </head>
-  <body class="cds--g100">
+  <body>
     <div id="container" role="main"></div>
     <script type="module" src="index.js"></script>
   </body>

--- a/e2e/carbon/theme.scss
+++ b/e2e/carbon/theme.scss
@@ -1,13 +1,13 @@
 @use '@carbon/styles' as * with (
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: '@ibm/plex'
 );
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme';
 
-.cds--g10 {
+[data-carbon-theme='g10'] {
   @include theme.theme(themes.$g10);
 }
 
-.cds--g100 {
+[data-carbon-theme='g100'] {
   @include theme.theme(themes.$g100);
 }

--- a/e2e/theming/index.html
+++ b/e2e/theming/index.html
@@ -20,7 +20,7 @@
       }
     </style>
   </head>
-  <body class="cds--g10">
+  <body>
     <div id="container" role="main"></div>
     <script type="module" src="index.js"></script>
   </body>

--- a/e2e/theming/theme.scss
+++ b/e2e/theming/theme.scss
@@ -1,13 +1,13 @@
 @use '@carbon/styles' as * with (
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: '@ibm/plex'
 );
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme';
 
-.cds--g10 {
+[data-carbon-theme='g10'] {
   @include theme.theme(themes.$g10);
 }
 
-.cds--g100 {
+[data-carbon-theme='g100'] {
   @include theme.theme(themes.$g100);
 }

--- a/e2e/visual/theming.spec.js
+++ b/e2e/visual/theming.spec.js
@@ -26,9 +26,7 @@ test('theming - viewer', async ({ page, makeAxeBuilder }) => {
   });
 
   await page.evaluate(() => {
-    const container = document.querySelector('body');
-    container.classList.remove('cds--g10');
-    container.classList.add('cds--g100');
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
   });
 
   // then
@@ -63,9 +61,7 @@ test('theming - editor', async ({ page, makeAxeBuilder }) => {
   });
 
   await page.evaluate(() => {
-    const container = document.querySelector('body');
-    container.classList.remove('cds--g10');
-    container.classList.add('cds--g100');
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
   });
 
   // then

--- a/packages/form-js-carbon-styles/src/carbon-styles.scss
+++ b/packages/form-js-carbon-styles/src/carbon-styles.scss
@@ -66,7 +66,7 @@
 
 // Themed icons /////////////
 
-.cds--g10 {
+[data-carbon-theme='g10'] {
   .fjs-container {
     .fjs-form-field-number .fjs-input-group {
       .fjs-number-arrow-container {
@@ -114,7 +114,7 @@
   }
 }
 
-.cds--g100 {
+[data-carbon-theme='g100'] {
   .fjs-container {
     .fjs-form-field-number .fjs-input-group {
       .fjs-number-arrow-container {
@@ -1269,7 +1269,7 @@
   }
 
   .fjs-table-th {
-    color: var(--cds-color-primary);
+    color: var(--cds-text-primary);
     font-size: var(--cds-heading-compact-01-font-size);
     font-weight: var(--cds-heading-compact-01-font-weight);
     line-height: var(--cds-heading-compact-01-line-height);

--- a/packages/form-js-carbon-styles/test/spec/carbon-styles.spec.js
+++ b/packages/form-js-carbon-styles/test/spec/carbon-styles.spec.js
@@ -50,9 +50,9 @@ describe('Carbon styles', function () {
 
   beforeEach(function () {
     container = document.createElement('div');
-    container.classList.add('cds--g100');
 
     document.body.appendChild(container);
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
   });
 
   !singleStart &&
@@ -107,7 +107,7 @@ describe('Carbon styles', function () {
     });
 
     toggle.addEventListener('click', () => {
-      toggleTheme(container);
+      toggleTheme();
       theme = theme === 'dark' ? 'light' : 'dark';
       createFormView(
         {
@@ -191,7 +191,7 @@ describe('Carbon styles', function () {
     });
 
     toggle.addEventListener('click', () => {
-      toggleTheme(container);
+      toggleTheme();
       theme = theme === 'dark' ? 'light' : 'dark';
       createFormView(
         {
@@ -284,7 +284,10 @@ function WithTheme(props) {
   return <ThemeProvider theme={theme}>{props.children}</ThemeProvider>;
 }
 
-function toggleTheme(node) {
-  node.classList.toggle('cds--g100');
-  node.classList.toggle('cds--g10');
+function toggleTheme() {
+  if (document.documentElement.dataset.carbonTheme === 'cds--g100') {
+    document.documentElement.setAttribute('data-carbon-theme', 'g10');
+  } else {
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
+  }
 }

--- a/packages/form-js-carbon-styles/test/spec/theme.scss
+++ b/packages/form-js-carbon-styles/test/spec/theme.scss
@@ -1,14 +1,14 @@
 @use '@carbon/react' as * with (
-  $font-path: 'https://fonts.camunda.io'
+  $font-path: '@ibm/plex'
 );
 
 @use '@carbon/react/scss/themes';
 @use '@carbon/react/scss/theme';
 
-.cds--g10 {
+[data-carbon-theme='g10'] {
   @include theme.theme(themes.$g10);
 }
 
-.cds--g100 {
+[data-carbon-theme='g100'] {
   @include theme.theme(themes.$g100);
 }

--- a/packages/form-js-editor/test/spec/FormEditor.spec.js
+++ b/packages/form-js-editor/test/spec/FormEditor.spec.js
@@ -86,7 +86,7 @@ describe('FormEditor', function () {
 
   (singleStartTheme ? it.only : it)('should render theme', async function () {
     // given
-    container.classList.add('cds--g100');
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
     insertTheme();
 
     // when
@@ -104,7 +104,7 @@ describe('FormEditor', function () {
 
   (singleStartNoTheme ? it.only : it)('should render with no theme', async function () {
     // given
-    container.classList.add('cds--g10');
+    document.documentElement.setAttribute('data-carbon-theme', 'g10');
     container.style.backgroundColor = 'white';
     insertTheme();
 

--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -162,7 +162,7 @@ describe('Form', function () {
 
   (singleStartTheme ? it.only : it)('should render theme', async function () {
     // given
-    container.classList.add('cds--g100');
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
     insertTheme();
 
     const data = {
@@ -199,7 +199,7 @@ describe('Form', function () {
 
   (singleStartNoTheme ? it.only : it)('should render with no theme', async function () {
     // given
-    container.classList.add('cds--g10');
+    document.documentElement.setAttribute('data-carbon-theme', 'g100');
     container.style.backgroundColor = 'white';
     insertTheme();
 


### PR DESCRIPTION
The arrows in the select were broken because we removed the `.cds--g10` theme classes.
I also fixed an issue with a token that doesn't exist

![image](https://github.com/user-attachments/assets/b03d88a1-7f85-4909-a7fa-3c5eca15ebcc)
