### PR TITLE
fix(number): address number field precision edge cases

### DIFF
--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -31,6 +31,8 @@
   --color-red-360-100-95: hsl(360, 100%, 95%);
   --color-red-360-100-97: hsl(360, 100%, 97%);
 
+  --color-orange-33-100-40: hsl(33, 100%, 40%);
+
   --color-white: hsl(0, 0%, 100%);
   --color-black: hsl(0, 0%, 0%);
 
@@ -72,6 +74,7 @@
 
   --color-warning: var(--cds-text-error, var(--color-red-360-100-45));
   --color-warning-light: var(--cds-text-error, var(--color-red-360-100-92));
+  --color-caution: var(--color-orange-33-100-40);
   --color-accent: var(--cds-link-primary, var(--color-blue-205-100-40));
   --color-accent-readonly: var(--cds-border-strong, var(--cds-border-strong-01, var(--color-grey-225-10-55)));
   --color-datepicker-focused-day: var(--cds-button-primary, var(--color-grey-225-10-55));
@@ -303,7 +306,8 @@
 
 .fjs-container .fjs-form-field-label,
 .fjs-container .fjs-form-field-description,
-.fjs-container .fjs-form-field-error {
+.fjs-container .fjs-form-field-error,
+.fjs-container .fjs-form-field-warning {
   font-size: var(--font-size-label);
   line-height: var(--line-height-label);
   letter-spacing: var(--letter-spacing-label);
@@ -773,19 +777,22 @@
   outline-color: var(--color-warning);
 }
 
-.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-container {
+.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-container:not(.fjs-disabled) {
   border-color: var(--color-red-360-100-92);
 }
 
-.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-separator {
+.fjs-container
+  .fjs-form-field.fjs-has-errors
+  .fjs-number-arrow-container:not(.fjs-disabled)
+  .fjs-number-arrow-separator {
   background-color: var(--color-red-360-100-92);
 }
 
-.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-container button {
+.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-container:not(.fjs-disabled) button {
   background-color: var(--color-red-360-100-97);
 }
 
-.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-container button:hover {
+.fjs-container .fjs-form-field.fjs-has-errors .fjs-number-arrow-container:not(.fjs-disabled) button:hover {
   background-color: var(--color-red-360-100-95);
 }
 
@@ -804,6 +811,20 @@
 }
 
 .fjs-container .fjs-form-field-error > ul > li {
+  list-style-type: none;
+}
+
+.fjs-container .fjs-form-field-warning {
+  color: var(--color-caution);
+}
+
+.fjs-container .fjs-form-field-warning > ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fjs-container .fjs-form-field-warning > ul > li {
   list-style-type: none;
 }
 

--- a/packages/form-js-viewer/src/render/components/Warning.js
+++ b/packages/form-js-viewer/src/render/components/Warning.js
@@ -1,0 +1,25 @@
+/**
+ * @typedef Props
+ * @property {string} id
+ * @property {string[]} warnings
+ *
+ * @param {Props} props
+ * @returns {import("preact").JSX.Element}
+ */
+export function Warning(props) {
+  const { warnings, id } = props;
+
+  if (!warnings.length) {
+    return null;
+  }
+
+  return (
+    <div class="fjs-form-field-warning" aria-live="polite" id={id}>
+      <ul>
+        {warnings.map((warning, index) => {
+          return <li key={index}>{warning}</li>;
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -5,6 +5,7 @@ import { useFlushDebounce, usePrevious } from '../../hooks';
 
 import { Description } from '../Description';
 import { Errors } from '../Errors';
+import { Warning } from '../Warning';
 import { Label } from '../Label';
 import { TemplatedInputAdorner } from './parts/TemplatedInputAdorner';
 
@@ -13,14 +14,27 @@ import AngelUpIcon from './icons/AngelUp.svg';
 
 import { formFieldClasses } from '../Util';
 
-import { isNullEquivalentValue, isValidNumber, willKeyProduceValidNumber } from '../util/numberFieldUtil';
+import {
+  isNullEquivalentValue,
+  isValidNumber,
+  willKeyProduceValidNumber,
+  isNumberInputSafe,
+} from '../util/numberFieldUtil';
 
 const type = 'number';
 
 export function Numberfield(props) {
   const { disabled, errors = [], domId, onBlur, onFocus, field, value, readonly } = props;
 
-  const { description, label, appearance = {}, validate = {}, decimalDigits, increment: incrementValue } = field;
+  const {
+    description,
+    label,
+    appearance = {},
+    validate = {},
+    decimalDigits,
+    increment: incrementValue,
+    serializeToString,
+  } = field;
 
   const { prefixAdorner, suffixAdorner } = appearance;
 
@@ -97,34 +111,58 @@ export function Numberfield(props) {
     return Big('1');
   }, [decimalDigits, incrementValue]);
 
+  // determine whether stepping would produce a value that loses precision as a Number
+  const arrowsDisabled = useMemo(() => {
+    if (serializeToString) return false;
+
+    const base = isValidNumber(cachedValue) ? Big(cachedValue) : Big(0);
+
+    const stepFlooredValue = base.minus(base.mod(incrementAmount));
+    const incrementedValue = stepFlooredValue.plus(incrementAmount).toFixed();
+
+    const offset = base.mod(incrementAmount);
+    let decrementedValue;
+    if (offset.cmp(0) === 0) {
+      decrementedValue = base.minus(incrementAmount).toFixed();
+    } else {
+      decrementedValue = base.minus(offset).toFixed();
+    }
+
+    return !isNumberInputSafe(incrementedValue) && !isNumberInputSafe(decrementedValue);
+  }, [cachedValue, incrementAmount, serializeToString]);
+
   const increment = () => {
-    if (readonly) {
+    if (readonly || arrowsDisabled) {
       return;
     }
 
     const base = isValidNumber(cachedValue) ? Big(cachedValue) : Big(0);
     const stepFlooredValue = base.minus(base.mod(incrementAmount));
+    const newValue = stepFlooredValue.plus(incrementAmount).toFixed();
 
     // note: toFixed() behaves differently in big.js
-    setValue(stepFlooredValue.plus(incrementAmount).toFixed());
+    setValue(newValue);
   };
 
   const decrement = () => {
-    if (readonly) {
+    if (readonly || arrowsDisabled) {
       return;
     }
 
     const base = isValidNumber(cachedValue) ? Big(cachedValue) : Big(0);
     const offset = base.mod(incrementAmount);
 
+    let newValue;
     if (offset.cmp(0) === 0) {
       // if we're already on a valid step, decrement
-      setValue(base.minus(incrementAmount).toFixed());
+      newValue = base.minus(incrementAmount).toFixed();
     } else {
       // otherwise floor to the step
       const stepFlooredValue = base.minus(base.mod(incrementAmount));
-      setValue(stepFlooredValue.toFixed());
+      newValue = stepFlooredValue.toFixed();
     }
+
+    setValue(newValue);
   };
 
   const onKeyDown = (e) => {
@@ -165,6 +203,14 @@ export function Numberfield(props) {
 
   const descriptionId = `${domId}-description`;
   const errorMessageId = `${domId}-error-message`;
+  const warningMessageId = `${domId}-warning-message`;
+
+  const precisionWarnings = useMemo(() => {
+    if (serializeToString || !isValidNumber(displayValue) || isNumberInputSafe(displayValue.toString())) {
+      return [];
+    }
+    return ['This value exceeds the precision supported by this field. It will be rounded.'];
+  }, [serializeToString, displayValue]);
 
   return (
     <div class={formFieldClasses(type, { errors, disabled, readonly })}>
@@ -193,16 +239,17 @@ export function Numberfield(props) {
             autoComplete="off"
             step={incrementAmount}
             value={displayValue}
-            aria-describedby={[descriptionId, errorMessageId].join(' ')}
+            aria-describedby={[descriptionId, errorMessageId, warningMessageId].join(' ')}
             required={required}
             aria-invalid={errors.length > 0}
           />
-          <div class={classNames('fjs-number-arrow-container', { 'fjs-disabled': disabled, 'fjs-readonly': readonly })}>
+          <div class={classNames('fjs-number-arrow-container', { 'fjs-disabled': disabled || arrowsDisabled, 'fjs-readonly': readonly })}>
             {/* we're disabling tab navigation on both buttons to imitate the native browser behavior of input[type='number'] increment arrows */}
             <button
               type="button"
               class="fjs-number-arrow-up"
               aria-label="Increment"
+              disabled={disabled || arrowsDisabled}
               onClick={() => increment()}
               tabIndex={-1}>
               <AngelUpIcon />
@@ -212,6 +259,7 @@ export function Numberfield(props) {
               type="button"
               class="fjs-number-arrow-down"
               aria-label="Decrement"
+              disabled={disabled || arrowsDisabled}
               onClick={() => decrement()}
               tabIndex={-1}>
               <AngelDownIcon />
@@ -221,6 +269,7 @@ export function Numberfield(props) {
       </TemplatedInputAdorner>
       <Description id={descriptionId} description={description} />
       <Errors id={errorMessageId} errors={errors} />
+      <Warning id={warningMessageId} warnings={precisionWarnings} />
     </div>
   );
 }

--- a/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
@@ -1,5 +1,24 @@
 import Big from 'big.js';
 
+/**
+ * Checks whether a numeric string value would survive a Number() round-trip
+ * without losing precision. This is relevant when serializeToString is not enabled,
+ * since the value will be stored as a JavaScript Number (IEEE 754 double-precision),
+ * which only supports ~15-17 significant digits.
+ *
+ * @param {string} value - The numeric string to check
+ * @returns {boolean} true if Number(value).toString() represents the same numeric value
+ */
+export function isNumberInputSafe(value) {
+  try {
+    const bigOriginal = Big(value);
+    const afterRoundTrip = Big(Number(value));
+    return bigOriginal.eq(afterRoundTrip);
+  } catch (e) {
+    return false;
+  }
+}
+
 export function countDecimals(number) {
   const num = Big(number);
   if (num.toString() === num.toFixed(0)) return 0;

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -476,6 +476,129 @@ describe('Number', function () {
         });
       });
     });
+
+    describe('high decimal digits without string serialization', function () {
+      it('should disable arrow buttons when stepping would lose precision', async function () {
+        // given
+        const { container } = createNumberField({
+          field: highDecimalField,
+          value: 1,
+        });
+
+        // then
+        const incrementButton = container.querySelector('.fjs-number-arrow-up');
+        const decrementButton = container.querySelector('.fjs-number-arrow-down');
+        expect(incrementButton.disabled).to.be.true;
+        expect(decrementButton.disabled).to.be.true;
+      });
+
+      it('should apply fjs-disabled class to arrow container when stepping would lose precision', function () {
+        // given
+        const { container } = createNumberField({
+          field: highDecimalField,
+          value: 1,
+        });
+
+        // then
+        const arrowContainer = container.querySelector('.fjs-number-arrow-container');
+        expect(arrowContainer.classList.contains('fjs-disabled')).to.be.true;
+      });
+
+      it('should not disable arrow buttons when stepping is safe', function () {
+        // given
+        const { container } = createNumberField({
+          field: highDecimalField,
+          value: 0,
+        });
+
+        // then
+        const incrementButton = container.querySelector('.fjs-number-arrow-up');
+        const decrementButton = container.querySelector('.fjs-number-arrow-down');
+        expect(incrementButton.disabled).to.be.false;
+        expect(decrementButton.disabled).to.be.false;
+      });
+
+      it('should not apply increment when buttons are disabled', async function () {
+        // given
+        const onChangeSpy = spy();
+
+        const { container } = createNumberField({
+          field: highDecimalField,
+          onChange: onChangeSpy,
+          value: 1,
+        });
+
+        // reset spy to ignore any calls during initial render
+        onChangeSpy.resetHistory();
+
+        // when
+        const incrementButton = container.querySelector('.fjs-number-arrow-up');
+        await userEvent.click(incrementButton);
+
+        // then
+        expect(onChangeSpy).to.not.have.been.called;
+      });
+
+      it('should increment when result is safe for Number precision', async function () {
+        // given
+        const onChangeSpy = spy();
+
+        const { container } = createNumberField({
+          field: highDecimalField,
+          onChange: onChangeSpy,
+          value: 0,
+        });
+
+        // when
+        const incrementButton = container.querySelector('.fjs-number-arrow-up');
+        await userEvent.click(incrementButton);
+
+        // then
+        expect(onChangeSpy).to.have.been.calledWithMatch({
+          value: 1e-100,
+        });
+      });
+
+      it('should show precision warning when typed value exceeds Number precision', async function () {
+        // given
+        const { container } = createNumberField({
+          field: highDecimalField,
+          value: 0,
+        });
+
+        // when
+        const input = container.querySelector('input[type="text"]');
+        await userEvent.clear(input);
+        await userEvent.type(input, '1.0000000000000001');
+
+        // then
+        const warning = container.querySelector('.fjs-form-field-warning');
+        expect(warning).to.exist;
+        expect(warning.textContent).to.contain('exceeds the precision');
+
+        const formField = container.querySelector('.fjs-form-field');
+        expect(formField.classList.contains('fjs-has-errors')).to.be.false;
+      });
+
+      it('should not show precision warning when serializeToString is enabled', async function () {
+        // given
+        const stringHighDecimalField = { ...highDecimalField, serializeToString: true };
+
+        const { container } = createNumberField({
+          field: stringHighDecimalField,
+          value: 0,
+        });
+
+        // when
+        const input = container.querySelector('input[type="text"]');
+        await userEvent.clear(input);
+        await userEvent.type(input, '1.0000000000000001');
+
+        // then
+        const warning = container.querySelector('.fjs-form-field-warning');
+        expect(warning).to.not.exist;
+      });
+    });
   });
 
   describe('formatting', function () {
@@ -959,6 +1082,11 @@ const stepField = {
   ...defaultField,
   decimalDigits: 3,
   increment: 0.25,
+};
+
+const highDecimalField = {
+  ...defaultField,
+  decimalDigits: 100,
 };
 
 function createNumberField({ services, ...restOptions } = {}) {

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/util/numberFieldUtil.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/util/numberFieldUtil.spec.js
@@ -1,6 +1,7 @@
 import {
   willKeyProduceValidNumber,
   countDecimals,
+  isNumberInputSafe,
 } from '../../../../../../src/render/components/util/numberFieldUtil.js';
 
 describe('numberFieldUtil', function () {
@@ -66,5 +67,27 @@ describe('numberFieldUtil', function () {
         expectedValue,
       );
     }
+  });
+
+  describe('#isNumberInputSafe', function () {
+    it('should return true for values that survive Number() round-trip', function () {
+      const safeCases = ['2', '123.456', '1.000000000000001', '0.0000000000000001', '999999999999999', '1e-100'];
+
+      for (const value of safeCases) {
+        expect(isNumberInputSafe(value)).to.equal(true, `expected '${value}' to be safe`);
+      }
+    });
+
+    it('should return false for values that lose precision through Number()', function () {
+      const unsafeCases = [
+        '1.0000000000000001', // 1 + tiny delta collapses to 1
+        '9999999999999999', // 16-digit integer exceeds safe range
+        '1.' + '0'.repeat(99) + '1', // 1 + 1e-100 collapses to 1
+      ];
+
+      for (const value of unsafeCases) {
+        expect(isNumberInputSafe(value)).to.equal(false, `expected '${value}' to be unsafe`);
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #1021

Adds:
- Warning when exceeding maximum numeric precision (:warning: we need to confirm this new warning pattern)
- Disables the stepper arrows when they'd break due to numeric precision issues  (like adding a 1e-6 step to 1e12)