### PR TITLE
fix: reset default value when statid option is deleted

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/StaticOptionsSourceEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/StaticOptionsSourceEntry.js
@@ -19,7 +19,14 @@ export function StaticOptionsSourceEntry(props) {
   };
 
   const removeEntry = (entry) => {
-    editField(field, OPTIONS_SOURCES_PATHS[OPTIONS_SOURCES.STATIC], without(values, entry));
+    if (field.defaultValue === entry.value) {
+      editField(field, {
+        values: without(values, entry),
+        defaultValue: undefined,
+      });
+    } else {
+      editField(field, OPTIONS_SOURCES_PATHS[OPTIONS_SOURCES.STATIC], without(values, entry));
+    }
   };
 
   const validateFactory = (key, getValue) => {

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -874,6 +874,34 @@ describe('properties panel', function () {
           expect(editFieldSpy).to.have.been.calledWith(field, ['values'], [field.values[1], field.values[2]]);
         });
 
+        it('should remove option and clear default value if option was default', function () {
+          // given
+          const editFieldSpy = spy();
+
+          const field = {
+            ...schema.components.find(({ key }) => key === 'mailto'),
+            defaultValue: 'approver', // Set first option as default
+          };
+
+          bootstrapPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field,
+          });
+
+          const group = findGroup(container, 'Static options');
+
+          // when
+          const removeEntry = group.querySelector('.bio-properties-panel-remove-entry');
+          fireEvent.click(removeEntry);
+
+          // then
+          expect(editFieldSpy).to.have.been.calledWith(field, {
+            values: [field.values[1], field.values[2]],
+            defaultValue: undefined,
+          });
+        });
+
         describe('validation', function () {
           describe('value', function () {
             it('should not be empty', function () {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

Before we were not deleting the default value of a radio group when we deleted the static option. This PR fixes this.

Closes #1351

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
