### PR TITLE
chore: adjust the readonly and disabled tooltips

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/DisabledEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/DisabledEntry.js
@@ -39,7 +39,7 @@ function Disabled(props) {
     getValue,
     id,
     label: 'Disabled',
-    tooltip: 'Field cannot be edited by the end-user, and the data is not submitted. Takes precedence over read only.',
+    tooltip: 'Disable this field when it should not be interactive for end-users. Its data will not be submitted. This setting takes precedence over read-only.',
     inline: true,
     setValue,
   });

--- a/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ReadonlyEntry.js
@@ -51,7 +51,7 @@ function Readonly(props) {
     getValue,
     id,
     label: 'Read only',
-    tooltip: 'Field cannot be edited by the end-user, but the data will still be submitted.',
+    tooltip: 'Make this field read-only when it cannot be edited by the end-user, but its content is important for them to see. Its data will still be submitted.',
     setValue,
     variables,
   });


### PR DESCRIPTION
Related to #1401

Might be closing if  volodymyr agrees to drop the first req: `The "Read only" option should be placed before the "Disabled" option in the properties panel.`
