### PR TITLE
chore(project): suppress passing specs in karma output

### DIFF
--- a/packages/form-js-carbon-styles/karma.conf.js
+++ b/packages/form-js-carbon-styles/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function (karma) {
       suppressSummary: true,
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      suppressPassed: true,
       suppressSkipped: true,
       showBrowser: false,
       showSpecTiming: false,

--- a/packages/form-js-editor/karma.conf.js
+++ b/packages/form-js-editor/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function (karma) {
       suppressSummary: true,
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      suppressPassed: true,
       suppressSkipped: true,
       showBrowser: false,
       showSpecTiming: false,

--- a/packages/form-js-playground/karma.conf.js
+++ b/packages/form-js-playground/karma.conf.js
@@ -32,7 +32,7 @@ module.exports = function (karma) {
       suppressSummary: true,
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      suppressPassed: true,
       suppressSkipped: true,
       showBrowser: false,
       showSpecTiming: false,

--- a/packages/form-js-viewer/karma.conf.js
+++ b/packages/form-js-viewer/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function (karma) {
       suppressSummary: true,
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      suppressPassed: true,
       suppressSkipped: true,
       showBrowser: false,
       showSpecTiming: false,

--- a/packages/form-js/test/config/karma.distro.js
+++ b/packages/form-js/test/config/karma.distro.js
@@ -32,7 +32,7 @@ module.exports = function (karma) {
       suppressSummary: true,
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      suppressPassed: true,
       suppressSkipped: true,
       showBrowser: false,
       showSpecTiming: false,

--- a/packages/form-js/test/config/karma.unit.js
+++ b/packages/form-js/test/config/karma.unit.js
@@ -30,7 +30,7 @@ module.exports = function (karma) {
       suppressSummary: true,
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      suppressPassed: true,
       suppressSkipped: true,
       showBrowser: false,
       showSpecTiming: false,


### PR DESCRIPTION
## Summary

Flip `suppressPassed: false → true` across all karma configs so only failures (and the summary) show up in test output. Passing specs become noise, especially in CI logs and watch mode.

## Root cause

Historical default never revisited. Nothing to fix functionally — just dev-experience cleanup.

Affected configs:
- `packages/form-js-carbon-styles/karma.conf.js`
- `packages/form-js-editor/karma.conf.js`
- `packages/form-js-playground/karma.conf.js`
- `packages/form-js-viewer/karma.conf.js`
- `packages/form-js/test/config/karma.distro.js`
- `packages/form-js/test/config/karma.unit.js`

## Test plan

- [ ] `npm test` in each affected package — passes green, logs only show failures / summary
- [ ] `npm run test:distro` still green
- [ ] Intentionally fail a spec locally — failure details still surface