### PR TITLE
Specify unit used in document preview and move description to tooltip

### DIFF
--- a/packages/form-js-editor/src/features/properties-panel/entries/MaxHeightEntry.js
+++ b/packages/form-js-editor/src/features/properties-panel/entries/MaxHeightEntry.js
@@ -44,7 +44,7 @@ function MaxHeight(props) {
     getValue,
     setValue,
     validate,
-    description,
+    tooltip,
   });
 }
 
@@ -72,4 +72,4 @@ const validate = (value) => {
   }
 };
 
-const description = <>Documents with height that exceeds the defined value will be vertically scrollable</>;
+const tooltip = 'Documents whose height exceeds the defined value in pixels will be vertically scrollable';


### PR DESCRIPTION
This PR specifies that the height is given in pixels, and moves the description to tooltip (following more recent development):

<img width="604" height="297" alt="image" src="https://github.com/user-attachments/assets/277e486b-45a6-4211-9faa-609556a9d1b3" />

Related to https://camunda.slack.com/archives/C0693F1NFK5/p1778489359258409