### PR TITLE
fix: prevent table component from breaking with invalid data

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Table.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Table.js
@@ -1,4 +1,4 @@
-import { isDefined, isNumber, isObject, isString } from 'min-dash';
+import { isDefined, isNil, isNumber, isObject, isString } from 'min-dash';
 import { useExpressionEvaluation } from '../../hooks';
 import { useEffect, useState } from 'preact/hooks';
 import { formFieldClasses, prefixId } from '../Util';
@@ -45,7 +45,9 @@ export function Table(props) {
   const evaluatedColumns = useEvaluatedColumns(columnsExpression || '', columns);
   const columnKeys = evaluatedColumns.map(({ key }) => key);
   const evaluatedDataSource = useExpressionEvaluation(dataSource);
-  const data = Array.isArray(evaluatedDataSource) ? evaluatedDataSource.filter((i) => i !== undefined) : [];
+  const data = Array.isArray(evaluatedDataSource)
+    ? evaluatedDataSource.filter((entry) => !isNil(entry) || typeof entry !== 'object')
+    : [];
   const sortedData = sortBy === null ? data : sortByColumn(data, sortBy.key, sortBy.direction);
 
   /** @type {unknown[][]} */
@@ -56,14 +58,6 @@ export function Table(props) {
   useEffect(() => {
     setCurrentPage(0);
   }, [rowCount, sortBy]);
-
-  const serializeCellData = (cellData) => {
-    if (cellData !== null && typeof cellData === 'object') {
-      return JSON.stringify(cellData);
-    }
-
-    return cellData;
-  };
 
   /** @param {string} key */
   function toggleSortBy(key) {
@@ -341,4 +335,16 @@ function getHeaderAriaLabel(sortBy, key, label) {
   }
 
   return `Click to sort by ${label} ascending`;
+}
+
+/**
+ * @param {unknown} cellData
+ * @returns string
+ */
+function serializeCellData(cellData) {
+  if (cellData !== null && typeof cellData === 'object') {
+    return JSON.stringify(cellData);
+  }
+
+  return `${cellData || ''}`;
 }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
@@ -117,8 +117,6 @@ describe('DocumentPreview', function () {
     // when
     const field = config.create();
 
-    console.log({ field });
-
     // then
     expect(field).to.eql({
       label: 'Document preview',


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

This filters out invalid data from the table component which would make it break the entire editor if it happened.

Closes #1337

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
