### PR TITLE
fix: increase the drop area at the bottom of the form editor

### DIFF
--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -120,7 +120,7 @@
   --toggle-switch-switcher-background-color: var(--cds-background, var(--color-white));
 
   --side-line-background-color: var(--cds-text-secondary, var(--color-grey-225-10-35));
-  --side-line-extension-background-color: var(--cds-text-secondary, (--color-grey-225-10-35));
+  --side-line-extension-background-color: var(--cds-text-secondary, var(--color-grey-225-10-35));
 
   --list-entry-dot-background-color: var(--cds-background-inverse, var(--color-grey-225-10-35));
   --list-entry-header-button-fill-color: var(--cds-background-inverse, var(--color-grey-225-10-35));

--- a/packages/form-js-editor/assets/form-js-editor-base.css
+++ b/packages/form-js-editor/assets/form-js-editor-base.css
@@ -180,6 +180,10 @@
   flex-grow: 1;
 }
 
+.fjs-editor-container .fjs-editor-form-root {
+  padding-bottom: 28px;
+}
+
 .fjs-editor-container .fjs-children .fjs-children {
   margin: 3px 0;
 }

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -254,9 +254,14 @@ function DebugColumns(props) {
 function Children(props) {
   const { field } = props;
 
-  const { id } = field;
+  const { id, type } = field;
 
   const classes = ['fjs-children', DROP_CONTAINER_VERTICAL_CLS];
+
+  // mark the top-level (root form) drop container
+  if (type === 'default') {
+    classes.push('fjs-editor-form-root');
+  }
 
   if (props.class) {
     classes.push(...props.class.split(' '));

--- a/packages/form-js-editor/src/render/components/FormEditor.js
+++ b/packages/form-js-editor/src/render/components/FormEditor.js
@@ -254,12 +254,12 @@ function DebugColumns(props) {
 function Children(props) {
   const { field } = props;
 
-  const { id, type } = field;
+  const { id, type, _parent } = field;
 
   const classes = ['fjs-children', DROP_CONTAINER_VERTICAL_CLS];
 
   // mark the top-level (root form) drop container
-  if (type === 'default') {
+  if (type === 'default' && !_parent) {
     classes.push('fjs-editor-form-root');
   }
 


### PR DESCRIPTION
Closes https://github.com/bpmn-io/form-js/issues/1432

Increase the drop area at the bottom of the form editor to make it easier to drop elements at the end of a form.

Additionally fixed small error at `side-line-extension-background-color` default color definition.

https://github.com/user-attachments/assets/5e584c96-0c95-4906-b169-2da62fa501fc

https://github.com/user-attachments/assets/3338735f-90ba-4a61-97ee-46289746f038

