### PR TITLE
feat: Inject content hash into document preview URL

### DIFF
--- a/packages/form-js-playground/test/spec/Playground.spec.js
+++ b/packages/form-js-playground/test/spec/Playground.spec.js
@@ -88,6 +88,9 @@ describe('playground', function () {
           metadata: {
             fileName: 'My document.pdf',
             contentType: 'application/pdf',
+            customProperties: {
+              contentHash: '1234567890',
+            },
           },
         },
         {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

This PR adds the content hash injection into the document preview URL so it works with Camunda Tasklist.
This is a temporary fix and we should try to remove it as soon as we can for the reasons explained here: https://github.com/bpmn-io/form-js/issues/1341

Closes #1340

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
