### PR TITLE
fix(form): render number field with value 0 set after initial render

### DIFF
--- a/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
+++ b/packages/form-js-editor/test/spec/features/properties-panel/PropertiesPanel.spec.js
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/preact/pure';
 
 import { query as domQuery } from 'min-dom';
+import { set } from 'min-dash';
 
 import { OPTIONS_SOURCES, OPTIONS_SOURCES_DEFAULTS } from '@bpmn-io/form-js-viewer';
 import { removeKey } from '../../../../src/features/properties-panel/groups/CustomPropertiesGroup';
@@ -664,14 +665,29 @@ describe('properties panel', function () {
       describe('static options', function () {
         it('should re-configure static source defaults', function () {
           // given
-          const editFieldSpy = spy();
+          const eventBus = new EventBusMock();
 
-          const field = schema.components.find(({ key }) => key === 'product');
+          const field = structuredClone(schema.components.find(({ key }) => key === 'product'));
+
+          const editFieldSpy = spy((field, properties) => {
+            for (const path of [['values'], ['valuesKey'], ['valuesExpression']]) {
+              set(field, path, undefined);
+            }
+
+            for (const key in properties) {
+              set(field, [key], properties[key]);
+            }
+
+            act(() => eventBus.fire('changed', { elements: [field] }));
+
+            return field;
+          });
 
           bootstrapPropertiesPanel({
             container,
             editField: editFieldSpy,
             field,
+            services: { eventBus },
           });
 
           // assume
@@ -680,8 +696,8 @@ describe('properties panel', function () {
           expect(input.value).to.equal(OPTIONS_SOURCES.STATIC);
 
           // when
-          fireEvent.input(input, { target: { value: OPTIONS_SOURCES.INPUT } });
-          fireEvent.input(input, { target: { value: OPTIONS_SOURCES.STATIC } });
+          fireEvent.input(screen.getByLabelText('Type'), { target: { value: OPTIONS_SOURCES.INPUT } });
+          fireEvent.input(screen.getByLabelText('Type'), { target: { value: OPTIONS_SOURCES.STATIC } });
 
           // then
           expect(editFieldSpy).to.have.been.calledTwice;
@@ -1494,7 +1510,7 @@ describe('properties panel', function () {
           // given
           const editFieldSpy = spy();
 
-          const field = schema.components.find(({ key }) => key === 'language');
+          const field = { ...schema.components.find(({ key }) => key === 'language'), defaultValue: 'english' };
 
           bootstrapPropertiesPanel({
             container,
@@ -1505,7 +1521,7 @@ describe('properties panel', function () {
           // assume
           const input = screen.getByLabelText('Default value');
 
-          expect(input.value).to.equal('');
+          expect(input.value).to.equal('english');
 
           // when
           fireEvent.input(input, { target: { value: EMPTY_OPTION } });

--- a/packages/form-js-viewer/src/render/components/form-fields/Number.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/Number.js
@@ -13,7 +13,12 @@ import AngelUpIcon from './icons/AngelUp.svg';
 
 import { formFieldClasses } from '../Util';
 
-import { isNullEquivalentValue, isValidNumber, willKeyProduceValidNumber } from '../util/numberFieldUtil';
+import {
+  isNullEquivalentValue,
+  isValidNumber,
+  serializeToInputString,
+  willKeyProduceValidNumber,
+} from '../util/numberFieldUtil';
 
 const type = 'number';
 
@@ -87,7 +92,7 @@ export function Numberfield(props) {
   const outerValueEqualsCache = sanitize(value) === sanitize(cachedValue);
 
   if (outerValueChanged && !outerValueEqualsCache) {
-    setValue((value && value.toString()) || '');
+    setValue(serializeToInputString(value));
   }
 
   // caches the value an increment/decrement operation will be based on

--- a/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
@@ -43,5 +43,6 @@ export function isNullEquivalentValue(value) {
 
 export function serializeToInputString(value) {
   if (value === undefined || value === null) return '';
+  if (typeof value !== 'string' && typeof value !== 'number') return '';
   return value.toString();
 }

--- a/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
+++ b/packages/form-js-viewer/src/render/components/util/numberFieldUtil.js
@@ -40,3 +40,8 @@ export function willKeyProduceValidNumber(key, previousValue, caretIndex, select
 export function isNullEquivalentValue(value) {
   return value === undefined || value === null || value === '';
 }
+
+export function serializeToInputString(value) {
+  if (value === undefined || value === null) return '';
+  return value.toString();
+}

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -149,6 +149,53 @@ describe('Number', function () {
     expect(input.value).to.equal('');
   });
 
+  it('should render <0> value', function () {
+    // when
+    const { container } = createNumberField({
+      value: 0,
+    });
+
+    // then
+    const input = container.querySelector('input[type="text"]');
+
+    expect(input).to.exist;
+    expect(input.value).to.equal('0');
+  });
+
+  it('should render <0> value when set after initial render', function () {
+    // given
+    const props = {
+      disabled: false,
+      errors: [],
+      domId: 'test-number',
+      field: defaultField,
+      onChange: () => {},
+    };
+
+    const options = { container: container.querySelector('.fjs-form') };
+
+    const { rerender } = render(
+      <MockFormContext options={options}>
+        <Numberfield {...props} value={undefined} />
+      </MockFormContext>,
+      options,
+    );
+
+    // when
+    rerender(
+      <MockFormContext options={options}>
+        <Numberfield {...props} value={0} />
+      </MockFormContext>,
+      options,
+    );
+
+    // then
+    const input = container.querySelector('input[type="text"]');
+
+    expect(input).to.exist;
+    expect(input.value).to.equal('0');
+  });
+
   it('should render default value on value removed', async function () {
     // given
     const props = {

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/util/numberFieldUtil.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/util/numberFieldUtil.spec.js
@@ -36,6 +36,10 @@ describe('numberFieldUtil', function () {
       [1, '1'],
       [-1.5, '-1.5'],
       ['0', '0'],
+      [false, ''],
+      [true, ''],
+      [{}, ''],
+      [[], ''],
     ];
 
     // then

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/util/numberFieldUtil.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/util/numberFieldUtil.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   willKeyProduceValidNumber,
   countDecimals,
+  serializeToInputString,
 } from '../../../../../../src/render/components/util/numberFieldUtil.js';
 
 describe('numberFieldUtil', function () {
@@ -21,6 +22,25 @@ describe('numberFieldUtil', function () {
     // then
     for (const [value, result] of valuesMatrix) {
       expect(countDecimals(value)).to.equal(result);
+    }
+  });
+
+  it('#serializeToInputString', function () {
+    // given
+    const valuesMatrix = [
+      [undefined, ''],
+      [null, ''],
+      ['', ''],
+      [0, '0'],
+      [-0, '0'],
+      [1, '1'],
+      [-1.5, '-1.5'],
+      ['0', '0'],
+    ];
+
+    // then
+    for (const [value, result] of valuesMatrix) {
+      expect(serializeToInputString(value)).to.equal(result);
     }
   });
 


### PR DESCRIPTION
Closes #1510

The number field used `(value && value.toString()) || ''` to mirror outer value changes into local state, which collapses `0` to `''` and then sanitizes to `null`. The bug only surfaces when the value transitions to `0` *after* the initial render (e.g. async data load or playground re-import), since `useState(value)` captures the initial value directly and bypasses the outer-sync path.

Extracted the conversion into `serializeToInputString` to keep the contract explicit: `null`/`undefined` map to `''`, everything else passes through `.toString()`.