### PR TITLE
fix(viewer): load rollup config as ESM in bundle:watch-js

### DIFF
--- a/packages/form-js-viewer/package.json
+++ b/packages/form-js-viewer/package.json
@@ -27,7 +27,7 @@
     "bundle": "rollup -c --failAfterWarnings",
     "bundle:scss": "sass --no-source-map --load-path=\"../../node_modules\" assets/index.scss dist/assets/form-js.css",
     "bundle:watch": "run-p bundle:watch-js bundle:watch-scss",
-    "bundle:watch-js": "rollup -c -w --bundleConfigAsCjs",
+    "bundle:watch-js": "rollup -c -w",
     "bundle:watch-scss": "npm run bundle:scss -- --watch",
     "dev": "npm test -- --auto-watch --no-single-run",
     "generate-types": "tsc --allowJs --skipLibCheck --declaration --emitDeclarationOnly --outDir dist/types src/index.js && copyfiles --flat src/*.d.ts dist/types",


### PR DESCRIPTION
## Summary

Drop the `--bundleConfigAsCjs` flag from `form-js-viewer`'s `bundle:watch-js` script. With the flag, rollup force-loads `rollup.config.mjs` via CommonJS `require`, which fails on the ESM-only `@rollup/plugin-alias@6`:

```
[!] Error: No "exports" main defined in node_modules/@rollup/plugin-alias/package.json
```

## Root cause

`--bundleConfigAsCjs` was a workaround from the rollup 2/3 era when ESM config support was fragile. Rollup 4 loads `.mjs` configs natively; with the flag removed, the viewer config's `import alias from '@rollup/plugin-alias'` resolves cleanly and the watch build completes.

The flag only exists on `bundle:watch-js`; the sibling `bundle` script already omits it, which is why this only bit watch mode.

## Test plan

- [x] `npm run bundle:watch-js` in `packages/form-js-viewer` — produces `dist/index.cjs` + `dist/index.es.js` and enters `waiting for changes...` with no error
- [x] `npm run build:watch` at repo root — all four rollups (viewer/editor/playground/form-js) enter watch cleanly
- [x] `npm run build` still green in CI