### PR TITLE
test(form-js-viewer): fix flaky focus/blur and high precision number specs

### DIFF
--- a/packages/form-js-viewer/test/spec/Form.spec.js
+++ b/packages/form-js-viewer/test/spec/Form.spec.js
@@ -669,11 +669,21 @@ describe('Form', function () {
       const elements = container.querySelector('.fjs-element').querySelectorAll('.fjs-element');
       const element = elements[index];
       const focusTarget = element.querySelector(selector);
-      const formRoot = container.querySelector('.fjs-form');
 
       // when
-      await userEvent.click(focusTarget);
-      await userEvent.click(formRoot);
+      //
+      // we dispatch focusin/focusout rather than clicking around: a real click
+      // only produces focus events while the browsing context holds system
+      // focus, which Firefox does not reliably have on CI. preact/compat maps
+      // onFocus/onBlur to focusin/focusout, so these are the events the
+      // component actually listens for.
+      await act(async () => {
+        focusTarget.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      });
+
+      await act(async () => {
+        focusTarget.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+      });
 
       // then
       expect(focusSpy).to.have.been.calledWithMatch({ formField });

--- a/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
+++ b/packages/form-js-viewer/test/spec/render/components/form-fields/Number.spec.js
@@ -610,7 +610,7 @@ describe('Number', function () {
       const input = container.querySelector('input[type="text"]');
 
       await userEvent.clear(input);
-      await userEvent.type(input, highPrecisionStringNumber);
+      await userEvent.type(input, highPrecisionStringNumber, { delay: null });
 
       // then
       expect(onChangeSpy).to.have.been.calledWithMatch({


### PR DESCRIPTION
Closes #

Draft — follow-up to #1555, where CI failures on unrelated changes made it hard to tell whether a red run meant anything. Two of the three flake clusters are fixed with a reproduced mechanism; the third I could not reproduce and deliberately left alone.

## Cluster 1 — Firefox focus/blur (ubuntu) — fixed

The twelve `focus and blur events should trigger for ...` specs drove focus with `userEvent.click`. A real click only produces focus events while the browsing context holds **system** focus, which Firefox does not reliably have on CI.

Measured in Firefox with no system focus:

| | `document.hasFocus()` | `activeElement` | native `focus` fired |
|---|---|---|---|
| Firefox | `false` | the input | **0** |
| ChromeHeadless | `true` | the input | 1 |

`.focus()` moves `activeElement` but Firefox dispatches no event — so `onFocus` never runs and `formField.focus` never fires. Chrome dispatches regardless, which is why it never flaked.

**Fix:** dispatch `focusin`/`focusout` directly. preact/compat maps `onFocus`/`onBlur` onto those, so this drives the same handler a real focus would, with no system-focus dependency.

One wrong turn worth recording: `fireEvent.focus` is *not* a substitute. It delivers the DOM event (a plain listener sees it) but preact/compat never listens for bare `focus`, so the handler does not run — in **either** browser. `input._listeners` is empty and only `focusin` reaches the component.

Verified: 12/12 failed in Firefox before, 12/12 pass after; ChromeHeadless stays green.

## Cluster 2 — high precision number typing (macOS) — fixed

`should handle high precision string numbers without trimming` typed a 121-character string via `userEvent.type`, which yields to the event loop per keystroke and re-renders plus re-parses each time. **611ms locally against mocha's 2000ms default** — too little headroom for a contended runner.

Its overrun also took down `should allow a minus at the start` five specs later, which normally runs in 16ms: the orphaned `userEvent.type` keeps running after mocha abandons the test and starves the event loop. **That pairing is exactly what CI reported on macOS**, and it's why the second failure looked unrelated.

Controlled reproduction:

| Condition | Result |
|---|---|
| mocha timeout 300ms, long string | both specs fail — matches CI |
| mocha timeout 300ms, string shortened | both pass |

So the second failure is collateral, not an independent bug.

One honest caveat: the *symptoms* differ. Locally the second spec times out; on CI it threw `AssertionError: expected true to be false`. A starved event loop explains both — the spec either overruns or observes the field mid-update — but I only reproduced the timeout variant directly.

**Fix:** pass `delay: null`. All 121 keystrokes still go through `onKeyPress` — the assertion on the full string proves it — and the spec drops from **611ms to 12ms**.

## Cluster 3 — playground timeout (Windows) — not reproduced, untouched

Seen once as `Timeout of 10000ms exceeded` in `@bpmn-io/form-js-playground`. The candidates are the two specs that already carry `this.timeout(10000)` (`should render` and the axe `should have no violations`). Locally the slowest is **602ms against 10000ms** — 16x headroom — and I could not make it fail. The original CI log has since been overwritten by a rerun, so I have no failing spec name.

I have not touched it. Raising a timeout that already has 16x headroom would be a guess, and the honest read is that this runner was pathologically slow rather than that the spec is wrong. Worth re-checking if it recurs.

## Verification

- `npm run lint` → clean
- `npm run lint:types` → clean
- full `npm test` across all workspaces (ChromeHeadless) → green
- viewer suite in **Firefox** → the 12 focus/blur specs now pass
- viewer suite with the mocha timeout lowered to **300ms** (6.7x tighter than CI's default) → **zero failures**, where that same condition previously reproduced both macOS failures

## Deliberately out of scope

- **24 remaining local Firefox failures.** Datepicker, dropdown and searchableselect specs (`should focus input on click`, `should blur input on second click`, …) also fail in a Firefox window without system focus. They were failing on `develop` before this change, the click behaviour genuinely *is* what they test, and none of them appear in CI's reported failures. Rewriting them to synthetic events would gut their purpose.
- **`selectionWidth` sign inversion.** [`Number.js`](packages/form-js-viewer/src/render/components/form-fields/Number.js) computes `selectionStart - selectionEnd`, which is always `<= 0`, so the `selectionWidth === 0` guard in `willKeyProduceValidNumber` is true for any selection. A real latent bug, but fixing it changes production behaviour and does not belong in a test-stability PR. Happy to file it separately.

- [ ] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
