### PR TITLE
fix: prevent form editor from breaking on invalid expression on filepicker prop

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/FilePicker.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/FilePicker.js
@@ -36,7 +36,7 @@ export function FilePicker(props) {
   const { field, onChange, domId, errors = [], disabled, readonly, required, value: filesKey = '' } = props;
   const { label, multiple = false, accept = '' } = field;
   /** @type {string} */
-  const evaluatedAccept = useSingleLineTemplateEvaluation(accept);
+  const evaluatedAccept = useSingleLineTemplateEvaluation(accept, { debug: true });
   const evaluatedMultiple = useBooleanExpressionEvaluation(multiple);
   const errorMessageId = `${domId}-error-message`;
   /** @type {File[]} */


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

Closes https://github.com/camunda/camunda-modeler/issues/4644

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
