### PR TITLE
chore: cleaned up usage examples in READMEs across repo

### DIFF
--- a/packages/form-js-editor/README.md
+++ b/packages/form-js-editor/README.md
@@ -14,6 +14,7 @@ npm install @bpmn-io/form-js-editor
 import { FormEditor } from '@bpmn-io/form-js-editor';
 
 const schema = {
+  type: 'default',
   components: [
     {
       key: 'creditor',

--- a/packages/form-js-playground/README.md
+++ b/packages/form-js-playground/README.md
@@ -13,6 +13,24 @@ Integrate the playground into your application:
 ```javascript
 import { Playground } from '@bpmn-io/form-js-playground';
 
+const schema = {
+  type: 'default',
+  components: [
+    {
+      key: 'creditor',
+      label: 'Creditor',
+      type: 'textfield',
+      validate: {
+        required: true,
+      },
+    },
+  ],
+};
+
+const data = {
+  creditor: 'John Doe Company',
+};
+
 const playground = new Playground({
   container: document.querySelector('#container'),
   schema,

--- a/packages/form-js-viewer/README.md
+++ b/packages/form-js-viewer/README.md
@@ -14,6 +14,7 @@ npm install @bpmn-io/form-js-viewer
 import { Form } from '@bpmn-io/form-js-viewer';
 
 const schema = {
+  type: 'default',
   components: [
     {
       key: 'creditor',

--- a/packages/form-js/README.md
+++ b/packages/form-js/README.md
@@ -15,6 +15,24 @@ Renders a form based on [a form schema](./docs/FORM_SCHEMA.md) and existing data
 ```javascript
 import { Form } from '@bpmn-io/form-js';
 
+const schema = {
+  type: 'default',
+  components: [
+    {
+      key: 'creditor',
+      label: 'Creditor',
+      type: 'textfield',
+      validate: {
+        required: true,
+      },
+    },
+  ],
+};
+
+const data = {
+  creditor: 'John Doe Company',
+};
+
 const form = new Form({
   container: document.querySelector('#form'),
 });
@@ -50,6 +68,24 @@ Create and simulate a form with input and output data:
 
 ```javascript
 import { FormPlayground } from '@bpmn-io/form-js';
+
+const schema = {
+  type: 'default',
+  components: [
+    {
+      key: 'creditor',
+      label: 'Creditor',
+      type: 'textfield',
+      validate: {
+        required: true,
+      },
+    },
+  ],
+};
+
+const data = {
+  creditor: 'John Doe Company',
+};
 
 const formPlayground = new FormPlayground({
   container: document.querySelector('#form-playground'),


### PR DESCRIPTION
Closes #1175

READMEs should be pretty much independently readable so I added sample data and schemas everywhere so that there's no questions. Also added `type:default` that is an actual requirement for the forms, fixing the source issue. 