### PR TITLE
Soft deprecate config labels

### DIFF
--- a/packages/form-js-editor/src/features/palette/components/Palette.js
+++ b/packages/form-js-editor/src/features/palette/components/Palette.js
@@ -175,7 +175,8 @@ export function collectPaletteEntries(formFields) {
       const { config: fieldConfig } = formField;
 
       return {
-        label: fieldConfig.label,
+        // fieldConfig.label is used to maintain backwards compatibility with custom form fields
+        label: fieldConfig.name || fieldConfig.label,
         type: type,
         group: fieldConfig.group,
         icon: fieldConfig.icon,

--- a/packages/form-js-editor/src/features/properties-panel/PropertiesPanelHeaderProvider.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesPanelHeaderProvider.js
@@ -2,17 +2,12 @@ import { textToLabel } from './Util';
 import { iconsByType } from '../../render/components/icons';
 import { getPaletteIcon } from '../palette/components/Palette';
 
-const headerlessTypes = ['spacer', 'separator', 'expression', 'html'];
-
 export function getPropertiesPanelHeaderProvider(options = {}) {
   const { getDocumentationRef, formFields } = options;
 
   return {
     getElementLabel: (field) => {
       const { type } = field;
-      if (headerlessTypes.includes(type)) {
-        return '';
-      }
       if (type === 'datetime') {
         return field.dateLabel || field.timeLabel;
       }
@@ -45,7 +40,7 @@ export function getPropertiesPanelHeaderProvider(options = {}) {
         return 'Form';
       }
       const fieldDefinition = formFields.get(type).config;
-      return fieldDefinition.label || type;
+      return fieldDefinition.name || fieldDefinition.label || type;
     },
 
     getDocumentationRef,

--- a/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
+++ b/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
@@ -310,12 +310,12 @@ describe('core/FieldFactory', function () {
 
 // helpers //////////////
 
-function testCreate(options, isNew = true) {
+function testCreate(options, isNewField = true) {
   const { type, label, keyed = false, initial = {}, expected = {} } = options;
 
   return inject(function (fieldFactory) {
     // when
-    const field = fieldFactory.create({ type, ...initial }, isNew);
+    const field = fieldFactory.create({ type, ...initial }, isNewField);
 
     // then
     expect(field.id).to.exist;

--- a/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
+++ b/packages/form-js-editor/test/spec/core/FieldFactory.spec.js
@@ -13,7 +13,7 @@ describe('core/FieldFactory', function () {
       testCreate({
         type: 'button',
         label: 'Button',
-        defaults: {
+        expected: {
           action: 'submit',
         },
       }),
@@ -34,7 +34,7 @@ describe('core/FieldFactory', function () {
         type: 'checklist',
         label: 'Checkbox group',
         keyed: true,
-        defaults: {
+        expected: {
           values: [
             {
               label: 'Value',
@@ -50,7 +50,7 @@ describe('core/FieldFactory', function () {
       testCreate({
         type: 'default',
         keyed: false,
-        defaults: {
+        expected: {
           components: [],
         },
       }),
@@ -71,7 +71,7 @@ describe('core/FieldFactory', function () {
         type: 'radio',
         label: 'Radio group',
         keyed: true,
-        defaults: {
+        expected: {
           values: [
             {
               label: 'Value',
@@ -88,7 +88,7 @@ describe('core/FieldFactory', function () {
         type: 'select',
         label: 'Select',
         keyed: true,
-        defaults: {
+        expected: {
           values: [
             {
               label: 'Value',
@@ -105,7 +105,7 @@ describe('core/FieldFactory', function () {
         type: 'taglist',
         label: 'Tag list',
         keyed: true,
-        defaults: {
+        expected: {
           values: [
             {
               label: 'Value',
@@ -118,14 +118,17 @@ describe('core/FieldFactory', function () {
 
     it(
       'Date time',
-      testCreate({
-        type: 'datetime',
-        keyed: true,
-        defaults: {
-          subtype: 'date',
-          dateLabel: 'Date',
+      testCreate(
+        {
+          type: 'datetime',
+          keyed: true,
+          expected: {
+            subtype: 'date',
+            dateLabel: 'Date',
+          },
         },
-      }),
+        true,
+      ),
     );
 
     it(
@@ -141,19 +144,24 @@ describe('core/FieldFactory', function () {
       'Image view',
       testCreate({
         type: 'image',
-        label: 'Image view',
       }),
     );
   });
 
-  describe('#create (no defaults)', function () {
+  describe('#create (from import)', function () {
     it(
-      'Button',
+      'Datetime',
       testCreate(
         {
-          type: 'button',
-          defaults: {
-            action: 'submit',
+          type: 'datetime',
+          keyed: true,
+          initial: {
+            subtype: 'time',
+            timeLabel: 'Time',
+          },
+          expected: {
+            subtype: 'time',
+            timeLabel: 'Time',
           },
         },
         false,
@@ -302,12 +310,12 @@ describe('core/FieldFactory', function () {
 
 // helpers //////////////
 
-function testCreate(options, applyDefaults = true) {
-  const { type, label, keyed = false, defaults = {} } = options;
+function testCreate(options, isNew = true) {
+  const { type, label, keyed = false, initial = {}, expected = {} } = options;
 
   return inject(function (fieldFactory) {
     // when
-    const field = fieldFactory.create({ type }, applyDefaults);
+    const field = fieldFactory.create({ type, ...initial }, isNew);
 
     // then
     expect(field.id).to.exist;
@@ -326,6 +334,6 @@ function testCreate(options, applyDefaults = true) {
       expect(field.label).not.to.exist;
     }
 
-    expect(field).to.deep.contain(defaults);
+    expect(field).to.deep.contain(expected);
   });
 }

--- a/packages/form-js-editor/test/spec/render/components/form-fields/EditorText.spec.js
+++ b/packages/form-js-editor/test/spec/render/components/form-fields/EditorText.spec.js
@@ -105,7 +105,7 @@ describe('Text', function () {
     // assume
     const { config } = EditorText;
     expect(config.type).to.eql('text');
-    expect(config.label).to.eql('Text view');
+    expect(config.name).to.eql('Text view');
     expect(config.group).to.eql('presentation');
     expect(config.keyed).to.be.false;
 

--- a/packages/form-js-viewer/src/core/FieldFactory.js
+++ b/packages/form-js-viewer/src/core/FieldFactory.js
@@ -13,7 +13,7 @@ export class FieldFactory {
     this._formFields = formFields;
   }
 
-  create(attrs, isNew = true) {
+  create(attrs, isNewField = true) {
     const { id, type, key, path, _parent } = attrs;
 
     const fieldDefinition = this._formFields.get(type);
@@ -65,7 +65,7 @@ export class FieldFactory {
         ...(config.label ? { label: config.label } : {}),
         ...attrs,
       },
-      isNew,
+      isNewField,
     );
 
     this._ensureId(field);

--- a/packages/form-js-viewer/src/core/FieldFactory.js
+++ b/packages/form-js-viewer/src/core/FieldFactory.js
@@ -13,7 +13,7 @@ export class FieldFactory {
     this._formFields = formFields;
   }
 
-  create(attrs, applyDefaults = true) {
+  create(attrs, isNew = true) {
     const { id, type, key, path, _parent } = attrs;
 
     const fieldDefinition = this._formFields.get(type);
@@ -60,14 +60,13 @@ export class FieldFactory {
       throw new Error(`binding path '${[...parentPath, ...path.split('.')].join('.')}' is already claimed`);
     }
 
-    // currently using a hard coded solution while we evaluate refactoring
-    // cf. https://github.com/bpmn-io/form-js/issues/1291
-    const shouldApplyLabel = applyDefaults && !(config.type === 'datetime') && config.label;
-
-    const field = config.create({
-      ...(shouldApplyLabel ? { label: config.label } : {}),
-      ...attrs,
-    });
+    const field = config.create(
+      {
+        ...(config.label ? { label: config.label } : {}),
+        ...attrs,
+      },
+      isNew,
+    );
 
     this._ensureId(field);
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Button.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Button.js
@@ -27,9 +27,10 @@ export function Button(props) {
 Button.config = {
   type,
   keyed: false,
-  label: 'Button',
+  name: 'Button',
   group: 'action',
   create: (options = {}) => ({
+    label: 'Button',
     action: 'submit',
     ...options,
   }),

--- a/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checkbox.js
@@ -52,11 +52,12 @@ export function Checkbox(props) {
 Checkbox.config = {
   type,
   keyed: true,
-  label: 'Checkbox',
+  name: 'Checkbox',
   group: 'selection',
   emptyValue: false,
   sanitizeValue: ({ value }) => value === true,
   create: (options = {}) => ({
+    label: 'Checkbox',
     ...options,
   }),
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Checklist.js
@@ -106,9 +106,12 @@ export function Checklist(props) {
 Checklist.config = {
   type,
   keyed: true,
-  label: 'Checkbox group',
+  name: 'Checkbox group',
   group: 'selection',
   emptyValue: [],
   sanitizeValue: sanitizeMultiSelectValue,
-  create: createEmptyOptions,
+  create: (options = {}) => ({
+    label: 'Checkbox group',
+    ...createEmptyOptions(options),
+  }),
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
@@ -214,11 +214,11 @@ Datetime.config = {
   group: 'basic-input',
   emptyValue: null,
   sanitizeValue: sanitizeDateTimePickerValue,
-  create: (options = {}, isNew) => {
+  create: (options = {}, isNewField) => {
     const defaults = {};
     set(defaults, DATETIME_SUBTYPE_PATH, DATETIME_SUBTYPES.DATE);
 
-    if (isNew) {
+    if (isNewField) {
       set(defaults, DATE_LABEL_PATH, 'Date');
     }
 

--- a/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Datetime.js
@@ -210,14 +210,17 @@ export function Datetime(props) {
 Datetime.config = {
   type,
   keyed: true,
-  label: 'Date time',
+  name: 'Date time',
   group: 'basic-input',
   emptyValue: null,
   sanitizeValue: sanitizeDateTimePickerValue,
-  create: (options = {}) => {
+  create: (options = {}, isNew) => {
     const defaults = {};
     set(defaults, DATETIME_SUBTYPE_PATH, DATETIME_SUBTYPES.DATE);
-    set(defaults, DATE_LABEL_PATH, 'Date');
+
+    if (isNew) {
+      set(defaults, DATE_LABEL_PATH, 'Date');
+    }
 
     return { ...defaults, ...options };
   },

--- a/packages/form-js-viewer/src/render/components/form-fields/DynamicList.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DynamicList.js
@@ -31,9 +31,10 @@ DynamicList.config = {
   type: 'dynamiclist',
   pathed: true,
   repeatable: true,
-  label: 'Dynamic list',
+  name: 'Dynamic list',
   group: 'container',
   create: (options = {}) => ({
+    label: 'Dynamic list',
     components: [],
     showOutline: true,
     isRepeating: true,

--- a/packages/form-js-viewer/src/render/components/form-fields/ExpressionField.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/ExpressionField.js
@@ -42,7 +42,7 @@ export function ExpressionField(props) {
 
 ExpressionField.config = {
   type,
-  label: 'Expression',
+  name: 'Expression',
   group: 'basic-input',
   keyed: true,
   emptyValue: null,

--- a/packages/form-js-viewer/src/render/components/form-fields/Group.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Group.js
@@ -26,9 +26,10 @@ export function Group(props) {
 Group.config = {
   type: 'group',
   pathed: true,
-  label: 'Group',
+  name: 'Group',
   group: 'container',
   create: (options = {}) => ({
+    label: 'Group',
     components: [],
     showOutline: true,
     ...options,

--- a/packages/form-js-viewer/src/render/components/form-fields/Html.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Html.js
@@ -64,7 +64,7 @@ export function Html(props) {
 Html.config = {
   type,
   keyed: false,
-  label: 'HTML view',
+  name: 'HTML view',
   group: 'presentation',
   create: (options = {}) => ({
     content: '',

--- a/packages/form-js-viewer/src/render/components/form-fields/IFrame.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/IFrame.js
@@ -65,9 +65,10 @@ function IFramePlaceholder(props) {
 IFrame.config = {
   type,
   keyed: false,
-  label: 'iFrame',
+  name: 'iFrame',
   group: 'container',
   create: (options = {}) => ({
+    label: 'iFrame',
     security: {
       allowScripts: true,
     },

--- a/packages/form-js-viewer/src/render/components/form-fields/Image.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Image.js
@@ -47,9 +47,7 @@ export function Image(props) {
 Image.config = {
   type,
   keyed: false,
-  label: 'Image view',
+  name: 'Image view',
   group: 'presentation',
-  create: (options = {}) => ({
-    ...options,
-  }),
+  create: (options = {}) => options,
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -224,7 +224,7 @@ export function Numberfield(props) {
 Numberfield.config = {
   type,
   keyed: true,
-  label: 'Number',
+  name: 'Number',
   group: 'basic-input',
   emptyValue: null,
   sanitizeValue: ({ value, formField }) => {
@@ -235,6 +235,7 @@ Numberfield.config = {
     return formField.serializeToString ? value.toString() : Number(value);
   },
   create: (options = {}) => ({
+    label: 'Number',
     ...options,
   }),
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Radio.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Radio.js
@@ -108,9 +108,12 @@ export function Radio(props) {
 Radio.config = {
   type,
   keyed: true,
-  label: 'Radio group',
+  name: 'Radio group',
   group: 'selection',
   emptyValue: null,
   sanitizeValue: sanitizeSingleSelectValue,
-  create: createEmptyOptions,
+  create: (options = {}) => ({
+    label: 'Radio group',
+    ...createEmptyOptions(options),
+  }),
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Select.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Select.js
@@ -55,9 +55,12 @@ export function Select(props) {
 Select.config = {
   type,
   keyed: true,
-  label: 'Select',
+  name: 'Select',
   group: 'selection',
   emptyValue: null,
   sanitizeValue: sanitizeSingleSelectValue,
-  create: createEmptyOptions,
+  create: (options = {}) => ({
+    label: 'Select',
+    ...createEmptyOptions(options),
+  }),
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Separator.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Separator.js
@@ -13,7 +13,7 @@ export function Separator() {
 Separator.config = {
   type,
   keyed: false,
-  label: 'Separator',
+  name: 'Separator',
   group: 'presentation',
   create: (options = {}) => ({
     ...options,

--- a/packages/form-js-viewer/src/render/components/form-fields/Spacer.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Spacer.js
@@ -12,7 +12,7 @@ export function Spacer(props) {
 Spacer.config = {
   type,
   keyed: false,
-  label: 'Spacer',
+  name: 'Spacer',
   group: 'presentation',
   create: (options = {}) => ({
     height: 60,

--- a/packages/form-js-viewer/src/render/components/form-fields/Table.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Table.js
@@ -194,7 +194,7 @@ export function Table(props) {
 Table.config = {
   type,
   keyed: false,
-  label: 'Table',
+  name: 'Table',
   group: 'presentation',
   create: (options = {}) => {
     const { id, columnsExpression, columns, rowCount, ...remainingOptions } = options;
@@ -221,6 +221,7 @@ Table.config = {
 
     return {
       ...remainingOptions,
+      label: 'Table',
       rowCount: 10,
       columns: [
         {

--- a/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Taglist.js
@@ -245,9 +245,12 @@ export function Taglist(props) {
 Taglist.config = {
   type,
   keyed: true,
-  label: 'Tag list',
+  name: 'Tag list',
   group: 'selection',
   emptyValue: [],
   sanitizeValue: sanitizeMultiSelectValue,
-  create: createEmptyOptions,
+  create: (options = {}) => ({
+    label: 'Tag list',
+    ...createEmptyOptions(options),
+  }),
 };

--- a/packages/form-js-viewer/src/render/components/form-fields/Text.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Text.js
@@ -60,7 +60,7 @@ export function Text(props) {
 Text.config = {
   type,
   keyed: false,
-  label: 'Text view',
+  name: 'Text view',
   group: 'presentation',
   create: (options = {}) => ({
     text: '# Text',

--- a/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textarea.js
@@ -76,11 +76,11 @@ export function Textarea(props) {
 Textarea.config = {
   type,
   keyed: true,
-  label: 'Text area',
+  name: 'Text area',
   group: 'basic-input',
   emptyValue: '',
   sanitizeValue: ({ value }) => (isArray(value) || isObject(value) || isNil(value) ? '' : String(value)),
-  create: (options = {}) => ({ ...options }),
+  create: (options = {}) => ({ label: 'Text area', ...options }),
 };
 
 const autoSizeTextarea = (textarea) => {

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -65,7 +65,7 @@ export function Textfield(props) {
 Textfield.config = {
   type,
   keyed: true,
-  label: 'Text field',
+  name: 'Text field',
   group: 'basic-input',
   emptyValue: '',
   sanitizeValue: ({ value }) => {
@@ -80,5 +80,5 @@ Textfield.config = {
 
     return String(value);
   },
-  create: (options = {}) => ({ ...options }),
+  create: (options = {}) => ({ label: 'Text field', ...options }),
 };

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Button.spec.js
@@ -106,7 +106,7 @@ describe('Button', function () {
     // assume
     const { config } = Button;
     expect(config.type).to.eql('button');
-    expect(config.label).to.eql('Button');
+    expect(config.name).to.eql('Button');
     expect(config.group).to.eql('action');
     expect(config.keyed).to.be.false;
 
@@ -115,6 +115,7 @@ describe('Button', function () {
 
     // then
     expect(field).to.eql({
+      label: 'Button',
       action: 'submit',
     });
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checkbox.spec.js
@@ -153,7 +153,7 @@ describe('Checkbox', function () {
     // assume
     const { config } = Checkbox;
     expect(config.type).to.eql('checkbox');
-    expect(config.label).to.eql('Checkbox');
+    expect(config.name).to.eql('Checkbox');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 
@@ -161,7 +161,9 @@ describe('Checkbox', function () {
     const field = config.create();
 
     // then
-    expect(field).to.eql({});
+    expect(field).to.eql({
+      label: 'Checkbox',
+    });
 
     // but when
     const customField = config.create({

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Checklist.spec.js
@@ -414,7 +414,7 @@ describe('Checklist', function () {
     // assume
     const { config } = Checklist;
     expect(config.type).to.eql('checklist');
-    expect(config.label).to.eql('Checkbox group');
+    expect(config.name).to.eql('Checkbox group');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 
@@ -423,6 +423,7 @@ describe('Checklist', function () {
 
     // then
     expect(field).to.eql({
+      label: 'Checkbox group',
       values: [
         {
           label: 'Value',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Datetime.spec.js
@@ -895,12 +895,28 @@ describe('Datetime', function () {
     expect(config.keyed).to.be.true;
 
     // when
-    const field = config.create();
+    const field = config.create({}, true);
 
     // then
     expect(field).to.eql({
       subtype: 'date',
       dateLabel: 'Date',
+    });
+
+    // but when
+    const timeField = config.create({
+      subtype: 'time',
+      timeLabel: 'Time',
+      timeSerializingFormat: 'no_timezone',
+      timeInterval: 15,
+    });
+
+    // then
+    expect(timeField).to.eql({
+      subtype: 'time',
+      timeLabel: 'Time',
+      timeSerializingFormat: 'no_timezone',
+      timeInterval: 15,
     });
 
     // but when

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Dynamiclist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Dynamiclist.spec.js
@@ -234,11 +234,13 @@ describe('Dynamic List', () => {
 
     // then
     expect(config.type).to.eql('dynamiclist');
+    expect(config.name).to.eql('Dynamic list');
     expect(config.repeatable).to.be.true;
     expect(config.pathed).to.be.true;
 
     const field = config.create();
     expect(field).to.eql({
+      label: 'Dynamic list',
       components: [],
       showOutline: true,
       isRepeating: true,

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Group.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Group.spec.js
@@ -103,7 +103,7 @@ describe('Group', () => {
     // assume
     const { config } = Group;
     expect(config.type).to.eql('group');
-    expect(config.label).to.eql('Group');
+    expect(config.name).to.eql('Group');
     expect(config.group).to.eql('container');
     expect(config.pathed).to.be.true;
 
@@ -112,6 +112,7 @@ describe('Group', () => {
 
     // then
     expect(field).to.eql({
+      label: 'Group',
       components: [],
       showOutline: true,
     });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/IFrame.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/IFrame.spec.js
@@ -229,7 +229,7 @@ describe('IFrame', function () {
     // assume
     const { config } = IFrame;
     expect(config.type).to.eql('iframe');
-    expect(config.label).to.eql('iFrame');
+    expect(config.name).to.eql('iFrame');
     expect(config.group).to.eql('container');
     expect(config.keyed).to.be.false;
 
@@ -237,7 +237,12 @@ describe('IFrame', function () {
     const field = config.create();
 
     // then
-    expect(field).to.exist;
+    expect(field).to.eql({
+      label: 'iFrame',
+      security: {
+        allowScripts: true,
+      },
+    });
 
     // but when
     const customField = config.create({

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Image.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Image.spec.js
@@ -217,7 +217,7 @@ describe('Image', function () {
     // assume
     const { config } = Image;
     expect(config.type).to.eql('image');
-    expect(config.label).to.eql('Image view');
+    expect(config.name).to.eql('Image view');
     expect(config.group).to.eql('presentation');
     expect(config.keyed).to.be.false;
 
@@ -225,7 +225,7 @@ describe('Image', function () {
     const field = config.create();
 
     // then
-    expect(field).to.exist;
+    expect(field).to.eql({});
 
     // but when
     const customField = config.create({

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -769,7 +769,7 @@ describe('Number', function () {
     // assume
     const { config } = Numberfield;
     expect(config.type).to.eql('number');
-    expect(config.label).to.eql('Number');
+    expect(config.name).to.eql('Number');
     expect(config.group).to.eql('basic-input');
     expect(config.keyed).to.be.true;
 
@@ -777,7 +777,9 @@ describe('Number', function () {
     const field = config.create();
 
     // then
-    expect(field).to.eql({});
+    expect(field).to.eql({
+      label: 'Number',
+    });
 
     // but when
     const customField = config.create({

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Radio.spec.js
@@ -272,7 +272,7 @@ describe('Radio', function () {
     // assume
     const { config } = Radio;
     expect(config.type).to.eql('radio');
-    expect(config.label).to.eql('Radio group');
+    expect(config.name).to.eql('Radio group');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 
@@ -281,6 +281,7 @@ describe('Radio', function () {
 
     // then
     expect(field).to.eql({
+      label: 'Radio group',
       values: [
         {
           label: 'Value',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Select.spec.js
@@ -892,7 +892,7 @@ describe('Select', function () {
     // assume
     const { config } = Select;
     expect(config.type).to.eql('select');
-    expect(config.label).to.eql('Select');
+    expect(config.name).to.eql('Select');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 
@@ -901,6 +901,7 @@ describe('Select', function () {
 
     // then
     expect(field).to.eql({
+      label: 'Select',
       values: [
         {
           label: 'Value',
@@ -924,7 +925,7 @@ describe('Select', function () {
     // assume
     const { config } = Select;
     expect(config.type).to.eql('select');
-    expect(config.label).to.eql('Select');
+    expect(config.name).to.eql('Select');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 
@@ -950,7 +951,7 @@ describe('Select', function () {
     // assume
     const { config } = Select;
     expect(config.type).to.eql('select');
-    expect(config.label).to.eql('Select');
+    expect(config.name).to.eql('Select');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Table.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Table.spec.js
@@ -6,6 +6,7 @@ import { Table } from '../../../../../src/render/components/form-fields/Table';
 import { createFormContainer, expectNoViolations } from '../../../../TestHelper';
 
 import { MockFormContext } from '../helper';
+import { expect } from 'chai';
 
 let container;
 
@@ -433,7 +434,7 @@ describe('Table', function () {
     // assume
     const { config } = Table;
     expect(config.type).to.eql('table');
-    expect(config.label).to.eql('Table');
+    expect(config.name).to.eql('Table');
     expect(config.group).to.eql('presentation');
     expect(config.keyed).to.be.false;
 
@@ -442,6 +443,7 @@ describe('Table', function () {
 
     // then
     expect(field).to.exist;
+    expect(field.label).to.eql('Table');
 
     // but when
     const customField = config.create({

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Taglist.spec.js
@@ -684,7 +684,7 @@ describe('Taglist', function () {
     // assume
     const { config } = Taglist;
     expect(config.type).to.eql('taglist');
-    expect(config.label).to.eql('Tag list');
+    expect(config.name).to.eql('Tag list');
     expect(config.group).to.eql('selection');
     expect(config.keyed).to.be.true;
 
@@ -693,6 +693,7 @@ describe('Taglist', function () {
 
     // then
     expect(field).to.eql({
+      label: 'Tag list',
       values: [
         {
           label: 'Value',

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Text.spec.js
@@ -262,7 +262,7 @@ Some _em_ **strong** [text](#text) \`code\`.
     // assume
     const { config } = Text;
     expect(config.type).to.eql('text');
-    expect(config.label).to.eql('Text view');
+    expect(config.name).to.eql('Text view');
     expect(config.group).to.eql('presentation');
     expect(config.keyed).to.be.false;
 

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textarea.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textarea.spec.js
@@ -208,7 +208,7 @@ describe('Textarea', function () {
     // assume
     const { config } = Textarea;
     expect(config.type).to.eql('textarea');
-    expect(config.label).to.eql('Text area');
+    expect(config.name).to.eql('Text area');
     expect(config.group).to.eql('basic-input');
     expect(config.keyed).to.be.true;
 
@@ -216,7 +216,9 @@ describe('Textarea', function () {
     const field = config.create();
 
     // then
-    expect(field).to.eql({});
+    expect(field).to.eql({
+      label: 'Text area',
+    });
 
     // but when
     const customField = config.create({

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Textfield.spec.js
@@ -349,7 +349,7 @@ describe('Textfield', function () {
     // assume
     const { config } = Textfield;
     expect(config.type).to.eql('textfield');
-    expect(config.label).to.eql('Text field');
+    expect(config.name).to.eql('Text field');
     expect(config.group).to.eql('basic-input');
     expect(config.keyed).to.be.true;
 
@@ -357,7 +357,9 @@ describe('Textfield', function () {
     const field = config.create();
 
     // then
-    expect(field).to.eql({});
+    expect(field).to.eql({
+      label: 'Text field',
+    });
 
     // but when
     const customField = config.create({

--- a/packages/form-js/test/spec/FormEditor.spec.js
+++ b/packages/form-js/test/spec/FormEditor.spec.js
@@ -94,6 +94,7 @@ describe('editor exports', function () {
         components: [
           {
             id: 'number',
+            label: '',
             type: 'number',
             key: 'number',
           },


### PR DESCRIPTION
Closes #1291

I ended up trying to keep it minimal. Still keeping the isNew flag, but there's only one place where it HAD to be used. We are safe to default the labels now because in any case, if it's not new, the label should be '' (not undefined).