### PR TITLE
fix: stop styling every button as read-only

### DIFF
--- a/packages/form-js-viewer/assets/form-js-base.css
+++ b/packages/form-js-viewer/assets/form-js-base.css
@@ -744,14 +744,6 @@
   border-color: var(--color-borders-disabled);
 }
 
-.fjs-container .fjs-button[type='submit']:read-only,
-.fjs-container .fjs-button[type='button']:read-only,
-.fjs-container .fjs-button[type='reset']:read-only {
-  color: var(--text-light);
-  background-color: var(--color-background-readonly);
-  border-color: var(--color-borders-readonly);
-}
-
 .fjs-container .fjs-disabled .fjs-input-group .fjs-input-adornment,
 .fjs-container .fjs-disabled .fjs-input-group .fjs-number-arrow-container,
 .fjs-container .fjs-disabled .fjs-input-group .fjs-number-arrow-separator {


### PR DESCRIPTION
Closes #

- [x] This PR adds a new `form-js` element or visually changes an existing component.
  - => In that case, we need to ensure we follow up on this, e.g. by [creating an issue in Tasklist](https://github.com/camunda/tasklist/issues/new/choose)

### Proposed Changes

Every form-js button currently renders grey with black text, because this rule overrides the accent and disabled styling for all of them:

```css
.fjs-container .fjs-button[type='submit']:read-only, … {
  color: var(--text-light);
  background-color: var(--color-background-readonly);
  border-color: var(--color-borders-readonly);
}
```
Introduced in 6bc96350 ("feat(viewer): support `readonly` attribute").
`:read-only` is the negation of `:read-write` — it matches every `<button>`, not just buttons in a readonly form. The rule is the last button background rule and one pseudo-class more specific than the accent rule above it, so it always wins. Its `color` also references `--text-light`, which does not exist; an invalid `var()` computes to `unset`, which for `color` means inherit, so the text does not fall back to the white set earlier.

Removing it restores what the existing rules already intend: accent for `submit`/`button`, bordered transparent for `reset`, and real disabled styling.

| | before | after |
|---|---|---|
| submit background | `rgb(241, 242, 244)` | `rgb(0, 119, 204)` |
| submit text | `rgb(0, 0, 0)` | `rgb(255, 255, 255)` |
| disabled text | `rgb(0, 0, 0)` | `rgb(129, 135, 152)` |

**Before**

<img width="693" height="290" alt="image" src="https://github.com/user-attachments/assets/fd0a8336-6d0d-490c-9d93-3e46813e81c2" />

**After**


<img width="712" height="277" alt="image" src="https://github.com/user-attachments/assets/5903f1f3-d004-4e39-8188-f11d73149774" />