### PR TITLE
fix: fix radio group default value after edit

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/ValueEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/ValueEntry.js
@@ -1,4 +1,4 @@
-import { get, set } from 'min-dash';
+import { get, isNil, set } from 'min-dash';
 
 import { useService } from '../hooks';
 
@@ -76,7 +76,14 @@ function Value(props) {
       return;
     }
 
+    const { defaultValue } = field;
     const values = get(field, ['values']);
+    const previousValue = get(field, ['values', index, 'value']);
+
+    if (!isNil(defaultValue) && defaultValue === previousValue) {
+      set(field, ['defaultValue'], value);
+    }
+
     return editField(field, 'values', set(values, [index, 'value'], value));
   };
 

--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -410,6 +410,36 @@ describe('properties panel', function () {
           expect(editFieldSpy).to.have.been.calledOnce;
           expect(editFieldSpy).to.have.been.calledWith(field, ['defaultValue'], undefined);
         });
+
+        it('should update defaultValue when editing a value that matches current defaultValue', function () {
+          // given
+          const editFieldSpy = spy();
+
+          const field = {
+            type: 'select',
+            key: 'test',
+            defaultValue: 'camunda-platform',
+            values: [
+              { label: 'Camunda Platform', value: 'camunda-platform' },
+              { label: 'Camunda Cloud', value: 'camunda-cloud' },
+            ],
+          };
+
+          bootstrapPropertiesPanel({
+            container,
+            editField: editFieldSpy,
+            field,
+          });
+
+          // when
+          const defaultOptionInput = screen.getByDisplayValue('camunda-platform');
+
+          fireEvent.input(defaultOptionInput, { target: { value: 'new-platform' } });
+
+          // then
+          expect(editFieldSpy).to.have.been.calledOnce;
+          expect(field.defaultValue).to.equal('new-platform');
+        });
       });
 
       describe('options', function () {


### PR DESCRIPTION
<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr".
This helps us to understand the context of this PR.

-->

[Previously I had fixed only the case when a default value is removed](https://github.com/bpmn-io/form-js/pull/1364), now I'm fixing it the case if a user edits the default value

Closes #1438

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
