### PR TITLE
chore: bump the dynamic list default number of items to 100

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/RepeatableEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/RepeatableEntry.js
@@ -17,7 +17,7 @@ export function RepeatableEntry(props) {
       path: ['defaultRepetitions'],
       label: 'Default number of items',
       min: 1,
-      max: 20,
+      max: 100,
       props,
     }),
     simpleBoolEntryFactory({


### PR DESCRIPTION
Closes #1398

This increases the limit of dynamic list items by default to 100. It's high enough that it should handle most reasonable requests, but low enough that it won't cause any meltdowns of the editor when someone enters an absurd value into the properties panel. Any further and we need pagination IMO.  