### PR TITLE
feat: add runtime implementation of document preview component

### DIFF
--- a/packages/form-js-carbon-styles/src/carbon-styles.scss
+++ b/packages/form-js-carbon-styles/src/carbon-styles.scss
@@ -1395,3 +1395,24 @@
     }
   }
 }
+
+// Document preview ////////////
+
+.fjs-container .fjs-form-field-documentPreview {
+  .fjs-documentPreview-single-document-container {
+    border-radius: 0;
+  }
+
+  .fjs-documentPreview-download-button {
+    border-radius: 0;
+    background-color: var(--cds-background);
+    border-color: var(--cds-button-tertiary);
+    color: var(--cds-button-tertiary);
+    cursor: pointer;
+
+    &:focus {
+      outline: 2px solid var(--cds-focus);
+      outline-offset: -2px;
+    }
+  }
+}

--- a/packages/form-js-editor/src/features/properties-panel/PropertiesProvider.js
+++ b/packages/form-js-editor/src/features/properties-panel/PropertiesProvider.js
@@ -10,6 +10,7 @@ import {
   TableHeaderGroups,
   LayoutGroup,
   SecurityAttributesGroup,
+  DownloadSettings,
 } from './groups';
 
 import { hasEntryConfigured } from './Util';
@@ -57,6 +58,7 @@ export class PropertiesProvider {
       groups = [
         ...groups,
         GeneralGroup(field, editField, getService),
+        DownloadSettings(field, editField),
         ...OptionsGroups(field, editField, getService),
         ...TableHeaderGroups(field, editField),
         SecurityAttributesGroup(field, editField),

--- a/packages/form-js-editor/src/features/properties-panel/entries/DocumentsDataSource.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DocumentsDataSource.js
@@ -42,8 +42,8 @@ function DocumentsDataSource(props) {
   {
     "documentId": "u123",
     "metadata": {
-      "filename": "Document.pdf",
-      "mimeType": "application/pdf"
+      "fileName": "Document.pdf",
+      "contentType": "application/pdf"
     }
   }
 ]`;

--- a/packages/form-js-editor/src/features/properties-panel/entries/DocumentsDataSource.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DocumentsDataSource.js
@@ -64,7 +64,7 @@ function DocumentsDataSource(props) {
     element: field,
     getValue,
     id,
-    label: 'Documents metadata source',
+    label: 'Document reference',
     feel: 'required',
     singleLine: true,
     setValue,

--- a/packages/form-js-editor/src/features/properties-panel/entries/DocumentsDataSource.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DocumentsDataSource.js
@@ -70,5 +70,18 @@ function DocumentsDataSource(props) {
     setValue,
     variables,
     tooltip,
+    validate,
   });
 }
+
+// helpers //////////
+
+/**
+ * @param {string|undefined} value
+ * @returns {string|null}
+ */
+const validate = (value) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return 'The document data source is required.';
+  }
+};

--- a/packages/form-js-editor/src/features/properties-panel/entries/EndpointKey.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/EndpointKey.js
@@ -40,21 +40,17 @@ function EndpointKey(props) {
 
   const tooltip = (
     <div>
-      <p>A context key that will be evaluated to a string containing the API endpoint for downloading a document.</p>
+      <p>Enter a context key that generates a string with the API endpoint to download a document.</p>
       <p>
-        This string must contain <br />
-        the <code>{'{ documentId }'}</code> placeholder which will be replaced with the document ID from the documents
-        metadata.
+        The string must contain <code>{'{ documentId }'}</code>, which will be replaced with the document ID from the
+        document's reference.
       </p>
+      <p>If you're using the Camunda Tasklist, this variable is automatically added to the context for you.</p>
       <p>
-        If you're using the Camunda Tasklist UI this variable will be automatically injected in the context for you.
-      </p>
-      <p>
-        Find more details in the{' '}
+        For more details, see the{' '}
         <a href="https://docs.camunda.io" rel="noopener noreferrer" target="_blank">
           Camunda documentation
         </a>
-        .
       </p>
     </div>
   );

--- a/packages/form-js-editor/src/features/properties-panel/entries/EndpointKey.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/EndpointKey.js
@@ -64,16 +64,27 @@ function EndpointKey(props) {
     element: field,
     getValue,
     id,
-    label: 'Document API endpoint key',
+    label: 'Document URL',
     feel: 'required',
     singleLine: true,
     setValue,
     variables,
     description,
     tooltip,
+    validate,
   });
 }
 
 // helpers //////////
 
-const description = <>An API endpoint for downloading a document</>;
+/**
+ * @param {string|undefined} value
+ * @returns {string|null}
+ */
+const validate = (value) => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return 'The document reference is required.';
+  }
+};
+
+const description = <>Define an API URL for downloading a document</>;

--- a/packages/form-js-editor/src/features/properties-panel/entries/MaxHeightEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/MaxHeightEntry.js
@@ -38,12 +38,13 @@ function MaxHeight(props) {
 
   return NumberFieldEntry({
     debounce,
-    label: 'Max height',
+    label: 'Max height of preview container',
     element: field,
     id,
     getValue,
     setValue,
     validate,
+    description,
   });
 }
 
@@ -70,3 +71,5 @@ const validate = (value) => {
     return 'Should be greater than zero.';
   }
 };
+
+const description = <>Documents with height that exceeds the defined value will be vertically scrollable</>;

--- a/packages/form-js-editor/src/features/properties-panel/groups/DownloadSettings.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/DownloadSettings.js
@@ -1,0 +1,15 @@
+import { EndpointKeyEntry } from '../entries';
+
+export function DownloadSettings(field, editField) {
+  const entries = [...EndpointKeyEntry({ field, editField })];
+
+  if (!entries.length) {
+    return null;
+  }
+
+  return {
+    id: 'downloadSettings',
+    label: 'Download settings',
+    entries,
+  };
+}

--- a/packages/form-js-editor/src/features/properties-panel/groups/GeneralGroup.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/GeneralGroup.js
@@ -27,7 +27,6 @@ import {
   AcceptEntry,
   MultipleEntry,
   DocumentsDataSourceEntry,
-  EndpointKeyEntry,
 } from '../entries';
 
 export function GeneralGroup(field, editField, getService) {
@@ -60,7 +59,6 @@ export function GeneralGroup(field, editField, getService) {
     ...PaginationEntry({ field, editField }),
     ...RowCountEntry({ field, editField }),
     ...DocumentsDataSourceEntry({ field, editField }),
-    ...EndpointKeyEntry({ field, editField }),
   ];
 
   if (entries.length === 0) {

--- a/packages/form-js-editor/src/features/properties-panel/groups/index.js
+++ b/packages/form-js-editor/src/features/properties-panel/groups/index.js
@@ -9,3 +9,4 @@ export { LayoutGroup } from './LayoutGroup';
 export { SecurityAttributesGroup } from './SecurityAttributesGroup';
 export { ConditionGroup } from './ConditionGroup';
 export { TableHeaderGroups } from './TableHeaderGroups';
+export { DownloadSettings } from './DownloadSettings';

--- a/packages/form-js-editor/src/render/components/editor-form-fields/EditorDocumentPreview.js
+++ b/packages/form-js-editor/src/render/components/editor-form-fields/EditorDocumentPreview.js
@@ -1,0 +1,25 @@
+import { iconsByType, DocumentPreview, Label } from '@bpmn-io/form-js-viewer';
+
+import { editorFormFieldClasses } from '../Util';
+
+export function EditorDocumentPreview(props) {
+  const { field, domId } = props;
+
+  const { label } = field;
+
+  const Icon = iconsByType(field.type);
+
+  return (
+    <div class={editorFormFieldClasses(field.type)}>
+      <Label id={domId} label={label} />
+      <div class="fjs-documentPreview-placeholder" id={domId}>
+        <p class="fjs-documentPreview-placeholder-text">
+          <Icon width="32" height="24" viewBox="0 0 56 56" />
+          Document preview
+        </p>
+      </div>
+    </div>
+  );
+}
+
+EditorDocumentPreview.config = DocumentPreview.config;

--- a/packages/form-js-editor/src/render/components/editor-form-fields/index.js
+++ b/packages/form-js-editor/src/render/components/editor-form-fields/index.js
@@ -3,5 +3,13 @@ import { EditorText } from './EditorText';
 import { EditorHtml } from './EditorHtml';
 import { EditorTable } from './EditorTable';
 import { EditorExpressionField } from './EditorExpressionField';
+import { EditorDocumentPreview } from './EditorDocumentPreview';
 
-export const editorFormFields = [EditorIFrame, EditorText, EditorHtml, EditorTable, EditorExpressionField];
+export const editorFormFields = [
+  EditorIFrame,
+  EditorText,
+  EditorHtml,
+  EditorTable,
+  EditorExpressionField,
+  EditorDocumentPreview,
+];

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -3449,7 +3449,7 @@ describe('properties panel', function () {
 
         // then
         expectPanelStructure(container, {
-          General: ['Title', 'Documents metadata source'],
+          General: ['Title', 'Document reference'],
           'Download settings': ['Document URL'],
           Condition: [],
           Appearance: ['Max height of preview container'],

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -3449,9 +3449,10 @@ describe('properties panel', function () {
 
         // then
         expectPanelStructure(container, {
-          General: ['Title', 'Documents metadata source', 'Document API endpoint key'],
+          General: ['Title', 'Documents metadata source'],
+          'Download settings': ['Document URL'],
           Condition: [],
-          Appearance: ['Max height'],
+          Appearance: ['Max height of preview container'],
           'Custom properties': [],
         });
       });

--- a/packages/form-js-editor/test/spec/form.json
+++ b/packages/form-js-editor/test/spec/form.json
@@ -247,7 +247,7 @@
       "accept": ".jpg,.png"
     },
     {
-      "title": "My documents",
+      "label": "My documents",
       "type": "documentPreview",
       "id": "myDocuments",
       "dataSource": "=myDocuments",

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -9,6 +9,7 @@ import { domify, query as domQuery, queryAll as domQueryAll } from 'min-dom';
 import { Playground } from '../../src';
 
 import schema from './form.json';
+// import schema from './temp.json';
 import otherSchema from './other-form.json';
 import rowsSchema from './rows-form.json';
 import customSchema from './custom.json';
@@ -82,6 +83,30 @@ describe('playground', function () {
       tags: ['tag1', 'tag2', 'tag3'],
       conversation: '2010-06-06T12:00Z',
       language: 'english',
+      documents: [
+        {
+          documentId: 'document0',
+          metadata: {
+            filename: 'My document.pdf',
+            mimeType: 'application/pdf',
+          },
+        },
+        {
+          documentId: 'document1',
+          metadata: {
+            filename: 'My document.png',
+            mimeType: 'image/png',
+          },
+        },
+        {
+          documentId: 'document2',
+          metadata: {
+            filename: 'My document.zip',
+            mimeType: 'application/zip',
+          },
+        },
+      ],
+      defaultDocumentsEndpointKey: 'https://pub-280be5f41fe1419e8d236b586696129e.r2.dev/{documentId}',
     };
 
     // when

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -86,22 +86,22 @@ describe('playground', function () {
         {
           documentId: 'document0',
           metadata: {
-            filename: 'My document.pdf',
-            mimeType: 'application/pdf',
+            fileName: 'My document.pdf',
+            contentType: 'application/pdf',
           },
         },
         {
           documentId: 'document1',
           metadata: {
-            filename: 'My document.png',
-            mimeType: 'image/png',
+            fileName: 'My document.png',
+            contentType: 'image/png',
           },
         },
         {
           documentId: 'document2',
           metadata: {
-            filename: 'My document.zip',
-            mimeType: 'application/zip',
+            fileName: 'My document.zip',
+            contentType: 'application/zip',
           },
         },
       ],

--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -9,7 +9,6 @@ import { domify, query as domQuery, queryAll as domQueryAll } from 'min-dom';
 import { Playground } from '../../src';
 
 import schema from './form.json';
-// import schema from './temp.json';
 import otherSchema from './other-form.json';
 import rowsSchema from './rows-form.json';
 import customSchema from './custom.json';

--- a/packages/form-js-playground/test/spec/form.json
+++ b/packages/form-js-playground/test/spec/form.json
@@ -260,6 +260,12 @@
       "type": "image"
     },
     {
+      "label": "Document preview",
+      "type": "documentPreview",
+      "dataSource": "=documents",
+      "id": "Field_1w82te0"
+    },
+    {
       "label": "Submit",
       "type": "button"
     },

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -63,6 +63,7 @@
   --color-borders: var(--cds-border-strong, var(--cds-border-strong-01, var(--color-grey-225-10-55)));
   --color-borders-group: var(--cds-border-subtle, var(--color-grey-225-10-85));
   --color-borders-table: var(--color-borders-group);
+  --color-borders-documentPreview: var(--cds-border-subtle, var(--color-grey-225-10-85));
   --color-borders-disabled: var(--cds-border-disabled, var(--color-grey-225-10-75));
   --color-borders-adornment: var(--cds-border-subtle, var(--cds-border-subtle-01, var(--color-grey-225-10-85)));
   --color-borders-readonly: var(--cds-border-subtle, var(--color-grey-225-10-75));
@@ -1023,7 +1024,8 @@
 }
 
 .fjs-container .fjs-image-placeholder,
-.fjs-container .fjs-iframe-placeholder {
+.fjs-container .fjs-iframe-placeholder,
+.fjs-container .fjs-documentPreview-placeholder {
   margin: 4px 0;
   width: 100%;
   height: 90px;
@@ -1033,12 +1035,14 @@
   color: var(--color-text-light);
 }
 
-.fjs-container .fjs-iframe-placeholder {
+.fjs-container .fjs-iframe-placeholder,
+.fjs-container .fjs-documentPreview-placeholder {
   border: 1px solid var(--color-borders-readonly);
 }
 
 .fjs-container .fjs-image-placeholder .fjs-image-placeholder-inner,
-.fjs-container .fjs-iframe-placeholder .fjs-iframe-placeholder-text {
+.fjs-container .fjs-iframe-placeholder .fjs-iframe-placeholder-text,
+.fjs-container .fjs-documentPreview-placeholder .fjs-documentPreview-placeholder-text {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1046,7 +1050,8 @@
   overflow: hidden;
 }
 
-.fjs-container .fjs-iframe-placeholder .fjs-iframe-placeholder-text {
+.fjs-container .fjs-iframe-placeholder .fjs-iframe-placeholder-text,
+.fjs-container .fjs-documentPreview-placeholder .fjs-documentPreview-placeholder-text {
   font-size: var(--font-size-label);
 }
 
@@ -1151,6 +1156,73 @@
 .fjs-container .fjs-table-sort-icon-asc,
 .fjs-container .fjs-table-sort-icon-desc {
   width: 16px;
+}
+
+.fjs-container .fjs-documentPreview-document-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fjs-container .fjs-documentPreview-single-document-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-borders-documentPreview);
+  border-radius: 3px;
+
+  .fjs-form-field-error {
+    align-self: flex-start;
+  }
+}
+
+.fjs-container .fjs-documentPreview-non-preview-item {
+  flex-direction: row;
+}
+
+.fjs-container .fjs-documentPreview-single-document-container:not(.fjs-documentPreview-non-preview-item) {
+  position: relative;
+  overflow-y: auto;
+}
+
+.fjs-container
+  .fjs-documentPreview-single-document-container:not(.fjs-documentPreview-non-preview-item)
+  .fjs-documentPreview-download-button {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 1;
+}
+
+.fjs-container .fjs-documentPreview-iframe {
+  all: unset;
+  width: 100%;
+  overflow: auto;
+  min-height: 400px;
+}
+
+.fjs-container .fjs-documentPreview-download-button {
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  border: 1px solid var(--color-borders-documentPreview);
+  background: var(--color-layer);
+  padding: 0;
+}
+
+.fjs-container .fjs-documentPreview-non-preview-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  color: var(--color-text-light);
 }
 
 .fjs-container .fjs-repeat-row-container {

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -1215,6 +1215,14 @@
   border: 1px solid var(--color-borders-documentPreview);
   background: var(--color-layer);
   padding: 0;
+
+  svg {
+    color: var(--color-text);
+  }
+
+  svg:focus {
+    outline: none;
+  }
 }
 
 .fjs-container .fjs-documentPreview-non-preview-item {

--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -1197,10 +1197,9 @@
   z-index: 1;
 }
 
-.fjs-container .fjs-documentPreview-iframe {
+.fjs-container .fjs-documentPreview-pdf-viewer {
   all: unset;
   width: 100%;
-  overflow: auto;
   min-height: 400px;
 }
 

--- a/packages/form-js-viewer/src/render/components/Errors.js
+++ b/packages/form-js-viewer/src/render/components/Errors.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef Props
+ * @property {string} id
+ * @property {string[]} errors
+ *
+ * @param {Props} props
+ * @returns {import("preact").JSX.Element}
+ */
 export function Errors(props) {
   const { errors, id } = props;
 

--- a/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
@@ -198,14 +198,7 @@ function DocumentRenderer(props) {
         class={singleDocumentContainerClassName}
         style={{ maxHeight }}
         aria-describedby={hasError ? errorMessageId : undefined}>
-        <iframe src={fullUrl} class={`fjs-${type}-iframe`} />
-        <DownloadButton
-          endpoint={fullUrl}
-          fileName={metadata.fileName}
-          onDownloadError={() => {
-            setHasError(true);
-          }}
-        />
+        <embed src={fullUrl} type="application/pdf" class={`fjs-${type}-pdf-viewer`} />
         {hasError ? <Errors id={errorMessageId} errors={[errorMessage]} /> : null}
       </div>
     );

--- a/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
@@ -13,8 +13,8 @@ const type = 'documentPreview';
  * @typedef DocumentMetadata
  * @property {string} documentId
  * @property {Object} metadata
- * @property {string} metadata.mimeType
- * @property {string} metadata.filename
+ * @property {string} metadata.contentType
+ * @property {string} metadata.fileName
  *
  * @typedef Field
  * @property {string} id
@@ -133,8 +133,8 @@ function isValidDocument(document) {
     'documentId' in document &&
     'metadata' in document &&
     typeof document.metadata === 'object' &&
-    'mimeType' in document.metadata &&
-    'filename' in document.metadata
+    'contentType' in document.metadata &&
+    'fileName' in document.metadata
   );
 }
 
@@ -173,16 +173,16 @@ function DocumentRenderer(props) {
   const errorMessageId = `${domId}-error-message`;
   const errorMessage = 'Unable to download document';
 
-  if (metadata.mimeType.toLowerCase().startsWith('image/') && isInViewport) {
+  if (metadata.contentType.toLowerCase().startsWith('image/') && isInViewport) {
     return (
       <div
         class={singleDocumentContainerClassName}
         style={{ maxHeight }}
         aria-describedby={hasError ? errorMessageId : undefined}>
-        <img src={fullUrl} alt={metadata.filename} class={`fjs-${type}-image`} />
+        <img src={fullUrl} alt={metadata.fileName} class={`fjs-${type}-image`} />
         <DownloadButton
           endpoint={fullUrl}
-          filename={metadata.filename}
+          fileName={metadata.fileName}
           onDownloadError={() => {
             setHasError(true);
           }}
@@ -192,7 +192,7 @@ function DocumentRenderer(props) {
     );
   }
 
-  if (metadata.mimeType.toLowerCase() === 'application/pdf' && isInViewport) {
+  if (metadata.contentType.toLowerCase() === 'application/pdf' && isInViewport) {
     return (
       <div
         class={singleDocumentContainerClassName}
@@ -201,7 +201,7 @@ function DocumentRenderer(props) {
         <iframe src={fullUrl} class={`fjs-${type}-iframe`} />
         <DownloadButton
           endpoint={fullUrl}
-          filename={metadata.filename}
+          fileName={metadata.fileName}
           onDownloadError={() => {
             setHasError(true);
           }}
@@ -217,12 +217,12 @@ function DocumentRenderer(props) {
       ref={ref}
       aria-describedby={hasError ? errorMessageId : undefined}>
       <div>
-        <div class="fjs-document-preview-title">{metadata.filename}</div>
+        <div class="fjs-document-preview-title">{metadata.fileName}</div>
         {hasError ? <Errors id={errorMessageId} errors={[errorMessage]} /> : null}
       </div>
       <DownloadButton
-        endpoint={endpoint}
-        filename={metadata.filename}
+        endpoint={fullUrl}
+        fileName={metadata.fileName}
         onDownloadError={() => {
           setHasError(true);
         }}
@@ -234,13 +234,13 @@ function DocumentRenderer(props) {
 /**
  * @param {Object} props
  * @param {string} props.endpoint
- * @param {string} props.filename
+ * @param {string} props.fileName
  * @param {Function} props.onDownloadError
  *
  * @returns {import("preact").JSX.Element}
  */
 function DownloadButton(props) {
-  const { endpoint, filename, onDownloadError } = props;
+  const { endpoint, fileName, onDownloadError } = props;
 
   const handleDownload = async () => {
     try {
@@ -255,7 +255,7 @@ function DownloadButton(props) {
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = filename;
+      link.download = fileName;
       link.click();
       window.URL.revokeObjectURL(url);
     } catch {
@@ -268,7 +268,7 @@ function DownloadButton(props) {
       type="button"
       onClick={handleDownload}
       class={classNames(`fjs-${type}-download-button`)}
-      aria-label={`Download ${filename}`}>
+      aria-label={`Download ${fileName}`}>
       <DownloadIcon />
     </button>
   );

--- a/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
@@ -13,7 +13,7 @@ const type = 'documentPreview';
  * @typedef DocumentMetadata
  * @property {string} documentId
  * @property {Object} metadata
- * @property {string} metadata.contentType
+ * @property {string|undefined} [metadata.contentType]
  * @property {string} metadata.fileName
  *
  * @typedef Field
@@ -133,7 +133,6 @@ function isValidDocument(document) {
     'documentId' in document &&
     'metadata' in document &&
     typeof document.metadata === 'object' &&
-    'contentType' in document.metadata &&
     'fileName' in document.metadata
   );
 }
@@ -172,8 +171,9 @@ function DocumentRenderer(props) {
   const singleDocumentContainerClassName = `fjs-${type}-single-document-container`;
   const errorMessageId = `${domId}-error-message`;
   const errorMessage = 'Unable to download document';
+  const isContentTypePresent = typeof metadata.contentType === 'string';
 
-  if (metadata.contentType.toLowerCase().startsWith('image/') && isInViewport) {
+  if (isContentTypePresent && metadata.contentType.toLowerCase().startsWith('image/') && isInViewport) {
     return (
       <div
         class={singleDocumentContainerClassName}
@@ -192,7 +192,7 @@ function DocumentRenderer(props) {
     );
   }
 
-  if (metadata.contentType.toLowerCase() === 'application/pdf' && isInViewport) {
+  if (isContentTypePresent && metadata.contentType.toLowerCase() === 'application/pdf' && isInViewport) {
     return (
       <div
         class={singleDocumentContainerClassName}

--- a/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
@@ -75,7 +75,7 @@ DocumentPreview.config = {
   name: 'Document preview',
   create: (options = {}) => ({
     label: 'Document preview',
-    endpointKey: '=defaultDocumentsEndpointKey',
+    endpointKey: DEFAULT_ENDPOINT_KEY,
     ...options,
   }),
 };
@@ -83,6 +83,7 @@ DocumentPreview.config = {
 // helpers /////////////////////////////
 
 const DOCUMENT_ID_PLACEHOLDER = '{documentId}';
+const DEFAULT_ENDPOINT_KEY = '=defaultDocumentsEndpointKey';
 
 /**
  * @typedef GetErrorOptions
@@ -98,16 +99,18 @@ function getErrors(options) {
   let errors = [];
 
   if (!isString(dataSource) || dataSource.length < 1) {
-    errors.push('Data source is not defined.');
+    errors.push('Document reference is not defined.');
   }
 
   if (!isString(endpointKey) || endpointKey.length < 1) {
     errors.push('Endpoint key is not defined.');
   }
 
-  if (!URL.canParse(endpoint)) {
-    errors.push('Endpoint is not valid.');
-  } else if (!isValidDocumentEndpoint(endpoint)) {
+  if (endpointKey !== DEFAULT_ENDPOINT_KEY && !URL.canParse(endpoint)) {
+    errors.push(
+      `If you change the endpoint key from "${DEFAULT_ENDPOINT_KEY}", the document preview won't work with Camunda Tasklist and you must provide a valid URL.`,
+    );
+  } else if (endpointKey !== DEFAULT_ENDPOINT_KEY && !isValidDocumentEndpoint(endpoint)) {
     errors.push('Endpoint must contain "{documentId}".');
   }
 

--- a/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
@@ -1,17 +1,309 @@
+import classNames from 'classnames';
+import { useExpressionEvaluation, useSingleLineTemplateEvaluation } from '../../hooks';
+import { Errors } from '../Errors';
+import { formFieldClasses } from '../Util';
+import { isString } from 'min-dash';
+import DownloadIcon from './icons/Download.svg';
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { Label } from '../Label';
+
+const type = 'documentPreview';
+
 /**
+ * @typedef DocumentMetadata
+ * @property {string} documentId
+ * @property {Object} metadata
+ * @property {string} metadata.mimeType
+ * @property {string} metadata.filename
+ *
+ * @typedef Field
+ * @property {string} id
+ * @property {string} [title]
+ * @property {string} [dataSource]
+ * @property {string} [endpointKey]
+ * @property {number} [maxHeight]
+ * @property {string} [label]
+ *
+ * @typedef Props
+ * @property {Field} field
+ * @property {string} domId
+ *
+ * @param {Props} props
  * @returns {import("preact").JSX.Element}
  */
-export function DocumentPreview() {
-  return null;
+export function DocumentPreview(props) {
+  const { field, domId } = props;
+  const { dataSource, endpointKey, maxHeight, label } = field;
+  const errorMessageId = `${domId}-error-message`;
+  const endpoint = useExpressionEvaluation(endpointKey || '');
+  const data = useValidDocumentData(dataSource || '');
+  const evaluatedLabel = useSingleLineTemplateEvaluation(label, { debug: true });
+
+  return (
+    <div class={formFieldClasses(type)}>
+      <Label htmlFor={domId} label={evaluatedLabel} />
+      <div class={`fjs-${type}-document-container`} id={domId}>
+        {isValidDocumentEndpoint(endpoint)
+          ? data.map((document, index) => (
+              <DocumentRenderer
+                key={document.documentId}
+                documentMetadata={document}
+                endpoint={endpoint}
+                maxHeight={maxHeight}
+                domId={`${domId}-${index}`}
+              />
+            ))
+          : null}
+      </div>
+
+      <Errors
+        id={errorMessageId}
+        errors={getErrors({
+          dataSource,
+          endpoint,
+          endpointKey,
+        })}
+      />
+    </div>
+  );
 }
 
 DocumentPreview.config = {
-  type: 'documentPreview',
+  type,
   keyed: false,
   group: 'presentation',
   name: 'Document preview',
   create: (options = {}) => ({
-    title: 'Document preview',
+    label: 'Document preview',
+    endpointKey: '=defaultDocumentsEndpointKey',
     ...options,
   }),
 };
+
+// helpers /////////////////////////////
+
+const DOCUMENT_ID_PLACEHOLDER = '{documentId}';
+
+/**
+ * @typedef GetErrorOptions
+ * @property {string|undefined} dataSource
+ * @property {string|undefined} endpointKey
+ * @property {string|null} endpoint
+ *
+ * @param {GetErrorOptions} options
+ * @returns {string[]}
+ */
+function getErrors(options) {
+  const { dataSource, endpointKey, endpoint } = options;
+  let errors = [];
+
+  if (!isString(dataSource) || dataSource.length < 1) {
+    errors.push('Data source is not defined.');
+  }
+
+  if (!isString(endpointKey) || endpointKey.length < 1) {
+    errors.push('Endpoint key is not defined.');
+  }
+
+  if (!URL.canParse(endpoint)) {
+    errors.push('Endpoint is not valid.');
+  } else if (!isValidDocumentEndpoint(endpoint)) {
+    errors.push('Endpoint must contain "{documentId}".');
+  }
+
+  return errors;
+}
+
+/**
+ *
+ * @param {unknown} endpoint
+ * @returns boolean
+ */
+function isValidDocumentEndpoint(endpoint) {
+  return typeof endpoint === 'string' && URL.canParse(endpoint) && endpoint.includes(DOCUMENT_ID_PLACEHOLDER);
+}
+
+/**
+ * @param {unknown} document
+ * @returns {metadata is DocumentMetadata}
+ */
+function isValidDocument(document) {
+  return (
+    typeof document === 'object' &&
+    'documentId' in document &&
+    'metadata' in document &&
+    typeof document.metadata === 'object' &&
+    'mimeType' in document.metadata &&
+    'filename' in document.metadata
+  );
+}
+
+/**
+ * @param {string} dataSource
+ * @returns {DocumentMetadata[]}
+ */
+function useValidDocumentData(dataSource) {
+  const data = useExpressionEvaluation(dataSource);
+
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  return data.filter(isValidDocument);
+}
+
+/**
+ *
+ * @param {Object} props
+ * @param {DocumentMetadata} props.documentMetadata
+ * @param {string} props.endpoint
+ * @param {string} props.domId
+ * @param {number|undefined} props.maxHeight
+ *
+ * @returns {import("preact").JSX.Element}
+ */
+function DocumentRenderer(props) {
+  const { documentMetadata, endpoint, maxHeight, domId } = props;
+  const { metadata } = documentMetadata;
+  const [hasError, setHasError] = useState(false);
+  const ref = useRef(null);
+  const isInViewport = useInViewport(ref);
+  const fullUrl = endpoint.replace(DOCUMENT_ID_PLACEHOLDER, documentMetadata.documentId);
+  const singleDocumentContainerClassName = `fjs-${type}-single-document-container`;
+  const errorMessageId = `${domId}-error-message`;
+  const errorMessage = 'Unable to download document';
+
+  if (metadata.mimeType.toLowerCase().startsWith('image/') && isInViewport) {
+    return (
+      <div
+        class={singleDocumentContainerClassName}
+        style={{ maxHeight }}
+        aria-describedby={hasError ? errorMessageId : undefined}>
+        <img src={fullUrl} alt={metadata.filename} class={`fjs-${type}-image`} />
+        <DownloadButton
+          endpoint={fullUrl}
+          filename={metadata.filename}
+          onDownloadError={() => {
+            setHasError(true);
+          }}
+        />
+        {hasError ? <Errors id={errorMessageId} errors={[errorMessage]} /> : null}
+      </div>
+    );
+  }
+
+  if (metadata.mimeType.toLowerCase() === 'application/pdf' && isInViewport) {
+    return (
+      <div
+        class={singleDocumentContainerClassName}
+        style={{ maxHeight }}
+        aria-describedby={hasError ? errorMessageId : undefined}>
+        <iframe src={fullUrl} class={`fjs-${type}-iframe`} />
+        <DownloadButton
+          endpoint={fullUrl}
+          filename={metadata.filename}
+          onDownloadError={() => {
+            setHasError(true);
+          }}
+        />
+        {hasError ? <Errors id={errorMessageId} errors={[errorMessage]} /> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      class={classNames(`fjs-${type}-non-preview-item`, `fjs-${type}-single-document-container`)}
+      ref={ref}
+      aria-describedby={hasError ? errorMessageId : undefined}>
+      <div>
+        <div class="fjs-document-preview-title">{metadata.filename}</div>
+        {hasError ? <Errors id={errorMessageId} errors={[errorMessage]} /> : null}
+      </div>
+      <DownloadButton
+        endpoint={endpoint}
+        filename={metadata.filename}
+        onDownloadError={() => {
+          setHasError(true);
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.endpoint
+ * @param {string} props.filename
+ * @param {Function} props.onDownloadError
+ *
+ * @returns {import("preact").JSX.Element}
+ */
+function DownloadButton(props) {
+  const { endpoint, filename, onDownloadError } = props;
+
+  const handleDownload = async () => {
+    try {
+      const response = await fetch(endpoint);
+
+      if (!response.ok) {
+        onDownloadError();
+        return;
+      }
+
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      link.click();
+      window.URL.revokeObjectURL(url);
+    } catch {
+      onDownloadError();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      class={classNames(`fjs-${type}-download-button`)}
+      aria-label={`Download ${filename}`}>
+      <DownloadIcon />
+    </button>
+  );
+}
+
+/**
+ *
+ * @param {import("preact").RefObject<HTMLElement>} ref
+ * @returns boolean
+ */
+function useInViewport(ref) {
+  const [isInViewport, setIsInViewport] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInViewport(true);
+        }
+      },
+      {
+        threshold: 0,
+      },
+    );
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, [ref]);
+
+  return isInViewport;
+}

--- a/packages/form-js-viewer/src/render/components/form-fields/icons/Download.svg
+++ b/packages/form-js-viewer/src/render/components/form-fields/icons/Download.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="currentColor" d="M13 12v2H3v-2H2v2c0 .553.448 1 1 1h10c.552 0 1-.447 1-1v-2h-1Zm0-5-.705-.705-3.795 3.79V1h-1v9.085l-3.795-3.79L3 7l5 5 5-5Z"/><path style="fill:none" d="M0 0h16v16H0V0Z"/></svg>

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
@@ -202,22 +202,22 @@ const initialData = {
     {
       documentId: 'document0',
       metadata: {
-        filename: 'My document.pdf',
-        mimeType: 'application/pdf',
+        fileName: 'My document.pdf',
+        contentType: 'application/pdf',
       },
     },
     {
       documentId: 'document1',
       metadata: {
-        filename: 'My document.png',
-        mimeType: 'image/png',
+        fileName: 'My document.png',
+        contentType: 'image/png',
       },
     },
     {
       documentId: 'document2',
       metadata: {
-        filename: 'My document.zip',
-        mimeType: 'application/zip',
+        fileName: 'My document.zip',
+        contentType: 'application/zip',
       },
     },
   ],

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
@@ -1,0 +1,250 @@
+import { render, screen } from '@testing-library/preact/pure';
+import { createFormContainer, expectNoViolations } from '../../../../TestHelper';
+import { MockFormContext } from '../helper';
+import { DocumentPreview } from '../../../../../src/render/components/form-fields/DocumentPreview';
+
+let container;
+
+describe('DocumentPreview', function () {
+  beforeEach(function () {
+    container = createFormContainer();
+  });
+
+  afterEach(function () {
+    container.remove();
+  });
+
+  it('should render', async function () {
+    // when
+    const { container } = createDocumentPreview({
+      initialData,
+      services: {
+        expressionLanguage: mockExpressionLanguageService,
+      },
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    expect(formField).to.exist;
+    expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
+
+    expect(screen.getByText('Document preview')).to.exist;
+    expect(screen.getByRole('button', { name: 'Download My document.pdf' })).to.exist;
+    expect(screen.getByRole('button', { name: 'Download My document.png' })).to.exist;
+    expect(screen.getByRole('button', { name: 'Download My document.zip' })).to.exist;
+    expect(screen.getByText('My document.pdf')).to.exist;
+    expect(screen.getByText('My document.png')).to.exist;
+    expect(screen.getByText('My document.zip')).to.exist;
+  });
+
+  it('should handle invalid endpoint value', function () {
+    // when
+    const { container } = createDocumentPreview({
+      initialData: {
+        defaultDocumentsEndpointKey: false,
+      },
+      services: {
+        expressionLanguage: mockExpressionLanguageService,
+      },
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    expect(formField).to.exist;
+    expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
+
+    expect(screen.queryByText('Endpoint is not valid.')).to.exist;
+  });
+
+  it('should handle bad endpoint format', function () {
+    // when
+    const { container } = createDocumentPreview({
+      initialData,
+      field: {
+        ...defaultField,
+        dataSource: undefined,
+      },
+      services: {
+        expressionLanguage: mockExpressionLanguageService,
+      },
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    expect(formField).to.exist;
+    expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
+
+    expect(screen.queryByText('Data source is not defined.')).to.exist;
+  });
+
+  it('should handle missing endpoint', function () {
+    // when
+    const { container } = createDocumentPreview({
+      initialData,
+      field: {
+        ...defaultField,
+        endpointKey: undefined,
+      },
+      services: {
+        expressionLanguage: mockExpressionLanguageService,
+      },
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    expect(formField).to.exist;
+    expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
+
+    expect(screen.queryByText('Endpoint key is not defined.')).to.exist;
+    expect(screen.queryByText('Endpoint is not valid.')).to.exist;
+  });
+
+  it('should handle missing data source', function () {
+    // when
+    const { container } = createDocumentPreview({
+      initialData: {
+        defaultDocumentsEndpointKey: 'https://pub-280be5f41fe1419e8d236b586696129e.r2.dev/{documentId}',
+      },
+      services: {
+        expressionLanguage: mockExpressionLanguageService,
+      },
+    });
+
+    // then
+    const formField = container.querySelector('.fjs-form-field');
+
+    expect(formField).to.exist;
+    expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
+  });
+
+  it('#create', function () {
+    // assume
+    const { config } = DocumentPreview;
+    expect(config.type).to.eql('documentPreview');
+    expect(config.name).to.eql('Document preview');
+    expect(config.group).to.eql('presentation');
+    expect(config.keyed).to.be.false;
+
+    // when
+    const field = config.create();
+
+    console.log({ field });
+
+    // then
+    expect(field).to.eql({
+      label: 'Document preview',
+      endpointKey: '=defaultDocumentsEndpointKey',
+    });
+
+    // but when
+    const customField = config.create({
+      custom: true,
+      endpointKey: '=foobar',
+    });
+
+    // then
+    expect(customField).to.contain({
+      custom: true,
+      endpointKey: '=foobar',
+    });
+  });
+
+  describe('a11y', function () {
+    it('should have no violations', async function () {
+      // given
+      this.timeout(10000);
+
+      const { container } = createDocumentPreview({
+        initialData,
+        services: {
+          expressionLanguage: mockExpressionLanguageService,
+        },
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+
+    it('should have no violations - security attributes', async function () {
+      // given
+      this.timeout(5000);
+
+      const { container } = createDocumentPreview({
+        initialData,
+        services: {
+          expressionLanguage: mockExpressionLanguageService,
+        },
+      });
+
+      // then
+      await expectNoViolations(container);
+    });
+  });
+});
+
+// helpers //////////
+
+const defaultField = {
+  title: 'Document preview',
+  type: 'documentPreview',
+  dataSource: '=documents',
+  endpointKey: '=defaultDocumentsEndpointKey',
+  id: 'myDocument',
+  label: 'Document preview',
+};
+
+const initialData = {
+  documents: [
+    {
+      documentId: 'document0',
+      metadata: {
+        filename: 'My document.pdf',
+        mimeType: 'application/pdf',
+      },
+    },
+    {
+      documentId: 'document1',
+      metadata: {
+        filename: 'My document.png',
+        mimeType: 'image/png',
+      },
+    },
+    {
+      documentId: 'document2',
+      metadata: {
+        filename: 'My document.zip',
+        mimeType: 'application/zip',
+      },
+    },
+  ],
+  defaultDocumentsEndpointKey: 'https://pub-280be5f41fe1419e8d236b586696129e.r2.dev/{documentId}',
+};
+
+const mockExpressionLanguageService = {
+  isExpression: () => true,
+  evaluate: (expression, context) => {
+    return context[expression.replace('=', '')];
+  },
+};
+
+function createDocumentPreview({ services, ...restOptions } = {}) {
+  const options = {
+    domId: 'test-documentPreview',
+    field: defaultField,
+    container,
+    ...restOptions,
+  };
+
+  return render(
+    <MockFormContext services={services} options={options}>
+      <DocumentPreview domId={options.domId} field={options.field} />
+    </MockFormContext>,
+    {
+      container: options.container || container.querySelector('.fjs-form'),
+    },
+  );
+}

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
@@ -42,7 +42,11 @@ describe('DocumentPreview', function () {
     // when
     const { container } = createDocumentPreview({
       initialData: {
-        defaultDocumentsEndpointKey: false,
+        foobar: false,
+      },
+      field: {
+        ...defaultField,
+        endpointKey: '=foobar',
       },
       services: {
         expressionLanguage: mockExpressionLanguageService,
@@ -55,7 +59,11 @@ describe('DocumentPreview', function () {
     expect(formField).to.exist;
     expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
 
-    expect(screen.queryByText('Endpoint is not valid.')).to.exist;
+    expect(
+      screen.queryByText(
+        'If you change the endpoint key from "=defaultDocumentsEndpointKey", the document preview won\'t work with Camunda Tasklist and you must provide a valid URL.',
+      ),
+    ).to.exist;
   });
 
   it('should handle bad endpoint format', function () {
@@ -77,30 +85,7 @@ describe('DocumentPreview', function () {
     expect(formField).to.exist;
     expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
 
-    expect(screen.queryByText('Data source is not defined.')).to.exist;
-  });
-
-  it('should handle missing endpoint', function () {
-    // when
-    const { container } = createDocumentPreview({
-      initialData,
-      field: {
-        ...defaultField,
-        endpointKey: undefined,
-      },
-      services: {
-        expressionLanguage: mockExpressionLanguageService,
-      },
-    });
-
-    // then
-    const formField = container.querySelector('.fjs-form-field');
-
-    expect(formField).to.exist;
-    expect(formField.classList.contains('fjs-form-field-documentPreview')).to.be.true;
-
-    expect(screen.queryByText('Endpoint key is not defined.')).to.exist;
-    expect(screen.queryByText('Endpoint is not valid.')).to.exist;
+    expect(screen.queryByText('Document reference is not defined.')).to.exist;
   });
 
   it('should handle missing data source', function () {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

Add runtime implementation of the document preview component and missing design fixes

Closes #1327

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
