### PR TITLE
fix: explictly pass textfield change event target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,7 @@ jobs:
         if: runner.os != 'Linux'
         env:
           TEST_BROWSERS: ChromeHeadless
+          NODE_OPTIONS: '--max_old_space_size=4096'
         run: npm run all
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Textfield.js
@@ -19,11 +19,18 @@ export function Textfield(props) {
 
   const { required } = validate;
 
-  const [onInputChange, flushOnChange] = useFlushDebounce(({ target }) => {
+  const [onChange, flushOnChange] = useFlushDebounce(({ target }) => {
     props.onChange({
       value: target.value,
     });
   });
+
+  /**
+   * @param {import('preact').JSX.TargetedEvent<HTMLInputElement, Event>} event
+   */
+  const onInputChange = (event) => {
+    onChange({ target: event.target });
+  };
 
   const onInputBlur = () => {
     flushOnChange && flushOnChange();


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

This fixes an issue when a form is instantiated inside a shadow DOM node together with React. When typing inside a textfield the value would disappear after a while (after the debounce function runs)

I couldn't dig 100% to the root reason of this, but I believe this is due to the differences in the event management between shadow DOM together with the React/Preact event handling

This fix was suggested by customers on this [support ticket](https://jira.camunda.com/browse/SUPPORT-26988)

Closes #1399

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
