### PR TITLE
fix: handle falsy values on table serialization

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/Table.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Table.js
@@ -346,5 +346,9 @@ function serializeCellData(cellData) {
     return JSON.stringify(cellData);
   }
 
-  return `${cellData || ''}`;
+  if (cellData === null || cellData === undefined) {
+    return '';
+  }
+
+  return `${cellData}`;
 }

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Table.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Table.spec.js
@@ -203,6 +203,55 @@ describe('Table', function () {
     expect(secondRow.querySelectorAll('.fjs-table-td')[2].textContent).to.eql('');
   });
 
+  it('should handle falsy values in table cells', function () {
+    // when
+    const DATA = [
+      {
+        id: 0,
+        name: false,
+        date: '',
+      },
+      {
+        id: null,
+        name: undefined,
+        date: 'valid',
+      },
+    ];
+
+    const { container } = createTable({
+      initialData: {
+        data: DATA,
+      },
+      field: {
+        ...defaultField,
+        columns: MOCK_COLUMNS,
+        dataSource: '=data',
+      },
+      services: {
+        expressionLanguage: {
+          isExpression: () => true,
+          evaluate: () => DATA,
+        },
+      },
+    });
+
+    // then
+    const bodyRows = container.querySelectorAll('.fjs-table-body .fjs-table-tr');
+    expect(bodyRows).to.have.length(2);
+
+    const [firstRow, secondRow] = bodyRows;
+
+    expect(firstRow.querySelectorAll('.fjs-table-td')).to.have.length(3);
+    expect(firstRow.querySelectorAll('.fjs-table-td')[0].textContent).to.eql('0');
+    expect(firstRow.querySelectorAll('.fjs-table-td')[1].textContent).to.eql('false');
+    expect(firstRow.querySelectorAll('.fjs-table-td')[2].textContent).to.eql('');
+
+    expect(secondRow.querySelectorAll('.fjs-table-td')).to.have.length(3);
+    expect(secondRow.querySelectorAll('.fjs-table-td')[0].textContent).to.eql('');
+    expect(secondRow.querySelectorAll('.fjs-table-td')[1].textContent).to.eql('');
+    expect(secondRow.querySelectorAll('.fjs-table-td')[2].textContent).to.eql('valid');
+  });
+
   it('should have pagination', async function () {
     // when
     const DATA = [


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

Prevent falsy values (except `null` and `undefined`) from being rendered in table elements

Closes #1383

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
