### PR TITLE
fix: allow dynamic-list item shorthand in text templates

### DIFF
--- a/packages/form-js-viewer/src/util/expressions.js
+++ b/packages/form-js-viewer/src/util/expressions.js
@@ -10,8 +10,11 @@ import { wrapObjectKeysWithUnderscores } from './simple';
 export function buildExpressionContext(context) {
   const { data, ...specialContextKeys } = context;
 
+  const currentItem = specialContextKeys.this && typeof specialContextKeys.this === 'object' ? specialContextKeys.this : {};
+
   return {
     ...specialContextKeys,
+    ...currentItem,
     ...data,
     ...wrapObjectKeysWithUnderscores(specialContextKeys),
   };

--- a/packages/form-js-viewer/test/spec/util/expressions.spec.js
+++ b/packages/form-js-viewer/test/spec/util/expressions.spec.js
@@ -1,0 +1,26 @@
+import { buildExpressionContext } from '../../../src/util/expressions';
+
+describe('util/expressions', function () {
+  it('should expose current dynamic list item properties as shorthand variables', function () {
+    const context = buildExpressionContext({
+      this: { title: 'Hello', amount: 7 },
+      data: { articles: [{ title: 'Hello', amount: 7 }] },
+      parent: {},
+      i: 0,
+    });
+
+    expect(context.title).to.eql('Hello');
+    expect(context.amount).to.eql(7);
+  });
+
+  it('should keep top-level data precedence for conflicting keys', function () {
+    const context = buildExpressionContext({
+      this: { title: 'Item title' },
+      data: { title: 'Form title' },
+      parent: {},
+      i: 0,
+    });
+
+    expect(context.title).to.eql('Form title');
+  });
+});


### PR DESCRIPTION
## Bug
Fixes #1496. Inside dynamic list items, `{{field}}` currently resolves only against top-level form data. Item properties are only available via `{{this.field}}`.

## Fix
- In `buildExpressionContext`, spread the current `this` item object into the expression context.
- Keep top-level form data precedence to avoid breaking existing forms where the same key exists globally.
- Added regression tests for both shorthand item access and conflict precedence behavior.

## Validation
- Built viewer package successfully (`npm run build --workspace @bpmn-io/form-js-viewer`).
- Ran viewer test suite in this environment; existing unrelated locale/time-based failures remain, while the new util/expressions assertions pass.

Greetings, saschabuehrle
