### PR TITLE
fix(viewer): avoid redundant document preview fetches

### DIFF
--- a/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
+++ b/packages/form-js-viewer/src/render/components/form-fields/DocumentPreview.js
@@ -4,7 +4,7 @@ import { Errors } from '../Errors';
 import { formFieldClasses } from '../Util';
 import { isString } from 'min-dash';
 import DownloadIcon from './icons/Download.svg';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { Label } from '../Label';
 
 const type = 'documentPreview';
@@ -57,14 +57,12 @@ export function DocumentPreview(props) {
             return null;
           }
 
-          const requestInit = getDocumentRequestInit(documentEndpointBuilder, document);
-
           return (
             <DocumentRenderer
               key={document.documentId}
               documentMetadata={document}
+              documentEndpointBuilder={documentEndpointBuilder}
               endpoint={finalEndpoint}
-              requestInit={requestInit}
               maxHeight={maxHeight}
               domId={`${domId}-${index}`}
             />
@@ -258,19 +256,24 @@ function ImageRenderer(props) {
  *
  * @param {Object} props
  * @param {DocumentMetadata} props.documentMetadata
+ * @param {DocumentEndpointBuilder | null} props.documentEndpointBuilder
  * @param {string} props.endpoint
  * @param {string} props.domId
- * @param {RequestInit|undefined} props.requestInit
  * @param {number|undefined} props.maxHeight
  *
  * @returns {import("preact").JSX.Element}
  */
 function DocumentRenderer(props) {
-  const { documentMetadata, endpoint, maxHeight, domId, requestInit } = props;
+  const { documentMetadata, documentEndpointBuilder, endpoint, maxHeight, domId } = props;
   const { metadata } = documentMetadata;
   const [hasError, setHasError] = useState(false);
   const ref = useRef(null);
   const isInViewport = useInViewport(ref);
+  const onError = useCallback(() => setHasError(true), []);
+  const requestInit = useMemo(
+    () => getDocumentRequestInit(documentEndpointBuilder, documentMetadata),
+    [documentEndpointBuilder, documentMetadata],
+  );
   const singleDocumentContainerClassName = `fjs-${type}-single-document-container`;
   const errorMessageId = `${domId}-error-message`;
   const errorMessage = 'Unable to download document';
@@ -286,15 +289,13 @@ function DocumentRenderer(props) {
           url={endpoint}
           alt={metadata.fileName}
           requestInit={requestInit}
-          onError={() => setHasError(true)}
+          onError={onError}
         />
         <DownloadButton
           endpoint={endpoint}
           fileName={metadata.fileName}
           requestInit={requestInit}
-          onDownloadError={() => {
-            setHasError(true);
-          }}
+          onDownloadError={onError}
         />
         {hasError ? <Errors id={errorMessageId} errors={[errorMessage]} /> : null}
       </div>
@@ -311,7 +312,7 @@ function DocumentRenderer(props) {
           url={endpoint}
           fileName={metadata.fileName}
           requestInit={requestInit}
-          onError={() => setHasError(true)}
+          onError={onError}
           errorMessageId={errorMessageId}
         />
       </div>
@@ -331,9 +332,7 @@ function DocumentRenderer(props) {
         endpoint={endpoint}
         fileName={metadata.fileName}
         requestInit={requestInit}
-        onDownloadError={() => {
-          setHasError(true);
-        }}
+        onDownloadError={onError}
       />
     </div>
   );

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/DocumentPreview.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { render, screen } from '@testing-library/preact/pure';
+import { render, screen, waitFor } from '@testing-library/preact/pure';
 import userEvent from '@testing-library/user-event';
 import { createFormContainer, expectNoViolations } from '../../../../TestHelper';
 import { MockFormContext } from '../helper';
@@ -184,6 +184,77 @@ describe('DocumentPreview', function () {
     }
   });
 
+  it('should only refetch preview for changed document', async function () {
+    // given
+    const requestInit = {
+      credentials: 'include',
+    };
+    const mockDocument = {
+      documentId: 'document0',
+      endpoint: 'https://example.com/document-preview-rerender.png',
+      metadata: {
+        fileName: 'My document.png',
+        contentType: 'image/png',
+      },
+    };
+    const changedDocument = {
+      ...mockDocument,
+      endpoint: 'https://example.com/changed-document-preview-rerender.png',
+    };
+    const mockDocumentEndpointBuilder = {
+      buildRequestInit: sinon.stub().returns(requestInit),
+    };
+    const fetchStub = sinon.stub(window, 'fetch').resolves({
+      ok: true,
+      blob: sinon.stub().resolves(new Blob()),
+    });
+    const intersectionObserverStub = sinon.stub(window, 'IntersectionObserver').callsFake((callback) => ({
+      observe: (element) => callback([{ isIntersecting: true, target: element }]),
+      unobserve: sinon.stub(),
+    }));
+    const previewFetchStub = fetchStub.withArgs(mockDocument.endpoint, requestInit);
+    const changedPreviewFetchStub = fetchStub.withArgs(changedDocument.endpoint, requestInit);
+
+    try {
+      const { rerender } = createDocumentPreview({
+        initialData: {
+          documents: [mockDocument],
+        },
+        services: {
+          expressionLanguage: mockExpressionLanguageService,
+          documentEndpointBuilder: mockDocumentEndpointBuilder,
+        },
+      });
+
+      await waitFor(() => {
+        expect(previewFetchStub).to.have.been.calledOnce;
+      });
+
+      // when
+      rerender();
+
+      // then
+      expect(mockDocumentEndpointBuilder.buildRequestInit).to.have.been.calledOnce;
+      expect(previewFetchStub).to.have.been.calledOnce;
+
+      // when
+      rerender({
+        initialData: {
+          documents: [changedDocument],
+        },
+      });
+
+      // then
+      await waitFor(() => {
+        expect(changedPreviewFetchStub).to.have.been.calledOnce;
+      });
+      expect(mockDocumentEndpointBuilder.buildRequestInit).to.have.been.calledTwice;
+    } finally {
+      intersectionObserverStub.restore();
+      fetchStub.restore();
+    }
+  });
+
   it('should fallback to default fetch config if request config builder throws', async function () {
     // given
     const mockDocument = {
@@ -336,12 +407,19 @@ function createDocumentPreview({ services, ...restOptions } = {}) {
     ...restOptions,
   };
 
-  return render(
-    <MockFormContext services={services} options={options}>
-      <DocumentPreview domId={options.domId} field={options.field} />
-    </MockFormContext>,
-    {
-      container: options.container || container.querySelector('.fjs-form'),
-    },
+  const renderDocumentPreview = (currentOptions = options) => (
+    <MockFormContext services={services} options={currentOptions}>
+      <DocumentPreview domId={currentOptions.domId} field={currentOptions.field} />
+    </MockFormContext>
   );
+
+  const result = render(renderDocumentPreview(), {
+    container: options.container || container.querySelector('.fjs-form'),
+  });
+
+  return {
+    ...result,
+    rerender: (optionsOverrides = {}) =>
+      result.rerender(renderDocumentPreview({ ...options, ...optionsOverrides })),
+  };
 }


### PR DESCRIPTION
Closes #1520

This keeps the request configuration and renderer error callback stable when the document is unchanged. Parent rerenders therefore no longer restart PDF or image fetch effects or replace object URLs.

The focused regression forces the preview into view, rerenders the same document, and verifies both request construction and preview fetching happen once. It also verifies that changing the document still triggers a new fetch.

Try it out:

1. Add a PDF or image Document Preview with a custom endpoint builder.
2. Trigger an unrelated form rerender.
3. Confirm the preview does not blink or issue another request.

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)
